### PR TITLE
feat: memory governance, MCP toggle, and session hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `1.8.0` Memory trust layer:
+  - `add_learning` supports citation fields (`citation_file`, `citation_line`, `citation_repo`, `citation_commit`) and stores citation metadata for saved learnings.
+  - Trust filter re-validates citations before injection, skips stale entries, and applies policy-based confidence decay (30/60/90/120 day buckets).
+- `1.8.1` Automatic candidate extraction:
+  - New CLI command `extract-memories [project]` mines git history and GitHub PR/review/CI/issue signals when `gh` is available.
+  - High-confidence candidates are auto-written to `LEARNINGS.md`; lower-confidence items are queued in `MEMORY_QUEUE.md` for review.
+- `1.8.2` Self-healing setup:
+  - New `doctor [--fix]` command with health checks for machine/profile linkage and optional full relink repair.
+  - Session-start hooks run `doctor --fix` after pull for continuous setup drift repair.
+- `1.8.3` Branch-aware retrieval:
+  - `hook-prompt` uses task intent, branch tokens, changed files, and local-project preference to rerank/filter injected memory.
+  - Injection output now includes a short reason trace (`intent`, file hits, branch hits, branch, changed file count).
+- `1.8.4` Governance and quality controls:
+  - Canonical/pinned memory support via `CANONICAL_MEMORIES.md` and `pin_memory` (MCP) / `pin-memory` (CLI).
+  - Governance queue + audit trail via `MEMORY_QUEUE.md` and `.cortex-audit.log`.
+  - Governance/policy/admin APIs:
+    - MCP: `govern_memories`, `memory_policy`, `memory_access`, `prune_memories`, `consolidate_memories`, `memory_feedback`
+    - CLI: `govern-memories`, `memory-policy`, `memory-access`, `prune-memories`, `consolidate-memories`, `quality-feedback`
+  - Quality feedback loop with usage scoring, reprompt/regression penalties, helpful signal capture, and daily maintenance hooks.
+  - Canonical drift locks with auto-restore and conflict queueing.
+- Lightweight review UI (`memory-ui`) with accepted/stale/conflicting/recently-used views and one-click approve/reject/edit actions backed by markdown files.
+- Role-based memory permissions and policy defaults auto-created at init/link:
+  - `.governance/access-control.json`
+  - `.governance/memory-policy.json`
+- MCP mode controls:
+  - `init`/`link` accept `--mcp on|off` to choose MCP tools vs hooks-only fallback during one-shot setup.
+  - New `mcp-mode on|off|status` command toggles MCP integration later without reinstalling.
+  - MCP preference is persisted in `.governance/install-preferences.json`.
+
+### Fixed
+- `remove_learning` now removes an immediately attached `cortex:cite` comment, preventing orphan citation metadata lines in `LEARNINGS.md`.
+- GitHub data mining now executes `gh` using argument-safe process execution (no shell-string concatenation in `runGhJson`).
+- `hook-prompt` daily quality maintenance moved to detached background execution (`background-maintenance`) so prompt hooks stay low-latency.
+- Version/docs consistency updates:
+  - package version aligned to `1.8.4`
+  - MCP server version aligned to `1.8.4`
+  - README MCP tool and CLI command docs updated to match current implementation
+
+### TODO
+- Run `tsc` and `vitest` once Node toolchain is installed and fix any compile/test regressions.
+- Add integration tests for `memory-ui` approve/reject/edit flows and markdown mutation edge cases.
+- Add CLI-level feature flags for gradual rollout of auto-extraction and daily maintenance jobs.
+- Harden GitHub mining for large repos and API failures (pagination, timeouts, rate-limit backoff).
+- Expand docs/README with governance model, role setup, policy tuning examples, and operator runbook.
+
 ## [1.7.4] - 2026-03-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,12 +58,25 @@ npx @alaarab/cortex init
 
 That's it. This:
 - Creates `~/.cortex` with starter templates
-- Registers the MCP server in Claude Code and VS Code
+- Registers the MCP server in Claude Code and VS Code (default, recommended)
 - Sets up hooks for automatic context injection and auto-save
 - Configures hooks for any other detected agents (Copilot CLI, Cursor, Codex)
 - Registers your machine
 
 Restart your agent. Your next prompt will already have context.
+
+If you want hooks-only mode (no MCP tools), install with:
+
+```bash
+npx @alaarab/cortex init --mcp off
+```
+
+You can toggle later anytime:
+
+```bash
+npx @alaarab/cortex mcp-mode on    # recommended
+npx @alaarab/cortex mcp-mode off   # hooks-only fallback
+```
 
 ### Sync across machines
 
@@ -105,7 +118,7 @@ When the context window fills and resets, a hook re-injects your project summary
 
 ## The MCP server
 
-The server indexes your cortex into a local SQLite FTS5 database. Twelve tools available:
+The server indexes your cortex into a local SQLite FTS5 database. Nineteen tools available:
 
 **Search and browse:**
 - `search_cortex(query, type?, limit?)` with automatic synonym expansion
@@ -121,9 +134,18 @@ The server indexes your cortex into a local SQLite FTS5 database. Twelve tools a
 - `update_backlog_item(project, item, updates)` changes priority, context, or section
 
 **Learning capture:**
-- `add_learning(project, insight)` appends under today's date
-- `remove_learning(project, text)` removes by matching text
+- `add_learning(project, learning, citation_file?, citation_line?, citation_repo?, citation_commit?)` appends under today's date with optional citation metadata
+- `remove_learning(project, learning)` removes by matching text
 - `save_learnings(message?)` commits and pushes all changes
+- `pin_memory(project, memory)` writes canonical/pinned memory entries
+
+**Memory governance and quality:**
+- `govern_memories(project?)` queues stale/conflicting/low-value entries for review
+- `memory_policy(mode, ...)` gets/sets retention, ttl, decay, and confidence thresholds
+- `memory_access(mode, ...)` gets/sets role-based permissions
+- `prune_memories(project?)` deletes expired entries by retention policy
+- `consolidate_memories(project?)` deduplicates and rewrites LEARNINGS.md
+- `memory_feedback(key, feedback)` records helpful/reprompt/regression outcomes
 
 ### CLI subcommands
 
@@ -134,6 +156,13 @@ cortex search "rate limiting"        # FTS5 search with synonym expansion
 cortex hook-prompt                   # reads stdin JSON, outputs context block
 cortex hook-context                  # project context for current directory
 cortex add-learning <project> "..."  # append a learning from the terminal
+cortex extract-memories [project]    # mine git + GitHub signals into candidates
+cortex govern-memories [project]     # queue stale/conflicting/low-value memories
+cortex doctor [--fix]                # health checks + optional self-heal
+cortex memory-ui [--port=3499]       # lightweight review UI
+cortex memory-policy get|set ...     # retention/decay/confidence tuning
+cortex memory-access get|set ...     # role permissions
+cortex mcp-mode on|off|status        # toggle MCP integration anytime
 ```
 
 ---

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -1,7 +1,36 @@
-import { findCortexPath, buildIndex, extractSnippet, queryRows, detectProject, addLearningToFile, checkConsolidationNeeded, debugLog } from "./shared.js";
+import {
+  findCortexPath,
+  buildIndex,
+  extractSnippet,
+  queryRows,
+  detectProject,
+  addLearningToFile,
+  checkConsolidationNeeded,
+  debugLog,
+  filterTrustedLearningsDetailed,
+  appendMemoryQueue,
+  appendAuditLog,
+  upsertCanonicalMemory,
+  getProjectDirs,
+  getMemoryPolicy,
+  updateMemoryPolicy,
+  getAccessControl,
+  updateAccessControl,
+  recordMemoryInjection,
+  recordMemoryFeedback,
+  getMemoryQualityMultiplier,
+  memoryScoreKey,
+  pruneDeadMemories,
+  consolidateProjectLearnings,
+  enforceCanonicalLocks,
+} from "./shared.js";
 import { sanitizeFts5Query, expandSynonyms, extractKeywords } from "./utils.js";
 import * as fs from "fs";
 import * as path from "path";
+import { execFileSync, execSync, spawn } from "child_process";
+import { fileURLToPath } from "url";
+import { runDoctor } from "./link.js";
+import { startMemoryUi } from "./memory-ui.js";
 
 const cortexPath = findCortexPath();
 const profile = process.env.CORTEX_PROFILE || "";
@@ -16,9 +45,226 @@ export async function runCliCommand(command: string, args: string[]) {
       return handleHookContext();
     case "add-learning":
       return handleAddLearning(args[0], args.slice(1).join(" "));
+    case "extract-memories":
+      return handleExtractMemories(args[0]);
+    case "govern-memories":
+      return handleGovernMemories(args[0]);
+    case "pin-memory":
+      return handlePinMemory(args[0], args.slice(1).join(" "));
+    case "doctor":
+      return handleDoctor(args);
+    case "quality-feedback":
+      return handleQualityFeedback(args);
+    case "prune-memories":
+      return handlePruneMemories(args[0]);
+    case "consolidate-memories":
+      return handleConsolidateMemories(args[0]);
+    case "memory-policy":
+      return handleMemoryPolicy(args);
+    case "memory-access":
+      return handleMemoryAccess(args);
+    case "memory-ui":
+      return handleMemoryUi(args);
+    case "background-maintenance":
+      return handleBackgroundMaintenance(args[0]);
     default:
       console.error(`Unknown command: ${command}`);
       process.exit(1);
+  }
+}
+
+interface GitContext {
+  branch: string;
+  changedFiles: Set<string>;
+}
+
+function runGit(cwd: string, cmd: string): string | null {
+  try {
+    return execSync(cmd, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function commandExists(cmd: string): boolean {
+  try {
+    execSync(`command -v ${cmd}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runGhJson<T>(cwd: string, args: string[]): T | null {
+  if (!commandExists("gh")) return null;
+  try {
+    const out = execFileSync("gh", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!out) return null;
+    return JSON.parse(out) as T;
+  } catch {
+    return null;
+  }
+}
+
+function getGitContext(cwd?: string): GitContext | null {
+  if (!cwd) return null;
+  const branch = runGit(cwd, "git rev-parse --abbrev-ref HEAD");
+  if (!branch) return null;
+  const changedFiles = new Set<string>();
+  for (const changed of [
+    runGit(cwd, "git diff --name-only"),
+    runGit(cwd, "git diff --name-only --cached"),
+  ]) {
+    if (!changed) continue;
+    for (const line of changed.split("\n").map((s) => s.trim()).filter(Boolean)) {
+      changedFiles.add(line);
+      const basename = path.basename(line);
+      if (basename) changedFiles.add(basename);
+    }
+  }
+  return { branch, changedFiles };
+}
+
+function branchTokens(branch: string): string[] {
+  return branch
+    .split(/[\/._-]/g)
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 2 && !["main", "master", "feature", "fix", "bugfix", "hotfix"].includes(s));
+}
+
+function detectTaskIntent(prompt: string): "debug" | "review" | "build" | "docs" | "general" {
+  const p = prompt.toLowerCase();
+  if (/(bug|error|fix|broken|regression|fail|stack trace)/.test(p)) return "debug";
+  if (/(review|audit|pr|pull request|nit|refactor)/.test(p)) return "review";
+  if (/(build|deploy|release|ci|workflow|pipeline|test)/.test(p)) return "build";
+  if (/(doc|readme|explain|guide|instruction)/.test(p)) return "docs";
+  return "general";
+}
+
+function intentBoost(intent: string, docType: string): number {
+  if (intent === "debug" && (docType === "learnings" || docType === "knowledge")) return 3;
+  if (intent === "review" && (docType === "canonical" || docType === "changelog")) return 3;
+  if (intent === "build" && (docType === "backlog" || docType === "knowledge")) return 2;
+  if (intent === "docs" && (docType === "summary" || docType === "claude")) return 2;
+  if (docType === "canonical") return 2;
+  return 0;
+}
+
+function fileRelevanceBoost(filePath: string, changedFiles: Set<string>): number {
+  if (changedFiles.size === 0) return 0;
+  const normalized = filePath.replace(/\\/g, "/");
+  for (const cf of changedFiles) {
+    const n = cf.replace(/\\/g, "/");
+    if (normalized.endsWith(n) || normalized.includes(`/${n}`)) return 3;
+  }
+  return 0;
+}
+
+function branchMatchBoost(content: string, branch: string | undefined): number {
+  if (!branch) return 0;
+  const text = content.toLowerCase();
+  const tokens = branchTokens(branch);
+  let score = 0;
+  for (const t of tokens) {
+    if (text.includes(t)) score += 1;
+  }
+  return Math.min(3, score);
+}
+
+function lowValuePenalty(content: string, docType: string): number {
+  if (docType !== "learnings") return 0;
+  const bullets = content.split("\n").filter((l) => l.startsWith("- "));
+  if (bullets.length === 0) return 0;
+  const low = bullets.filter((b) => /(fixed stuff|updated things|misc|temp|wip)/i.test(b) || b.length < 16).length;
+  return low >= Math.ceil(bullets.length * 0.5) ? 2 : 0;
+}
+
+interface SessionMetric {
+  prompts: number;
+  keys: Record<string, number>;
+  lastChangedCount: number;
+  lastKeys: string[];
+}
+
+function parseSessionMetrics(cortexPathLocal: string): Record<string, SessionMetric> {
+  const file = path.join(cortexPathLocal, ".governance", "session-metrics.json");
+  if (!fs.existsSync(file)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8")) as Record<string, SessionMetric>;
+  } catch {
+    return {};
+  }
+}
+
+function writeSessionMetrics(cortexPathLocal: string, data: Record<string, SessionMetric>) {
+  const file = path.join(cortexPathLocal, ".governance", "session-metrics.json");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\n");
+}
+
+function qualityMarkers(cortexPathLocal: string): { done: string; lock: string } {
+  const today = new Date().toISOString().slice(0, 10);
+  return {
+    done: path.join(cortexPathLocal, `.quality-${today}`),
+    lock: path.join(cortexPathLocal, `.quality-${today}.lock`),
+  };
+}
+
+function scheduleBackgroundMaintenance(cortexPathLocal: string, project?: string): boolean {
+  const markers = qualityMarkers(cortexPathLocal);
+  if (fs.existsSync(markers.done)) return false;
+  if (fs.existsSync(markers.lock)) {
+    try {
+      const ageMs = Date.now() - fs.statSync(markers.lock).mtimeMs;
+      if (ageMs <= 2 * 60 * 60 * 1000) return false;
+      fs.unlinkSync(markers.lock);
+    } catch {
+      return false;
+    }
+  }
+
+  const distEntry = path.join(path.dirname(fileURLToPath(import.meta.url)), "index.js");
+  let spawnArgs: string[] | null = null;
+  if (fs.existsSync(distEntry)) {
+    spawnArgs = [distEntry, "background-maintenance"];
+  } else {
+    const sourceEntry = process.argv.find((a) => /[\\/]index\.(ts|js)$/.test(a) && fs.existsSync(a));
+    const runner = process.argv[1];
+    if (sourceEntry && runner) {
+      spawnArgs = [runner, sourceEntry, "background-maintenance"];
+    }
+  }
+  if (!spawnArgs) return false;
+
+  try {
+    fs.writeFileSync(
+      markers.lock,
+      JSON.stringify({
+        startedAt: new Date().toISOString(),
+        project: project || "all",
+        pid: process.pid,
+      }) + "\n"
+    );
+    if (project) spawnArgs.push(project);
+    const child = spawn(process.execPath, spawnArgs, {
+      cwd: process.cwd(),
+      detached: true,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        CORTEX_PATH: cortexPathLocal,
+        CORTEX_PROFILE: profile,
+      },
+    });
+    child.unref();
+    return true;
+  } catch {
+    try { fs.unlinkSync(markers.lock); } catch { /* best effort */ }
+    return false;
   }
 }
 
@@ -87,6 +333,8 @@ async function handleHookPrompt() {
   debugLog(`hook-prompt keywords: "${keywords}"`);
 
   const db = await buildIndex(cortexPath, profile);
+  const gitCtx = getGitContext(cwd);
+  const intent = detectTaskIntent(prompt);
 
   // Detect project from cwd to boost relevant results
   const detectedProject = cwd ? detectProject(cortexPath, cwd, profile) : null;
@@ -102,7 +350,7 @@ async function handleHookPrompt() {
     if (detectedProject) {
       rows = queryRows(
         db,
-        "SELECT project, filename, type, content FROM docs WHERE docs MATCH ? AND project = ? ORDER BY rank LIMIT 5",
+        "SELECT project, filename, type, content, path FROM docs WHERE docs MATCH ? AND project = ? ORDER BY rank LIMIT 5",
         [safeQuery, detectedProject]
       );
     }
@@ -111,12 +359,82 @@ async function handleHookPrompt() {
     if (!rows) {
       rows = queryRows(
         db,
-        "SELECT project, filename, type, content FROM docs WHERE docs MATCH ? ORDER BY rank LIMIT 5",
+        "SELECT project, filename, type, content, path FROM docs WHERE docs MATCH ? ORDER BY rank LIMIT 5",
         [safeQuery]
       );
     }
 
     if (!rows) process.exit(0);
+
+    const policy = getMemoryPolicy(cortexPath);
+    const memoryTtlDays = Number.parseInt(
+      process.env.CORTEX_MEMORY_TTL_DAYS || String(policy.ttlDays),
+      10
+    );
+    rows = rows.map((row) => {
+      const [project, filename, docType, content, filePath] = row as string[];
+      if (docType !== "learnings") return row;
+      const trust = filterTrustedLearningsDetailed(content, {
+        ttlDays: Number.isNaN(memoryTtlDays) ? policy.ttlDays : memoryTtlDays,
+        minConfidence: policy.minInjectConfidence,
+        decay: policy.decay,
+      });
+      if (trust.issues.length > 0) {
+        const stale = trust.issues.filter((i) => i.reason === "stale").map((i) => i.bullet);
+        const conflicts = trust.issues.filter((i) => i.reason === "invalid_citation").map((i) => i.bullet);
+        if (stale.length) appendMemoryQueue(cortexPath, project, "Stale", stale);
+        if (conflicts.length) appendMemoryQueue(cortexPath, project, "Conflicts", conflicts);
+        appendAuditLog(
+          cortexPath,
+          "trust_filter",
+          `project=${project} stale=${stale.length} invalid_citation=${conflicts.length}`
+        );
+      }
+      const trusted = trust.content;
+      return [project, filename, docType, trusted, filePath];
+    }).filter((row) => {
+      const [, , docType, content] = row as string[];
+      return docType !== "learnings" || Boolean((content as string).trim());
+    });
+
+    if (!rows.length) process.exit(0);
+
+    // Keep retrieval branch/project-local whenever possible.
+    if (detectedProject) {
+      const localByType = new Set(
+        rows
+          .filter((r) => (r as string[])[0] === detectedProject)
+          .map((r) => (r as string[])[2])
+      );
+      rows = rows.filter((r) => {
+        const [project, , type] = r as string[];
+        if (project === detectedProject) return true;
+        return !localByType.has(type);
+      });
+    }
+
+    // Bring canonical memories from detected project into ranking pool.
+    if (detectedProject) {
+      const canonicalRows = queryRows(
+        db,
+        "SELECT project, filename, type, content, path FROM docs WHERE project = ? AND type = 'canonical' LIMIT 1",
+        [detectedProject]
+      );
+      if (canonicalRows) rows = [...canonicalRows, ...rows];
+    }
+
+    // Automatic extraction from PR/review/CI/issues once per session+project.
+    if (sessionId && detectedProject && cwd) {
+      const marker = path.join(cortexPath, `.extracted-${sessionId}-${detectedProject}`);
+      if (!fs.existsSync(marker)) {
+        try {
+          await handleExtractMemories(detectedProject, cwd, true);
+          fs.writeFileSync(marker, "");
+        } catch {
+          // best effort
+        }
+      }
+    }
 
     // Recency boost: for learnings rows, extract the most recent date header and sort newer first.
     // Non-learnings rows keep their FTS5 rank order at the front.
@@ -127,21 +445,51 @@ async function handleHookPrompt() {
     }
 
     rows = [...rows].sort((a, b) => {
-      const [, , typeA, contentA] = a as string[];
-      const [, , typeB, contentB] = b as string[];
+      const [, , typeA, contentA, pathA] = a as string[];
+      const [, , typeB, contentB, pathB] = b as string[];
       const isLearningsA = typeA === "learnings";
       const isLearningsB = typeB === "learnings";
       // Non-learnings rank above learnings when scores are equal
       if (isLearningsA !== isLearningsB) return isLearningsA ? 1 : -1;
       // Both learnings: sort by most recent date descending
       if (isLearningsA && isLearningsB) {
-        return mostRecentDate(contentB).localeCompare(mostRecentDate(contentA));
+        const byDate = mostRecentDate(contentB).localeCompare(mostRecentDate(contentA));
+        if (byDate !== 0) return byDate;
       }
-      return 0; // Preserve FTS5 rank order for non-learnings
+
+      const intentDelta = intentBoost(intent, typeB) - intentBoost(intent, typeA);
+      if (intentDelta !== 0) return intentDelta;
+
+      const changedFiles = gitCtx?.changedFiles || new Set<string>();
+      const fileDelta = fileRelevanceBoost(pathB, changedFiles) - fileRelevanceBoost(pathA, changedFiles);
+      if (fileDelta !== 0) return fileDelta;
+
+      const branchDelta = branchMatchBoost(contentB, gitCtx?.branch) - branchMatchBoost(contentA, gitCtx?.branch);
+      if (branchDelta !== 0) return branchDelta;
+
+      const keyA = memoryScoreKey((a as string[])[0], (a as string[])[1], contentA);
+      const keyB = memoryScoreKey((b as string[])[0], (b as string[])[1], contentB);
+      const qualityDelta = getMemoryQualityMultiplier(cortexPath, keyB) - getMemoryQualityMultiplier(cortexPath, keyA);
+      if (qualityDelta !== 0) return qualityDelta;
+
+      const penaltyDelta = lowValuePenalty(contentA, typeA) - lowValuePenalty(contentB, typeB);
+      if (penaltyDelta !== 0) return penaltyDelta;
+
+      return 0;
     });
 
     // Show top 3 after recency sort
     rows = rows.slice(0, 3);
+
+    // If we have changed files, drop unrelated rows except high-priority docs.
+    if (gitCtx && gitCtx.changedFiles.size > 0) {
+      rows = rows.filter((r) => {
+        const [, , type, , file] = r as string[];
+        if (["summary", "canonical", "backlog", "claude"].includes(type)) return true;
+        return fileRelevanceBoost(file, gitCtx.changedFiles) > 0 || branchMatchBoost((r as string[])[3], gitCtx.branch) > 0;
+      });
+      if (!rows.length) process.exit(0);
+    }
 
     const projectLabel = detectedProject ? ` · ${detectedProject}` : "";
     const resultLabel = rows.length === 1 ? "1 result" : `${rows.length} results`;
@@ -151,11 +499,53 @@ async function handleHookPrompt() {
     for (const row of rows) {
       const [project, filename, docType, content] = row as string[];
       const snippet = extractSnippet(content, keywords, 8);
+      const key = memoryScoreKey(project, filename, snippet);
+      recordMemoryInjection(cortexPath, key, sessionId);
       parts.push(`[${project}/${filename}] (${docType})`);
       parts.push(snippet);
       parts.push("");
     }
     parts.push("</cortex-context>");
+    if (gitCtx) {
+      const changedCount = gitCtx.changedFiles.size;
+      const fileHits = rows.filter((r) => fileRelevanceBoost((r as string[])[4], gitCtx.changedFiles) > 0).length;
+      const branchHits = rows.filter((r) => branchMatchBoost((r as string[])[3], gitCtx.branch) > 0).length;
+      parts.push(
+        `◆ cortex · trace: intent=${intent}; reasons=file:${fileHits},branch:${branchHits}; branch=${gitCtx.branch}; changed_files=${changedCount}`
+      );
+    } else {
+      parts.push(`◆ cortex · trace: intent=${intent}; reasons=intent-only`);
+    }
+
+    if (sessionId) {
+      const metrics = parseSessionMetrics(cortexPath);
+      if (!metrics[sessionId]) metrics[sessionId] = { prompts: 0, keys: {}, lastChangedCount: 0, lastKeys: [] };
+      metrics[sessionId].prompts += 1;
+      const injectedKeys: string[] = [];
+      for (const row of rows) {
+        const [project, filename, , content] = row as string[];
+        const key = memoryScoreKey(project, filename, extractSnippet(content, keywords, 8));
+        injectedKeys.push(key);
+        const seen = metrics[sessionId].keys[key] || 0;
+        metrics[sessionId].keys[key] = seen + 1;
+        if (seen >= 1) recordMemoryFeedback(cortexPath, key, "reprompt");
+      }
+
+      const changedCount = gitCtx?.changedFiles.size ?? 0;
+      const prevChanged = metrics[sessionId].lastChangedCount || 0;
+      const prevKeys = metrics[sessionId].lastKeys || [];
+      if (changedCount > prevChanged) {
+        for (const prevKey of prevKeys) {
+          recordMemoryFeedback(cortexPath, prevKey, "helpful");
+        }
+      }
+      metrics[sessionId].lastChangedCount = changedCount;
+      metrics[sessionId].lastKeys = injectedKeys;
+      writeSessionMetrics(cortexPath, metrics);
+    }
+
+    // Periodic quality maintenance (once/day) runs in detached background mode.
+    scheduleBackgroundMaintenance(cortexPath);
 
     // Check for consolidation needs once per session
     const noticeFile = sessionId ? path.join(cortexPath, `.noticed-${sessionId}`) : null;
@@ -279,4 +669,386 @@ async function handleAddLearning(project: string, learning: string) {
 
   const result = addLearningToFile(cortexPath, project, learning);
   console.log(result);
+}
+
+function inferProject(arg?: string): string | null {
+  if (arg) return arg;
+  return detectProject(cortexPath, process.cwd(), profile);
+}
+
+function parseGitLogRecords(cwd: string, days: number): Array<{ hash: string; subject: string; body: string }> {
+  const fmt = "%H%x1f%s%x1f%b%x1e";
+  const raw = runGit(cwd, `git log --since="${days} days ago" --first-parent --pretty=format:${fmt}`) || "";
+  const records: Array<{ hash: string; subject: string; body: string }> = [];
+  for (const rec of raw.split("\x1e")) {
+    const trimmed = rec.trim();
+    if (!trimmed) continue;
+    const [hash, subject, body] = trimmed.split("\x1f");
+    if (!hash || !subject) continue;
+    records.push({ hash, subject, body: body || "" });
+  }
+  return records;
+}
+
+interface GhPr {
+  number: number;
+  title: string;
+  body?: string;
+  mergeCommit?: { oid?: string };
+  files?: Array<{ path?: string }>;
+  comments?: Array<{ body?: string }>;
+  reviews?: Array<{ body?: string; state?: string }>;
+}
+
+interface GhRun {
+  databaseId?: number;
+  displayTitle?: string;
+  workflowName?: string;
+  headSha?: string;
+}
+
+interface GhIssue {
+  number: number;
+  title: string;
+  body?: string;
+}
+
+interface Candidate {
+  text: string;
+  score: number;
+  commit?: string;
+  file?: string;
+}
+
+function mineGithubCandidates(repoRoot: string): Candidate[] {
+  const candidates: Candidate[] = [];
+
+  const prs = runGhJson<GhPr[]>(repoRoot, [
+    "pr",
+    "list",
+    "--state",
+    "merged",
+    "--limit",
+    "40",
+    "--json",
+    "number,title,body,mergeCommit,files,comments,reviews",
+  ]) || [];
+  for (const pr of prs) {
+    const text = `PR #${pr.number}: ${pr.title}`;
+    const body = (pr.body || "").toLowerCase();
+    const commentBlob = [
+      ...(pr.comments || []).map((c) => c.body || ""),
+      ...(pr.reviews || []).map((r) => r.body || ""),
+    ].join("\n").toLowerCase();
+    let score = 0.65;
+    if (/(fix|workaround|must|avoid|regression|incident|root cause|migration)/.test(body)) score += 0.2;
+    if (/(review|comment|nit|requested changes)/.test(body + "\n" + commentBlob)) score += 0.1;
+    if (/(must|should|avoid|required|don't|do not)/.test(commentBlob)) score += 0.08;
+    candidates.push({
+      text,
+      score: Math.min(0.98, score),
+      commit: pr.mergeCommit?.oid,
+      file: pr.files?.find((f) => f.path)?.path,
+    });
+  }
+
+  const runs = runGhJson<GhRun[]>(repoRoot, [
+    "run",
+    "list",
+    "--status",
+    "failure",
+    "--limit",
+    "25",
+    "--json",
+    "databaseId,displayTitle,workflowName,headSha",
+  ]) || [];
+  for (const run of runs) {
+    const title = run.displayTitle || run.workflowName || "CI failure";
+    const text = `CI failure pattern: ${title}`;
+    candidates.push({
+      text,
+      score: 0.62,
+      commit: run.headSha,
+    });
+  }
+
+  const issues = runGhJson<GhIssue[]>(repoRoot, [
+    "issue",
+    "list",
+    "--state",
+    "all",
+    "--limit",
+    "25",
+    "--json",
+    "number,title,body",
+  ]) || [];
+  for (const issue of issues) {
+    const body = (issue.body || "").toLowerCase();
+    if (!/(bug|regression|incident|outage|postmortem|fix)/.test(body) && !/(bug|regression|incident)/.test(issue.title.toLowerCase())) {
+      continue;
+    }
+    const text = `Issue #${issue.number}: ${issue.title}`;
+    let issueScore = 0.58;
+    const comments = runGhJson<Array<{ body?: string }>>(
+      repoRoot,
+      ["issue", "view", String(issue.number), "--json", "comments"]
+    ) as any;
+    if (comments && Array.isArray((comments as any).comments)) {
+      const blob = (comments as any).comments.map((c: any) => c.body || "").join("\n").toLowerCase();
+      if (/(workaround|root cause|regression|postmortem|must|avoid)/.test(blob)) issueScore += 0.1;
+    }
+    candidates.push({ text, score: Math.min(0.9, issueScore) });
+  }
+
+  return candidates;
+}
+
+function scoreMemoryCandidate(subject: string, body: string): { score: number; text: string } | null {
+  const s = `${subject}\n${body}`.toLowerCase();
+  const mergedPr = /merge pull request #\d+/.test(s);
+  const ci = /(ci|workflow|pipeline|flake|test fail|build fail)/.test(s);
+  const review = /(review|requested changes|address comments|nit|follow-up)/.test(s);
+  const learningSignal = /(fix|workaround|must|avoid|regression|root cause|postmortem|incident|retry|timeout)/.test(s);
+
+  let score = 0.35;
+  if (mergedPr) score += 0.2;
+  if (ci) score += 0.2;
+  if (review) score += 0.1;
+  if (learningSignal) score += 0.25;
+  if (subject.length > 20) score += 0.05;
+  if (score < 0.5) return null;
+
+  const cleaned = subject
+    .replace(/^merge pull request #\d+\s*from\s+\S+\s*/i, "")
+    .replace(/^fix:\s*/i, "")
+    .trim();
+  const text = cleaned ? cleaned[0].toUpperCase() + cleaned.slice(1) : subject;
+  return { score: Math.min(score, 0.99), text };
+}
+
+async function handleExtractMemories(projectArg?: string, cwdArg?: string, silent: boolean = false) {
+  const project = inferProject(projectArg);
+  if (!project) {
+    if (!silent) console.error("Usage: cortex extract-memories <project>");
+    if (!silent) process.exit(1);
+    return;
+  }
+
+  const repoRoot = runGit(cwdArg || process.cwd(), "git rev-parse --show-toplevel");
+  if (!repoRoot) {
+    if (!silent) console.error("extract-memories must run from inside a git repository.");
+    if (!silent) process.exit(1);
+    return;
+  }
+
+  const days = Number.parseInt(process.env.CORTEX_MEMORY_EXTRACT_WINDOW_DAYS || "30", 10);
+  const threshold = Number.parseFloat(process.env.CORTEX_MEMORY_AUTO_ACCEPT || String(getMemoryPolicy(cortexPath).autoAcceptThreshold));
+  const records = parseGitLogRecords(repoRoot, Number.isNaN(days) ? 30 : days);
+  const ghCandidates = mineGithubCandidates(repoRoot);
+
+  let accepted = 0;
+  let queued = 0;
+  for (const rec of records) {
+    const candidate = scoreMemoryCandidate(rec.subject, rec.body);
+    if (!candidate) continue;
+    const line = `${candidate.text} (source commit ${rec.hash.slice(0, 8)})`;
+    if (candidate.score >= threshold) {
+      addLearningToFile(cortexPath, project, line, {
+        repo: repoRoot,
+        commit: rec.hash,
+      });
+      accepted++;
+    } else {
+      queued += appendMemoryQueue(cortexPath, project, "Review", [`[confidence ${candidate.score.toFixed(2)}] ${line}`]);
+    }
+  }
+
+  for (const c of ghCandidates) {
+    const line = `${c.text}${c.commit ? ` (source commit ${c.commit.slice(0, 8)})` : ""}`;
+    if (c.text.startsWith("CI failure pattern:")) {
+      const key = memoryScoreKey(project, "LEARNINGS.md", line);
+      recordMemoryFeedback(cortexPath, key, "regression");
+    }
+    if (c.score >= threshold) {
+      addLearningToFile(cortexPath, project, line, {
+        repo: repoRoot,
+        commit: c.commit,
+        file: c.file,
+      });
+      accepted++;
+    } else {
+      queued += appendMemoryQueue(cortexPath, project, "Review", [`[confidence ${c.score.toFixed(2)}] ${line}`]);
+    }
+  }
+
+  appendAuditLog(cortexPath, "extract_memories", `project=${project} accepted=${accepted} queued=${queued} window_days=${days}`);
+  if (!silent) console.log(`Extracted memory candidates for ${project}: accepted=${accepted}, queued=${queued}, window=${days}d`);
+}
+
+async function handleGovernMemories(projectArg?: string, silent: boolean = false) {
+  const policy = getMemoryPolicy(cortexPath);
+  const ttlDays = Number.parseInt(process.env.CORTEX_MEMORY_TTL_DAYS || String(policy.ttlDays), 10);
+  const projects = projectArg
+    ? [projectArg]
+    : getProjectDirs(cortexPath, profile).map((p) => path.basename(p)).filter((p) => p !== "global");
+
+  let staleCount = 0;
+  let conflictCount = 0;
+  let reviewCount = 0;
+
+  for (const project of projects) {
+    const learningsPath = path.join(cortexPath, project, "LEARNINGS.md");
+    if (!fs.existsSync(learningsPath)) continue;
+    const content = fs.readFileSync(learningsPath, "utf8");
+    const trust = filterTrustedLearningsDetailed(content, {
+      ttlDays: Number.isNaN(ttlDays) ? policy.ttlDays : ttlDays,
+      minConfidence: policy.minInjectConfidence,
+      decay: policy.decay,
+    });
+
+    const stale = trust.issues.filter((i) => i.reason === "stale").map((i) => i.bullet);
+    const conflicts = trust.issues.filter((i) => i.reason === "invalid_citation").map((i) => i.bullet);
+    staleCount += appendMemoryQueue(cortexPath, project, "Stale", stale);
+    conflictCount += appendMemoryQueue(cortexPath, project, "Conflicts", conflicts);
+
+    const lowValue = content.split("\n")
+      .filter((l) => l.startsWith("- "))
+      .filter((l) => /(fixed stuff|updated things|misc|temp|wip|quick note)/i.test(l) || l.length < 16);
+    reviewCount += appendMemoryQueue(cortexPath, project, "Review", lowValue);
+  }
+
+  appendAuditLog(
+    cortexPath,
+    "govern_memories",
+    `projects=${projects.length} stale=${staleCount} conflicts=${conflictCount} review=${reviewCount}`
+  );
+  for (const project of projects) {
+    consolidateProjectLearnings(cortexPath, project);
+  }
+  enforceCanonicalLocks(cortexPath, projectArg);
+  if (!silent) console.log(`Governed memories: stale=${staleCount}, conflicts=${conflictCount}, review=${reviewCount}`);
+}
+
+async function handlePinMemory(project: string, memory: string) {
+  if (!project || !memory) {
+    console.error('Usage: cortex pin-memory <project> "<memory>"');
+    process.exit(1);
+  }
+  const result = upsertCanonicalMemory(cortexPath, project, memory);
+  console.log(result);
+}
+
+async function handleDoctor(args: string[]) {
+  const fix = args.includes("--fix");
+  const result = await runDoctor(cortexPath, fix);
+  console.log(`cortex doctor: ${result.ok ? "ok" : "issues found"}`);
+  if (result.machine) console.log(`machine: ${result.machine}`);
+  if (result.profile) console.log(`profile: ${result.profile}`);
+  for (const check of result.checks) {
+    console.log(`- ${check.ok ? "ok" : "fail"} ${check.name}: ${check.detail}`);
+  }
+  process.exit(result.ok ? 0 : 1);
+}
+
+async function handleQualityFeedback(args: string[]) {
+  const key = args.find((a) => a.startsWith("--key="))?.slice("--key=".length);
+  const feedback = args.find((a) => a.startsWith("--type="))?.slice("--type=".length) as "helpful" | "reprompt" | "regression" | undefined;
+  if (!key || !feedback || !["helpful", "reprompt", "regression"].includes(feedback)) {
+    console.error("Usage: cortex quality-feedback --key=<memory-key> --type=helpful|reprompt|regression");
+    process.exit(1);
+  }
+  recordMemoryFeedback(cortexPath, key, feedback);
+  console.log(`Recorded feedback: ${feedback} for ${key}`);
+}
+
+async function handlePruneMemories(projectArg?: string) {
+  const result = pruneDeadMemories(cortexPath, projectArg);
+  console.log(result);
+}
+
+async function handleConsolidateMemories(projectArg?: string) {
+  const projects = projectArg
+    ? [projectArg]
+    : getProjectDirs(cortexPath, profile).map((p) => path.basename(p)).filter((p) => p !== "global");
+  const results = projects.map((p) => consolidateProjectLearnings(cortexPath, p));
+  console.log(results.join("\n"));
+}
+
+async function handleMemoryPolicy(args: string[]) {
+  if (!args.length || args[0] === "get") {
+    console.log(JSON.stringify(getMemoryPolicy(cortexPath), null, 2));
+    return;
+  }
+  if (args[0] === "set") {
+    const patch: any = {};
+    for (const arg of args.slice(1)) {
+      if (!arg.startsWith("--")) continue;
+      const [k, v] = arg.slice(2).split("=");
+      if (!k || v === undefined) continue;
+      const num = Number(v);
+      const value = Number.isNaN(num) ? v : num;
+      if (k.startsWith("decay.")) {
+        patch.decay = patch.decay || {};
+        patch.decay[k.slice("decay.".length)] = value;
+      } else {
+        patch[k] = value;
+      }
+    }
+    const result = updateMemoryPolicy(cortexPath, patch);
+    if (typeof result === "string") {
+      console.log(result);
+      if (result.startsWith("Permission denied")) process.exit(1);
+      return;
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.error("Usage: cortex memory-policy [get|set --ttlDays=120 --retentionDays=365 --autoAcceptThreshold=0.75 --minInjectConfidence=0.35 --decay.d30=1 --decay.d60=0.85 --decay.d90=0.65 --decay.d120=0.45]");
+  process.exit(1);
+}
+
+async function handleMemoryAccess(args: string[]) {
+  if (!args.length || args[0] === "get") {
+    console.log(JSON.stringify(getAccessControl(cortexPath), null, 2));
+    return;
+  }
+  if (args[0] === "set") {
+    const patch: any = {};
+    for (const arg of args.slice(1)) {
+      if (!arg.startsWith("--")) continue;
+      const [k, v] = arg.slice(2).split("=");
+      if (!k || v === undefined) continue;
+      patch[k] = v.split(",").map((s) => s.trim()).filter(Boolean);
+    }
+    const result = updateAccessControl(cortexPath, patch);
+    if (typeof result === "string") {
+      console.log(result);
+      if (result.startsWith("Permission denied")) process.exit(1);
+      return;
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.error("Usage: cortex memory-access [get|set --admins=u1,u2 --maintainers=u3 --contributors=u4 --viewers=u5]");
+  process.exit(1);
+}
+
+async function handleMemoryUi(args: string[]) {
+  const portArg = args.find((a) => a.startsWith("--port="));
+  const port = portArg ? Number.parseInt(portArg.slice("--port=".length), 10) : 3499;
+  const safePort = Number.isNaN(port) ? 3499 : port;
+  await startMemoryUi(cortexPath, safePort);
+}
+
+async function handleBackgroundMaintenance(projectArg?: string) {
+  const markers = qualityMarkers(cortexPath);
+  try {
+    await handleGovernMemories(projectArg, true);
+    pruneDeadMemories(cortexPath, projectArg);
+    fs.writeFileSync(markers.done, new Date().toISOString() + "\n");
+  } catch (err: any) {
+    appendAuditLog(cortexPath, "background_maintenance_failed", `error=${err?.message || String(err)}`);
+  } finally {
+    try { fs.unlinkSync(markers.lock); } catch { /* best effort */ }
+  }
 }

--- a/mcp/src/hooks.ts
+++ b/mcp/src/hooks.ts
@@ -32,7 +32,7 @@ export function configureAllHooks(cortexPath: string, tools: Set<string> | boole
     tools ? new Set(["copilot", "cursor", "codex"]) :
     detectInstalledTools();
 
-  const pullCmd = `cd "${cortexPath}" && git pull --rebase --quiet 2>/dev/null || true`;
+  const pullCmd = `cd "${cortexPath}" && (git pull --rebase --quiet 2>/dev/null || true) && (npx @alaarab/cortex doctor --fix >/dev/null 2>&1 || true)`;
   const promptCmd = `npx @alaarab/cortex hook-prompt`;
   const stopCmd = `cd "${cortexPath}" && git diff --quiet 2>/dev/null || (git add -A && git commit -m 'auto-save cortex' && git push 2>/dev/null || true)`;
 

--- a/mcp/src/index.test.ts
+++ b/mcp/src/index.test.ts
@@ -1,9 +1,36 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { sanitizeFts5Query, isValidProjectName, safeProjectPath, expandSynonyms, extractKeywords } from "./utils.js";
-import { validateLearningsFormat, validateBacklogFormat, extractConflictVersions, mergeLearnings, mergeBacklog, debugLog } from "./shared.js";
+import {
+  validateLearningsFormat,
+  validateBacklogFormat,
+  extractConflictVersions,
+  mergeLearnings,
+  mergeBacklog,
+  debugLog,
+  filterTrustedLearnings,
+  addLearningToFile,
+  pruneDeadMemories,
+  consolidateProjectLearnings,
+} from "./shared.js";
 import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
+
+function grantAdminAccess(cortexDir: string, actor = "vitest-admin"): string {
+  const govDir = path.join(cortexDir, ".governance");
+  fs.mkdirSync(govDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(govDir, "access-control.json"),
+    JSON.stringify({
+      admins: [actor],
+      maintainers: [],
+      contributors: [],
+      viewers: [],
+    }, null, 2) + "\n"
+  );
+  process.env.CORTEX_ACTOR = actor;
+  return actor;
+}
 
 describe("sanitizeFts5Query", () => {
   it("passes through a normal query", () => {
@@ -411,6 +438,156 @@ describe("mergeBacklog", () => {
     const theirs = "# Other\n\n## Active\n\n## Queue\n\n## Done\n";
     const merged = mergeBacklog(ours, theirs);
     expect(merged.startsWith("# My Backlog")).toBe(true);
+  });
+});
+
+describe("filterTrustedLearnings", () => {
+  it("keeps recent legacy bullets and valid cited bullets", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-cite-valid-"));
+    const file = path.join(tmpDir, "source.ts");
+    fs.writeFileSync(file, "line1\nline2\nline3\n");
+
+    const today = new Date().toISOString().slice(0, 10);
+    const cited = `<!-- cortex:cite ${JSON.stringify({ created_at: new Date().toISOString(), file, line: 2 })} -->`;
+    const content = [
+      "# Project LEARNINGS",
+      "",
+      `## ${today}`,
+      "",
+      "- Legacy entry",
+      "- Cited entry",
+      `  ${cited}`,
+      "",
+    ].join("\n");
+
+    const filtered = filterTrustedLearnings(content, 90);
+    expect(filtered).toContain("- Legacy entry");
+    expect(filtered).toContain("- Cited entry");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("drops stale and invalid-citation bullets", () => {
+    const content = [
+      "# Project LEARNINGS",
+      "",
+      "## 2000-01-01",
+      "",
+      "- Too old",
+      "",
+      `## ${new Date().toISOString().slice(0, 10)}`,
+      "",
+      "- Bad citation",
+      `  <!-- cortex:cite ${JSON.stringify({ created_at: new Date().toISOString(), file: "/missing/file.ts", line: 1 })} -->`,
+      "",
+    ].join("\n");
+
+    const filtered = filterTrustedLearnings(content, 90);
+    expect(filtered).not.toContain("- Too old");
+    expect(filtered).not.toContain("- Bad citation");
+  });
+});
+
+describe("addLearningToFile", () => {
+  const originalActor = process.env.CORTEX_ACTOR;
+
+  afterEach(() => {
+    process.env.CORTEX_ACTOR = originalActor;
+  });
+
+  it("writes citation metadata alongside a new learning", () => {
+    const cortexDir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-add-learning-"));
+    const project = "proj";
+    const projectDir = path.join(cortexDir, project);
+    fs.mkdirSync(projectDir, { recursive: true });
+    grantAdminAccess(cortexDir);
+
+    const result = addLearningToFile(cortexDir, project, "Remember to clear cache", {
+      file: "/tmp/source.ts",
+      line: 12,
+      commit: "abc123",
+    });
+    expect(result).toContain("citation metadata");
+
+    const learnings = fs.readFileSync(path.join(projectDir, "LEARNINGS.md"), "utf8");
+    expect(learnings).toContain("<!-- cortex:cite");
+    expect(learnings).toContain("\"file\":\"/tmp/source.ts\"");
+    expect(learnings).toContain("\"line\":12");
+
+    fs.rmSync(cortexDir, { recursive: true, force: true });
+  });
+});
+
+describe("memory maintenance", () => {
+  const originalActor = process.env.CORTEX_ACTOR;
+
+  afterEach(() => {
+    process.env.CORTEX_ACTOR = originalActor;
+  });
+
+  it("prunes stale bullets and removes attached/dangling citation comments", () => {
+    const cortexDir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-prune-"));
+    const project = "proj";
+    const projectDir = path.join(cortexDir, project);
+    fs.mkdirSync(projectDir, { recursive: true });
+    grantAdminAccess(cortexDir);
+
+    const today = new Date().toISOString().slice(0, 10);
+    const content = [
+      "# proj LEARNINGS",
+      "",
+      "## 2000-01-01",
+      "",
+      "- Old bullet",
+      "  <!-- cortex:cite {\"created_at\":\"2000-01-01T00:00:00.000Z\"} -->",
+      "",
+      `## ${today}`,
+      "",
+      "- Fresh bullet",
+      "  <!-- cortex:cite {\"created_at\":\"2026-01-01T00:00:00.000Z\"} -->",
+      "  <!-- cortex:cite {\"created_at\":\"2026-01-01T00:00:00.000Z\"} -->",
+      "",
+    ].join("\n");
+    fs.writeFileSync(path.join(projectDir, "LEARNINGS.md"), content);
+
+    const result = pruneDeadMemories(cortexDir, project);
+    expect(result).toContain("Pruned");
+    const next = fs.readFileSync(path.join(projectDir, "LEARNINGS.md"), "utf8");
+    expect(next).not.toContain("- Old bullet");
+    expect(next).toContain("- Fresh bullet");
+    // One citation remains (attached to fresh bullet); dangling citation is removed.
+    expect((next.match(/<!-- cortex:cite/g) || []).length).toBe(1);
+
+    fs.rmSync(cortexDir, { recursive: true, force: true });
+  });
+
+  it("consolidates duplicate bullets and preserves citation metadata", () => {
+    const cortexDir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-consolidate-"));
+    const project = "proj";
+    const projectDir = path.join(cortexDir, project);
+    fs.mkdirSync(projectDir, { recursive: true });
+    grantAdminAccess(cortexDir);
+
+    const today = new Date().toISOString().slice(0, 10);
+    const content = [
+      "# proj LEARNINGS",
+      "",
+      `## ${today}`,
+      "",
+      "- Same bullet",
+      "- Same bullet",
+      "  <!-- cortex:cite {\"created_at\":\"2026-01-01T00:00:00.000Z\"} -->",
+      "",
+    ].join("\n");
+    fs.writeFileSync(path.join(projectDir, "LEARNINGS.md"), content);
+
+    const result = consolidateProjectLearnings(cortexDir, project);
+    expect(result).toContain("Consolidated");
+    const next = fs.readFileSync(path.join(projectDir, "LEARNINGS.md"), "utf8");
+    expect((next.match(/- Same bullet/g) || []).length).toBe(1);
+    expect((next.match(/<!-- cortex:cite/g) || []).length).toBe(1);
+
+    fs.rmSync(cortexDir, { recursive: true, force: true });
   });
 });
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
 
-import { runInit } from "./init.js";
+import { parseMcpMode, runInit } from "./init.js";
 
 if (process.argv[2] === "--help" || process.argv[2] === "-h" || process.argv[2] === "help") {
   console.log(`cortex - Long-term memory for Claude Code
 
 Usage:
-  npx @alaarab/cortex init [--machine <name>] [--profile <name>]
+  npx @alaarab/cortex init [--machine <name>] [--profile <name>] [--mcp on|off]
                                                  Set up cortex in ~/.cortex
+                                                 --mcp on|off: MCP tools enabled/disabled (default on)
   npx @alaarab/cortex uninstall                  Remove cortex MCP config and hooks
-  npx @alaarab/cortex link [--machine <n>] [--profile <n>] [--register] [--task debugging|planning|clean] [--all-tools]
+  npx @alaarab/cortex mcp-mode [on|off|status]   Toggle MCP integration without reinstalling
+  npx @alaarab/cortex link [--machine <n>] [--profile <n>] [--register] [--task debugging|planning|clean] [--all-tools] [--mcp on|off]
                                                  Sync profile, symlinks, hooks, and context (replaces link.sh)
                                                  --all-tools: configure hooks for all agents (default: auto-detect)
   npx @alaarab/cortex search <query>             Search your knowledge base
@@ -17,6 +19,21 @@ Usage:
                                                  Add a learning to a project
   npx @alaarab/cortex hook-prompt                (used by Claude Code UserPromptSubmit hook)
   npx @alaarab/cortex hook-context               (used by Claude Code SessionStart hook)
+  npx @alaarab/cortex extract-memories [project] Auto-generate memory candidates from git history
+  npx @alaarab/cortex govern-memories [project]  Queue stale/conflicting/low-value memory items
+  npx @alaarab/cortex pin-memory <project> "<memory>"
+                                                 Pin canonical memory for a project
+  npx @alaarab/cortex doctor [--fix]             Health-check setup; with --fix run self-heal
+  npx @alaarab/cortex memory-ui [--port=3499]    Open lightweight memory review UI
+  npx @alaarab/cortex quality-feedback --key=<k> --type=helpful|reprompt|regression
+                                                 Record memory usefulness feedback
+  npx @alaarab/cortex prune-memories [project]   Delete stale memory entries by retention policy
+  npx @alaarab/cortex consolidate-memories [project]
+                                                 Deduplicate and consolidate LEARNINGS.md bullets
+  npx @alaarab/cortex memory-policy [get|set ...]
+                                                 Read/update retention and scoring policy
+  npx @alaarab/cortex memory-access [get|set ...]
+                                                 Read/update role-based memory access control
 
 MCP server mode (used by Claude Code automatically):
   npx @alaarab/cortex [cortex-path]
@@ -33,9 +50,16 @@ if (process.argv[2] === "init") {
   const initArgs = process.argv.slice(3);
   const machineIdx = initArgs.indexOf("--machine");
   const profileIdx = initArgs.indexOf("--profile");
+  const mcpIdx = initArgs.indexOf("--mcp");
+  const mcpMode = mcpIdx !== -1 ? parseMcpMode(initArgs[mcpIdx + 1]) : undefined;
+  if (mcpIdx !== -1 && !mcpMode) {
+    console.error(`Invalid --mcp value "${initArgs[mcpIdx + 1] || ""}". Use "on" or "off".`);
+    process.exit(1);
+  }
   await runInit({
     machine: machineIdx !== -1 ? initArgs[machineIdx + 1] : undefined,
     profile: profileIdx !== -1 ? initArgs[profileIdx + 1] : undefined,
+    mcp: mcpMode,
   });
   process.exit(0);
 }
@@ -43,6 +67,12 @@ if (process.argv[2] === "init") {
 if (process.argv[2] === "uninstall") {
   const { runUninstall } = await import("./init.js");
   await runUninstall();
+  process.exit(0);
+}
+
+if (process.argv[2] === "mcp-mode") {
+  const { runMcpMode } = await import("./init.js");
+  await runMcpMode(process.argv[3]);
   process.exit(0);
 }
 
@@ -54,12 +84,19 @@ if (process.argv[2] === "link") {
     return idx !== -1 ? linkArgs[idx + 1] : undefined;
   };
   const taskArg = getFlag("--task") as "debugging" | "planning" | "clean" | undefined;
+  const mcpArg = getFlag("--mcp");
+  const mcpMode = mcpArg ? parseMcpMode(mcpArg) : undefined;
+  if (mcpArg && !mcpMode) {
+    console.error(`Invalid --mcp value "${mcpArg}". Use "on" or "off".`);
+    process.exit(1);
+  }
   await runLink(process.env.CORTEX_PATH || require("os").homedir() + "/.cortex", {
     machine: getFlag("--machine"),
     profile: getFlag("--profile"),
     register: linkArgs.includes("--register"),
     task: taskArg,
     allTools: linkArgs.includes("--all-tools"),
+    mcp: mcpMode,
   });
   process.exit(0);
 }
@@ -69,7 +106,23 @@ if (process.argv[2] === "--health") {
 }
 
 // CLI subcommands (run before MCP server starts)
-const CLI_COMMANDS = ["search", "hook-prompt", "hook-context", "add-learning"];
+const CLI_COMMANDS = [
+  "search",
+  "hook-prompt",
+  "hook-context",
+  "add-learning",
+  "extract-memories",
+  "govern-memories",
+  "pin-memory",
+  "doctor",
+  "memory-ui",
+  "quality-feedback",
+  "prune-memories",
+  "consolidate-memories",
+  "memory-policy",
+  "memory-access",
+  "background-maintenance",
+];
 if (CLI_COMMANDS.includes(process.argv[2])) {
   const { runCliCommand } = await import("./cli.js");
   await runCliCommand(process.argv[2], process.argv.slice(3));
@@ -83,7 +136,28 @@ import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
 import { isValidProjectName, safeProjectPath, sanitizeFts5Query, expandSynonyms } from "./utils.js";
-import { findCortexPathWithArg, buildIndex, extractSnippet, queryRows, addLearningToFile, validateBacklogFormat, autoMergeConflicts, debugLog } from "./shared.js";
+import {
+  findCortexPathWithArg,
+  buildIndex,
+  extractSnippet,
+  queryRows,
+  addLearningToFile,
+  validateBacklogFormat,
+  autoMergeConflicts,
+  debugLog,
+  upsertCanonicalMemory,
+  filterTrustedLearningsDetailed,
+  appendMemoryQueue,
+  appendAuditLog,
+  getMemoryPolicy,
+  updateMemoryPolicy,
+  getAccessControl,
+  updateAccessControl,
+  pruneDeadMemories,
+  consolidateProjectLearnings,
+  recordMemoryFeedback,
+  enforceCanonicalLocks,
+} from "./shared.js";
 
 // MCP mode: first non-flag arg is the cortex path
 const cortexArg = process.argv.find((a, i) => i >= 2 && !a.startsWith("-"));
@@ -99,8 +173,185 @@ async function main() {
 
   const server = new McpServer({
     name: "cortex-mcp",
-    version: "1.7.4",
+    version: "1.8.4",
   });
+
+  server.registerTool(
+    "pin_memory",
+    {
+      title: "◆ cortex · pin memory",
+      description:
+        "Promote an important memory into CANONICAL_MEMORIES.md so retrieval prioritizes it.",
+      inputSchema: z.object({
+        project: z.string().describe("Project name."),
+        memory: z.string().describe("Canonical memory text to pin."),
+      }),
+    },
+    async ({ project, memory }) => {
+      const result = upsertCanonicalMemory(cortexPath, project, memory);
+      return textResponse(result);
+    }
+  );
+
+  server.registerTool(
+    "govern_memories",
+    {
+      title: "◆ cortex · govern",
+      description:
+        "Scan LEARNINGS.md entries and queue stale/citation-conflicting/low-value memory items in MEMORY_QUEUE.md.",
+      inputSchema: z.object({
+        project: z.string().optional().describe("Optional project name; omit to scan all indexed projects."),
+      }),
+    },
+    async ({ project }) => {
+      const projects = project
+        ? [project]
+        : (queryRows(db, "SELECT DISTINCT project FROM docs ORDER BY project", []) ?? []).map((r) => r[0] as string);
+      const policy = getMemoryPolicy(cortexPath);
+      const ttlDays = Number.parseInt(process.env.CORTEX_MEMORY_TTL_DAYS || String(policy.ttlDays), 10);
+
+      let staleCount = 0;
+      let conflictCount = 0;
+      let reviewCount = 0;
+      for (const proj of projects) {
+        const learningsFile = path.join(cortexPath, proj, "LEARNINGS.md");
+        if (!fs.existsSync(learningsFile)) continue;
+        const content = fs.readFileSync(learningsFile, "utf8");
+        const trust = filterTrustedLearningsDetailed(content, {
+          ttlDays: Number.isNaN(ttlDays) ? policy.ttlDays : ttlDays,
+          minConfidence: policy.minInjectConfidence,
+          decay: policy.decay,
+        });
+        const stale = trust.issues.filter((i) => i.reason === "stale").map((i) => i.bullet);
+        const conflicts = trust.issues.filter((i) => i.reason === "invalid_citation").map((i) => i.bullet);
+        staleCount += appendMemoryQueue(cortexPath, proj, "Stale", stale);
+        conflictCount += appendMemoryQueue(cortexPath, proj, "Conflicts", conflicts);
+        const lowValue = content.split("\n")
+          .filter((l) => l.startsWith("- "))
+          .filter((l) => /(fixed stuff|updated things|misc|temp|wip|quick note)/i.test(l) || l.length < 16);
+        reviewCount += appendMemoryQueue(cortexPath, proj, "Review", lowValue);
+        consolidateProjectLearnings(cortexPath, proj);
+      }
+
+      appendAuditLog(
+        cortexPath,
+        "govern_memories_mcp",
+        `projects=${projects.length} stale=${staleCount} conflicts=${conflictCount} review=${reviewCount}`
+      );
+      enforceCanonicalLocks(cortexPath, project);
+      return textResponse(
+        `Governed memories across ${projects.length} project(s): stale=${staleCount}, conflicts=${conflictCount}, review=${reviewCount}`
+      );
+    }
+  );
+
+  server.registerTool(
+    "memory_policy",
+    {
+      title: "◆ cortex · policy",
+      description:
+        "Read or update memory governance policy (retention, ttl, confidence thresholds, decay).",
+      inputSchema: z.object({
+        mode: z.enum(["get", "set"]).describe("get returns policy, set applies provided fields."),
+        ttlDays: z.number().optional(),
+        retentionDays: z.number().optional(),
+        autoAcceptThreshold: z.number().optional(),
+        minInjectConfidence: z.number().optional(),
+        decay_d30: z.number().optional(),
+        decay_d60: z.number().optional(),
+        decay_d90: z.number().optional(),
+        decay_d120: z.number().optional(),
+      }),
+    },
+    async ({ mode, ttlDays, retentionDays, autoAcceptThreshold, minInjectConfidence, decay_d30, decay_d60, decay_d90, decay_d120 }) => {
+      if (mode === "get") {
+        return textResponse(JSON.stringify(getMemoryPolicy(cortexPath), null, 2));
+      }
+      const result = updateMemoryPolicy(cortexPath, {
+        ttlDays,
+        retentionDays,
+        autoAcceptThreshold,
+        minInjectConfidence,
+        decay: {
+          d30: decay_d30,
+          d60: decay_d60,
+          d90: decay_d90,
+          d120: decay_d120,
+        },
+      });
+      if (typeof result === "string") return textResponse(result);
+      return textResponse(JSON.stringify(result, null, 2));
+    }
+  );
+
+  server.registerTool(
+    "prune_memories",
+    {
+      title: "◆ cortex · prune",
+      description: "Delete stale memory entries based on retention policy.",
+      inputSchema: z.object({
+        project: z.string().optional().describe("Optional project name; omit to prune all projects."),
+      }),
+    },
+    async ({ project }) => {
+      return textResponse(pruneDeadMemories(cortexPath, project));
+    }
+  );
+
+  server.registerTool(
+    "memory_access",
+    {
+      title: "◆ cortex · access",
+      description: "Read or update role-based memory access control (admins/maintainers/contributors/viewers).",
+      inputSchema: z.object({
+        mode: z.enum(["get", "set"]).describe("get returns current access control, set updates role lists."),
+        admins: z.array(z.string()).optional(),
+        maintainers: z.array(z.string()).optional(),
+        contributors: z.array(z.string()).optional(),
+        viewers: z.array(z.string()).optional(),
+      }),
+    },
+    async ({ mode, admins, maintainers, contributors, viewers }) => {
+      if (mode === "get") return textResponse(JSON.stringify(getAccessControl(cortexPath), null, 2));
+      const updated = updateAccessControl(cortexPath, { admins, maintainers, contributors, viewers });
+      if (typeof updated === "string") return textResponse(updated);
+      return textResponse(JSON.stringify(updated, null, 2));
+    }
+  );
+
+  server.registerTool(
+    "consolidate_memories",
+    {
+      title: "◆ cortex · consolidate",
+      description: "Deduplicate LEARNINGS.md bullets for one project or all projects.",
+      inputSchema: z.object({
+        project: z.string().optional().describe("Optional project name; omit to consolidate all indexed projects."),
+      }),
+    },
+    async ({ project }) => {
+      const projects = project
+        ? [project]
+        : (queryRows(db, "SELECT DISTINCT project FROM docs ORDER BY project", []) ?? []).map((r) => r[0] as string);
+      const out = projects.map((p) => consolidateProjectLearnings(cortexPath, p));
+      return textResponse(out.join("\n"));
+    }
+  );
+
+  server.registerTool(
+    "memory_feedback",
+    {
+      title: "◆ cortex · feedback",
+      description: "Record feedback on whether an injected memory was helpful or noisy/regressive.",
+      inputSchema: z.object({
+        key: z.string().describe("Memory key to score."),
+        feedback: z.enum(["helpful", "reprompt", "regression"]).describe("Feedback type."),
+      }),
+    },
+    async ({ key, feedback }) => {
+      recordMemoryFeedback(cortexPath, key, feedback);
+      return textResponse(`Recorded feedback ${feedback} for ${key}`);
+    }
+  );
 
   server.registerTool(
     "search_cortex",
@@ -110,7 +361,7 @@ async function main() {
       inputSchema: z.object({
         query: z.string().describe("Search query (supports FTS5 syntax: AND, OR, NOT, phrase matching with quotes)"),
         limit: z.number().min(1).max(20).optional().describe("Max results to return (1-20, default 5)"),
-        type: z.enum(["claude", "learnings", "knowledge", "skills", "summary", "backlog", "changelog", "skill", "other"])
+        type: z.enum(["claude", "learnings", "knowledge", "skills", "summary", "backlog", "changelog", "canonical", "memory-queue", "skill", "other"])
           .optional()
           .describe("Filter by document type: claude, learnings, knowledge, summary, backlog, skill"),
       }),
@@ -451,10 +702,19 @@ async function main() {
       inputSchema: z.object({
         project: z.string().describe("Project name (must match a directory in your cortex)."),
         learning: z.string().describe("The insight, written as a single bullet point. Be specific enough that someone could act on it without extra context."),
+        citation_file: z.string().optional().describe("Optional source file path that supports this learning."),
+        citation_line: z.number().int().positive().optional().describe("Optional 1-based line number in citation_file."),
+        citation_repo: z.string().optional().describe("Optional git repository root path for citation validation."),
+        citation_commit: z.string().optional().describe("Optional git commit SHA that supports this learning."),
       }),
     },
-    async ({ project, learning }) => {
-      const result = addLearningToFile(cortexPath, project, learning);
+    async ({ project, learning, citation_file, citation_line, citation_repo, citation_commit }) => {
+      const result = addLearningToFile(cortexPath, project, learning, {
+        file: citation_file,
+        line: citation_line,
+        repo: citation_repo,
+        commit: citation_commit,
+      });
       return textResponse(result);
     }
   );
@@ -484,8 +744,11 @@ async function main() {
       if (idx === -1) return textResponse(`No learning matching "${learning}" found in ${project}.`);
 
       const matched = lines[idx];
-      lines.splice(idx, 1);
-      fs.writeFileSync(learningsPath, lines.join("\n"));
+      const citationComment = /^\s*<!--\s*cortex:cite\s+\{.*\}\s*-->\s*$/;
+      const removeCount = citationComment.test(lines[idx + 1] || "") ? 2 : 1;
+      lines.splice(idx, removeCount);
+      const normalized = lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+      fs.writeFileSync(learningsPath, normalized);
       return textResponse(`Removed from ${project}: ${matched}`);
     }
   );

--- a/mcp/src/init.test.ts
+++ b/mcp/src/init.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  configureClaude,
+  configureVSCode,
+  getMcpEnabledPreference,
+  parseMcpMode,
+  setMcpEnabledPreference,
+} from "./init.js";
+
+describe.sequential("mcp mode configuration", () => {
+  let tmpRoot: string;
+  let homeDir: string;
+  let cortexPath: string;
+  const origHome = process.env.HOME;
+  const origUserProfile = process.env.USERPROFILE;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-init-test-"));
+    homeDir = path.join(tmpRoot, "home");
+    cortexPath = path.join(tmpRoot, "cortex");
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(cortexPath, { recursive: true });
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    process.env.USERPROFILE = origUserProfile;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("parses mcp mode values", () => {
+    expect(parseMcpMode("on")).toBe("on");
+    expect(parseMcpMode("OFF")).toBe("off");
+    expect(parseMcpMode("status")).toBeUndefined();
+    expect(parseMcpMode("")).toBeUndefined();
+  });
+
+  it("defaults to mcp enabled and persists preference updates", () => {
+    expect(getMcpEnabledPreference(cortexPath)).toBe(true);
+    setMcpEnabledPreference(cortexPath, false);
+    expect(getMcpEnabledPreference(cortexPath)).toBe(false);
+    setMcpEnabledPreference(cortexPath, true);
+    expect(getMcpEnabledPreference(cortexPath)).toBe(true);
+  });
+
+  it("toggles Claude MCP config on and off while keeping hooks", () => {
+    const claudeDir = path.join(homeDir, ".claude");
+    fs.mkdirSync(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, "settings.json");
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            cortex: { command: "npx", args: ["-y", "@alaarab/cortex", "/old/path"] },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const offStatus = configureClaude(cortexPath, { mcpEnabled: false });
+    expect(offStatus).toBe("disabled");
+    const offCfg = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+    expect(offCfg.mcpServers?.cortex).toBeUndefined();
+    expect(Array.isArray(offCfg.hooks?.UserPromptSubmit)).toBe(true);
+    expect(Array.isArray(offCfg.hooks?.Stop)).toBe(true);
+    expect(Array.isArray(offCfg.hooks?.SessionStart)).toBe(true);
+
+    const onStatus = configureClaude(cortexPath, { mcpEnabled: true });
+    expect(onStatus).toBe("installed");
+    const onCfg = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+    expect(onCfg.mcpServers?.cortex?.command).toBe("npx");
+    expect(onCfg.mcpServers?.cortex?.args).toContain(cortexPath);
+  });
+
+  it("toggles VS Code MCP config on and off", () => {
+    const vscodeDir = path.join(homeDir, ".config", "Code", "User");
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    const mcpPath = path.join(vscodeDir, "mcp.json");
+    fs.writeFileSync(
+      mcpPath,
+      JSON.stringify(
+        {
+          servers: {
+            cortex: { command: "npx", args: ["-y", "@alaarab/cortex", "/old/path"] },
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const offStatus = configureVSCode(cortexPath, { mcpEnabled: false });
+    expect(offStatus).toBe("disabled");
+    const offCfg = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
+    expect(offCfg.servers?.cortex).toBeUndefined();
+
+    const onStatus = configureVSCode(cortexPath, { mcpEnabled: true });
+    expect(onStatus).toBe("installed");
+    const onCfg = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
+    expect(onCfg.servers?.cortex?.command).toBe("npx");
+    expect(onCfg.servers?.cortex?.args).toContain(cortexPath);
+  });
+});

--- a/mcp/src/init.ts
+++ b/mcp/src/init.ts
@@ -9,6 +9,63 @@ const ROOT = path.join(__dirname, "..", "..");
 const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
 const VERSION = pkg.version as string;
 const STARTER_DIR = path.join(ROOT, "starter");
+const DEFAULT_CORTEX_PATH = path.join(os.homedir(), ".cortex");
+
+export type McpMode = "on" | "off";
+
+interface InstallPreferences {
+  mcpEnabled?: boolean;
+  updatedAt?: string;
+}
+
+function preferencesFile(cortexPath: string): string {
+  return path.join(cortexPath, ".governance", "install-preferences.json");
+}
+
+function readInstallPreferences(cortexPath: string): InstallPreferences {
+  const file = preferencesFile(cortexPath);
+  if (!fs.existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as InstallPreferences;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeInstallPreferences(cortexPath: string, patch: Partial<InstallPreferences>) {
+  const file = preferencesFile(cortexPath);
+  const current = readInstallPreferences(cortexPath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        ...current,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      },
+      null,
+      2
+    ) + "\n"
+  );
+}
+
+export function parseMcpMode(raw?: string): McpMode | undefined {
+  if (!raw) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "on" || normalized === "off") return normalized;
+  return undefined;
+}
+
+export function getMcpEnabledPreference(cortexPath: string): boolean {
+  const prefs = readInstallPreferences(cortexPath);
+  return prefs.mcpEnabled !== false;
+}
+
+export function setMcpEnabledPreference(cortexPath: string, enabled: boolean): void {
+  writeInstallPreferences(cortexPath, { mcpEnabled: enabled });
+}
 
 function log(msg: string) {
   process.stdout.write(msg + "\n");
@@ -34,18 +91,57 @@ function resolveEntryScript(): string {
   return path.join(ROOT, "mcp", "dist", "index.js");
 }
 
-export function configureClaude(cortexPath: string) {
+export function ensureGovernanceFiles(cortexPath: string) {
+  const govDir = path.join(cortexPath, ".governance");
+  fs.mkdirSync(govDir, { recursive: true });
+  const policy = path.join(govDir, "memory-policy.json");
+  const access = path.join(govDir, "access-control.json");
+
+  if (!fs.existsSync(policy)) {
+    fs.writeFileSync(
+      policy,
+      JSON.stringify({
+        ttlDays: 120,
+        retentionDays: 365,
+        autoAcceptThreshold: 0.75,
+        minInjectConfidence: 0.35,
+        decay: { d30: 1.0, d60: 0.85, d90: 0.65, d120: 0.45 },
+      }, null, 2) + "\n"
+    );
+  }
+  if (!fs.existsSync(access)) {
+    const user = process.env.USER || process.env.USERNAME || "owner";
+    fs.writeFileSync(
+      access,
+      JSON.stringify({
+        admins: [user],
+        maintainers: [],
+        contributors: [],
+        viewers: [],
+      }, null, 2) + "\n"
+    );
+  }
+}
+
+export function configureClaude(cortexPath: string, opts: { mcpEnabled?: boolean } = {}) {
   const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
   const entryScript = resolveEntryScript();
+  const mcpEnabled = opts.mcpEnabled ?? getMcpEnabledPreference(cortexPath);
+  let status: "installed" | "already_configured" | "disabled" | "already_disabled" = "already_disabled";
 
   patchJsonFile(settingsPath, (data) => {
     // MCP server
     if (!data.mcpServers) data.mcpServers = {};
-    if (!data.mcpServers.cortex) {
+    const hadMcp = Boolean(data.mcpServers.cortex);
+    if (mcpEnabled) {
       data.mcpServers.cortex = {
         command: "npx",
         args: ["-y", `@alaarab/cortex@${VERSION}`, cortexPath],
       };
+      status = hadMcp ? "already_configured" : "installed";
+    } else {
+      if (hadMcp) delete data.mcpServers.cortex;
+      status = hadMcp ? "disabled" : "already_disabled";
     }
 
     // Hooks: always update to latest version
@@ -83,7 +179,7 @@ export function configureClaude(cortexPath: string) {
     // SessionStart hook: auto-pull cortex on session start
     const startHook = {
       type: "command",
-      command: `cd "${cortexPath}" && git pull --rebase --quiet 2>/dev/null || true`,
+      command: `cd "${cortexPath}" && (git pull --rebase --quiet 2>/dev/null || true) && (npx @alaarab/cortex doctor --fix >/dev/null 2>&1 || true)`,
     };
     const existingStart = data.hooks.SessionStart as any[] | undefined;
     const hasCortexStartHook = existingStart?.some(
@@ -94,12 +190,11 @@ export function configureClaude(cortexPath: string) {
       data.hooks.SessionStart.push({ matcher: "", hooks: [startHook] });
     }
   });
-  return !JSON.parse(fs.readFileSync(settingsPath, "utf8")).mcpServers?.cortex
-    ? "skipped"
-    : "installed";
+  return status;
 }
 
-export function configureVSCode(cortexPath: string) {
+export function configureVSCode(cortexPath: string, opts: { mcpEnabled?: boolean } = {}) {
+  const mcpEnabled = opts.mcpEnabled ?? getMcpEnabledPreference(cortexPath);
   const candidates = [
     path.join(os.homedir(), ".config", "Code", "User"),
     path.join(os.homedir(), "Library", "Application Support", "Code", "User"),
@@ -109,21 +204,23 @@ export function configureVSCode(cortexPath: string) {
   if (!vscodeDir) return "no_vscode";
 
   const mcp_file = path.join(vscodeDir, "mcp.json");
-  if (fs.existsSync(mcp_file)) {
-    try {
-      const existing = JSON.parse(fs.readFileSync(mcp_file, "utf8"));
-      if (existing?.servers?.cortex) return "already_configured";
-    } catch {}
-  }
-
+  if (!mcpEnabled && !fs.existsSync(mcp_file)) return "already_disabled";
+  let status: "installed" | "already_configured" | "disabled" | "already_disabled" = "already_disabled";
   patchJsonFile(mcp_file, (data) => {
     if (!data.servers) data.servers = {};
-    data.servers.cortex = {
-      command: "npx",
-      args: ["-y", `@alaarab/cortex@${VERSION}`, cortexPath],
-    };
+    const hadMcp = Boolean(data.servers.cortex);
+    if (mcpEnabled) {
+      data.servers.cortex = {
+        command: "npx",
+        args: ["-y", `@alaarab/cortex@${VERSION}`, cortexPath],
+      };
+      status = hadMcp ? "already_configured" : "installed";
+    } else {
+      if (hadMcp) delete data.servers.cortex;
+      status = hadMcp ? "disabled" : "already_disabled";
+    }
   });
-  return "installed";
+  return status;
 }
 
 function updateMachinesYaml(cortexPath: string, machine?: string, profile?: string) {
@@ -146,35 +243,46 @@ function updateMachinesYaml(cortexPath: string, machine?: string, profile?: stri
 export interface InitOptions {
   machine?: string;
   profile?: string;
+  mcp?: McpMode;
 }
 
 export async function runInit(opts: InitOptions = {}) {
-  const home = os.homedir();
-  const cortexPath = path.join(home, ".cortex");
+  const cortexPath = process.env.CORTEX_PATH || DEFAULT_CORTEX_PATH;
+  const mcpEnabled = opts.mcp ? opts.mcp === "on" : getMcpEnabledPreference(cortexPath);
+  const mcpLabel = mcpEnabled ? "ON (recommended)" : "OFF (hooks-only fallback)";
 
   if (fs.existsSync(cortexPath)) {
     const entries = fs.readdirSync(cortexPath);
     if (entries.length > 0) {
       log(`\ncortex already exists at ${cortexPath}`);
-      log(`Updating MCP + hook configuration...\n`);
+      log(`Updating configuration...\n`);
+      log(`  MCP mode: ${mcpLabel}`);
 
       // Always reconfigure MCP and hooks (picks up new features on upgrade)
       try {
-        configureClaude(cortexPath);
-        log(`  Updated Claude Code MCP + hooks`);
+        const status = configureClaude(cortexPath, { mcpEnabled });
+        if (status === "disabled" || status === "already_disabled") {
+          log(`  Updated Claude Code hooks (MCP disabled)`);
+        } else {
+          log(`  Updated Claude Code MCP + hooks`);
+        }
       } catch (e) {
-        log(`  Could not configure Claude Code MCP (${e}), add manually`);
+        log(`  Could not configure Claude Code settings (${e}), add manually`);
       }
 
       try {
-        const vscodeResult = configureVSCode(cortexPath);
+        const vscodeResult = configureVSCode(cortexPath, { mcpEnabled });
         if (vscodeResult === "installed") log(`  Updated VS Code MCP`);
+        if (vscodeResult === "disabled") log(`  Disabled VS Code MCP`);
       } catch {}
 
       try {
         const hooked = configureAllHooks(cortexPath);
         if (hooked.length) log(`  Updated hooks: ${hooked.join(", ")}`);
       } catch { /* best effort */ }
+
+      ensureGovernanceFiles(cortexPath);
+      setMcpEnabledPreference(cortexPath, mcpEnabled);
 
       log(`\nDone. Restart Claude Code to pick up changes.\n`);
       process.exit(0);
@@ -235,20 +343,26 @@ export async function runInit(opts: InitOptions = {}) {
   const effectiveMachine = opts.machine || os.hostname();
   updateMachinesYaml(cortexPath, opts.machine, opts.profile);
   log(`  Updated machines.yaml with hostname "${effectiveMachine}"`);
+  log(`  MCP mode: ${mcpLabel}`);
 
   // Configure Claude Code
   try {
-    configureClaude(cortexPath);
-    log(`  Configured Claude Code MCP + hooks`);
+    const status = configureClaude(cortexPath, { mcpEnabled });
+    if (status === "disabled" || status === "already_disabled") {
+      log(`  Configured Claude Code hooks (MCP disabled)`);
+    } else {
+      log(`  Configured Claude Code MCP + hooks`);
+    }
   } catch (e) {
-    log(`  Could not configure Claude Code MCP (${e}), add manually`);
+    log(`  Could not configure Claude Code settings (${e}), add manually`);
   }
 
   // Configure VS Code
   try {
-    const vscodeResult = configureVSCode(cortexPath);
+    const vscodeResult = configureVSCode(cortexPath, { mcpEnabled });
     if (vscodeResult === "installed") log(`  Configured VS Code MCP`);
     else if (vscodeResult === "already_configured") log(`  VS Code MCP already configured`);
+    else if (vscodeResult === "disabled") log(`  VS Code MCP disabled`);
     // no_vscode: skip silently
   } catch {
     // skip
@@ -260,6 +374,9 @@ export async function runInit(opts: InitOptions = {}) {
     if (hooked.length) log(`  Configured hooks: ${hooked.join(", ")}`);
   } catch { /* best effort */ }
 
+  ensureGovernanceFiles(cortexPath);
+  setMcpEnabledPreference(cortexPath, mcpEnabled);
+
   log(`\nDone. Your knowledge base is at ${cortexPath}\n`);
   log(`Next steps:`);
   log(`  1. Create a private GitHub repo and push your cortex:`);
@@ -269,8 +386,41 @@ export async function runInit(opts: InitOptions = {}) {
   log(`     git commit -m "Initial cortex setup"`);
   log(`     git remote add origin git@github.com:YOUR_USERNAME/cortex.git`);
   log(`     git push -u origin main`);
-  log(`  2. Restart Claude Code to activate the MCP server`);
+  if (mcpEnabled) {
+    log(`  2. Restart Claude Code to activate the MCP server`);
+  } else {
+    log(`  2. Restart Claude Code to use hooks-only mode (no MCP tools)`);
+    log(`     Turn MCP on later: npx @alaarab/cortex mcp-mode on`);
+  }
   log(`  3. Open a project and run /cortex-init <name> to add it\n`);
+}
+
+export async function runMcpMode(modeArg?: string) {
+  const cortexPath = process.env.CORTEX_PATH || DEFAULT_CORTEX_PATH;
+  const normalizedArg = modeArg?.trim().toLowerCase();
+  if (!normalizedArg || normalizedArg === "status") {
+    const current = getMcpEnabledPreference(cortexPath);
+    log(`MCP mode: ${current ? "on (recommended)" : "off (hooks-only fallback)"}`);
+    log(`Change mode: npx @alaarab/cortex mcp-mode on|off`);
+    return;
+  }
+  const mode = parseMcpMode(normalizedArg);
+  if (!mode) {
+    log(`Invalid mode "${modeArg}". Use: on | off | status`);
+    process.exit(1);
+  }
+  const enabled = mode === "on";
+  setMcpEnabledPreference(cortexPath, enabled);
+
+  let claudeStatus = "no_settings";
+  let vscodeStatus = "no_vscode";
+  try { claudeStatus = configureClaude(cortexPath, { mcpEnabled: enabled }) ?? claudeStatus; } catch { /* best effort */ }
+  try { vscodeStatus = configureVSCode(cortexPath, { mcpEnabled: enabled }) ?? vscodeStatus; } catch { /* best effort */ }
+
+  log(`MCP mode set to ${mode}.`);
+  log(`Claude status: ${claudeStatus}`);
+  log(`VS Code status: ${vscodeStatus}`);
+  log(`Restart your agent to apply changes.`);
 }
 
 export async function runUninstall() {

--- a/mcp/src/link.ts
+++ b/mcp/src/link.ts
@@ -3,8 +3,15 @@ import * as path from "path";
 import * as os from "os";
 import * as readline from "readline";
 import * as yaml from "js-yaml";
-import { execSync } from "child_process";
-import { configureClaude, configureVSCode } from "./init.js";
+import { execFileSync } from "child_process";
+import {
+  configureClaude,
+  configureVSCode,
+  ensureGovernanceFiles,
+  getMcpEnabledPreference,
+  setMcpEnabledPreference,
+  type McpMode,
+} from "./init.js";
 import { configureAllHooks, detectInstalledTools } from "./hooks.js";
 
 const MACHINE_FILE = path.join(os.homedir(), ".cortex-machine");
@@ -114,8 +121,8 @@ async function registerMachine(cortexPath: string): Promise<{ machine: string; p
 
   // Commit if in git repo
   try {
-    execSync(`git add machines.yaml`, { cwd: cortexPath, stdio: "ignore" });
-    execSync(`git commit -m "Register machine: ${machine} (${profile})" --allow-empty`, {
+    execFileSync("git", ["add", "machines.yaml"], { cwd: cortexPath, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", `Register machine: ${machine} (${profile})`, "--allow-empty"], {
       cwd: cortexPath, stdio: "ignore",
     });
   } catch { /* best effort */ }
@@ -126,14 +133,14 @@ async function registerMachine(cortexPath: string): Promise<{ machine: string; p
 
 function setupSparseCheckout(cortexPath: string, projects: string[]) {
   try {
-    execSync("git rev-parse --git-dir", { cwd: cortexPath, stdio: "ignore" });
+    execFileSync("git", ["rev-parse", "--git-dir"], { cwd: cortexPath, stdio: "ignore" });
   } catch { return; } // Not a git repo
 
   const alwaysInclude = ["profiles", "machines.yaml", "global", "link.sh", "README.md", ".gitignore"];
   const paths = [...alwaysInclude, ...projects];
   try {
-    execSync(`git sparse-checkout set ${paths.join(" ")}`, { cwd: cortexPath, stdio: "ignore" });
-    execSync("git pull --ff-only", { cwd: cortexPath, stdio: "ignore" });
+    execFileSync("git", ["sparse-checkout", "set", ...paths], { cwd: cortexPath, stdio: "ignore" });
+    execFileSync("git", ["pull", "--ff-only"], { cwd: cortexPath, stdio: "ignore" });
   } catch { /* best effort */ }
 }
 
@@ -148,7 +155,7 @@ function symlinkFile(src: string, dest: string) {
 
 function writeSkillMd(cortexPath: string) {
   const cortexPathEscaped = cortexPath.replace(/"/g, '\\"');
-  const pullCmd = `cd "${cortexPathEscaped}" && git pull --rebase --quiet 2>/dev/null || true`;
+  const pullCmd = `cd "${cortexPathEscaped}" && (git pull --rebase --quiet 2>/dev/null || true) && (npx @alaarab/cortex doctor --fix >/dev/null 2>&1 || true)`;
   const stopCmd = `cd "${cortexPathEscaped}" && git diff --quiet 2>/dev/null || (git add -A && git commit -m 'auto-save cortex' && git push 2>/dev/null || true)`;
 
   const content = `---
@@ -179,7 +186,7 @@ context at the start of each prompt and saves learnings at session end via git.
 
 ## What it does
 
-- **SessionStart**: pulls latest cortex knowledge from remote
+- **SessionStart**: pulls latest cortex knowledge and self-heals hook/symlink drift
 - **UserPromptSubmit**: injects relevant project context, learnings, and backlog items
 - **Stop**: commits and pushes any new learnings to remote
 
@@ -300,6 +307,9 @@ function writeContextFile(managedContent: string) {
 function formatMcpStatus(status: string): string {
   if (status === "installed" || status === "already_configured") {
     return "MCP: active (search_cortex, get_project_summary, list_projects)";
+  }
+  if (status === "disabled" || status === "already_disabled") {
+    return "MCP: disabled (hooks-only fallback active)";
   }
   if (status === "not_built") return "MCP: not built. Run: cd mcp && npm install && npm run build";
   return "";
@@ -427,10 +437,19 @@ export interface LinkOptions {
   register?: boolean;
   task?: "debugging" | "planning" | "clean";
   allTools?: boolean;   // configure hooks for all tools regardless of detection
+  mcp?: McpMode;
+}
+
+export interface DoctorResult {
+  ok: boolean;
+  machine?: string;
+  profile?: string;
+  checks: Array<{ name: string; ok: boolean; detail: string }>;
 }
 
 export async function runLink(cortexPath: string, opts: LinkOptions = {}) {
   log("cortex link\n");
+  ensureGovernanceFiles(cortexPath);
 
   // Step 1: Identify machine + profile
   let machine = opts.machine ?? getMachineName();
@@ -484,12 +503,17 @@ export async function runLink(cortexPath: string, opts: LinkOptions = {}) {
 
   // Step 6: Configure MCP
   log("Configuring MCP...");
+  const mcpEnabled = opts.mcp ? opts.mcp === "on" : getMcpEnabledPreference(cortexPath);
+  setMcpEnabledPreference(cortexPath, mcpEnabled);
+  log(`  MCP mode: ${mcpEnabled ? "ON (recommended)" : "OFF (hooks-only fallback)"}`);
   let mcpStatus = "no_settings";
-  try { mcpStatus = configureClaude(cortexPath) ?? "installed"; } catch { /* best effort */ }
+  try { mcpStatus = configureClaude(cortexPath, { mcpEnabled }) ?? "installed"; } catch { /* best effort */ }
 
   const mcpMessages: Record<string, string> = {
     installed: "  Claude: installed cortex MCP server",
     already_configured: "  Claude: cortex MCP already configured",
+    disabled: "  Claude: cortex MCP disabled (hooks still active)",
+    already_disabled: "  Claude: cortex MCP already disabled",
     not_built: "  MCP: no local dist found and npx not available.",
     no_settings: "  Claude settings not found (skipping)",
     no_jq: "  Claude: skipped (install jq to auto-configure)",
@@ -497,11 +521,13 @@ export async function runLink(cortexPath: string, opts: LinkOptions = {}) {
   if (mcpMessages[mcpStatus]) log(mcpMessages[mcpStatus]);
 
   let vsStatus = "no_vscode";
-  try { vsStatus = configureVSCode(cortexPath) ?? "no_vscode"; } catch { /* best effort */ }
+  try { vsStatus = configureVSCode(cortexPath, { mcpEnabled }) ?? "no_vscode"; } catch { /* best effort */ }
 
   const vsMessages: Record<string, string> = {
     installed: "  VS Code: installed cortex MCP server",
     already_configured: "  VS Code: cortex MCP already configured",
+    disabled: "  VS Code: cortex MCP disabled",
+    already_disabled: "  VS Code: cortex MCP already disabled",
     no_jq: "  VS Code: mcp.json exists but jq not available",
   };
   if (vsMessages[vsStatus]) log(vsMessages[vsStatus]);
@@ -533,4 +559,162 @@ export async function runLink(cortexPath: string, opts: LinkOptions = {}) {
 
   log(`\nDone. Profile '${profile}' is active.`);
   if (opts.task) log(`Task mode: ${opts.task}`);
+}
+
+export async function runDoctor(cortexPath: string, fix: boolean = false): Promise<DoctorResult> {
+  const checks: Array<{ name: string; ok: boolean; detail: string }> = [];
+  const machine = getMachineName();
+  const profile = lookupProfile(cortexPath, machine);
+
+  checks.push({
+    name: "machine-registered",
+    ok: Boolean(profile),
+    detail: profile
+      ? `machine=${machine} profile=${profile}`
+      : `no profile mapping for machine=${machine} in machines.yaml`,
+  });
+
+  const profileFile = profile ? findProfileFile(cortexPath, profile) : null;
+  checks.push({
+    name: "profile-exists",
+    ok: Boolean(profileFile),
+    detail: profileFile ? `profile file found: ${profileFile}` : "profile file missing",
+  });
+
+  const projects = profileFile ? getProfileProjects(profileFile) : [];
+  checks.push({
+    name: "profile-projects",
+    ok: projects.length > 0,
+    detail: projects.length ? `${projects.length} projects in profile` : "no projects listed",
+  });
+
+  const contextFile = path.join(os.homedir(), ".cortex-context.md");
+  checks.push({
+    name: "context-file",
+    ok: fs.existsSync(contextFile),
+    detail: fs.existsSync(contextFile) ? contextFile : "missing ~/.cortex-context.md",
+  });
+
+  const memoryFile = path.join(
+    os.homedir(),
+    ".claude",
+    "projects",
+    `-home-${os.userInfo().username}`,
+    "memory",
+    "MEMORY.md"
+  );
+  checks.push({
+    name: "root-memory",
+    ok: fs.existsSync(memoryFile),
+    detail: fs.existsSync(memoryFile) ? memoryFile : "missing generated MEMORY.md",
+  });
+
+  const globalClaudeSrc = path.join(cortexPath, "global", "CLAUDE.md");
+  const globalClaudeDest = path.join(os.homedir(), ".claude", "CLAUDE.md");
+  let globalLinkOk = false;
+  try {
+    globalLinkOk = fs.existsSync(globalClaudeDest) && fs.realpathSync(globalClaudeDest) === fs.realpathSync(globalClaudeSrc);
+  } catch {
+    globalLinkOk = false;
+  }
+  checks.push({
+    name: "global-link",
+    ok: globalLinkOk,
+    detail: globalLinkOk ? "global CLAUDE.md symlink ok" : "global CLAUDE.md link drifted/missing",
+  });
+
+  for (const project of projects) {
+    if (project === "global") continue;
+    const target = findProjectDir(project);
+    if (!target) {
+      checks.push({ name: `project-path:${project}`, ok: false, detail: "project directory not found on disk" });
+      continue;
+    }
+    for (const f of ["CLAUDE.md", "KNOWLEDGE.md", "LEARNINGS.md"]) {
+      const src = path.join(cortexPath, project, f);
+      if (!fs.existsSync(src)) continue;
+      const dest = path.join(target, f);
+      let ok = false;
+      try {
+        ok = fs.existsSync(dest) && fs.realpathSync(dest) === fs.realpathSync(src);
+      } catch {
+        ok = false;
+      }
+      checks.push({
+        name: `symlink:${project}/${f}`,
+        ok,
+        detail: ok ? "ok" : `missing/drifted link at ${dest}`,
+      });
+    }
+  }
+
+  const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
+  let hookOk = false;
+  let doctorOk = false;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+    const hooks = cfg?.hooks || {};
+    const promptHooks = JSON.stringify(hooks.UserPromptSubmit || []);
+    const stopHooks = JSON.stringify(hooks.Stop || []);
+    const startHooks = JSON.stringify(hooks.SessionStart || []);
+    hookOk = promptHooks.includes("hook-prompt") && stopHooks.includes("auto-save");
+    doctorOk = startHooks.includes("doctor --fix");
+  } catch {
+    hookOk = false;
+    doctorOk = false;
+  }
+  checks.push({
+    name: "claude-hooks",
+    ok: hookOk,
+    detail: hookOk ? "prompt + stop hooks configured" : "missing prompt/stop hooks in ~/.claude/settings.json",
+  });
+  checks.push({
+    name: "doctor-background",
+    ok: doctorOk,
+    detail: doctorOk ? "doctor --fix is wired in SessionStart hook" : "doctor --fix missing from SessionStart",
+  });
+
+  const detected = detectInstalledTools();
+  if (detected.has("copilot")) {
+    const copilotHooks = path.join(os.homedir(), ".github", "hooks", "cortex.json");
+    checks.push({
+      name: "copilot-hooks",
+      ok: fs.existsSync(copilotHooks),
+      detail: fs.existsSync(copilotHooks) ? "copilot hooks config present" : "missing ~/.github/hooks/cortex.json",
+    });
+  }
+  if (detected.has("cursor")) {
+    const cursorHooks = path.join(os.homedir(), ".cursor", "hooks.json");
+    checks.push({
+      name: "cursor-hooks",
+      ok: fs.existsSync(cursorHooks),
+      detail: fs.existsSync(cursorHooks) ? "cursor hooks config present" : "missing ~/.cursor/hooks.json",
+    });
+  }
+  if (detected.has("codex")) {
+    const codexHooks = path.join(cortexPath, "codex.json");
+    checks.push({
+      name: "codex-hooks",
+      ok: fs.existsSync(codexHooks),
+      detail: fs.existsSync(codexHooks) ? "codex hooks config present" : "missing codex.json in cortex root",
+    });
+  }
+
+  if (fix && profile && profileFile) {
+    await runLink(cortexPath, { machine, profile });
+    checks.push({ name: "self-heal", ok: true, detail: "relinked hooks, symlinks, context, memory pointers" });
+  } else if (fix) {
+    checks.push({ name: "self-heal", ok: false, detail: "blocked: machine/profile not fully configured" });
+  } else {
+    const detectedTools = detectInstalledTools();
+    const hooked = configureAllHooks(cortexPath, detectedTools);
+    checks.push({
+      name: "hooks",
+      ok: hooked.length > 0 || detectedTools.size === 0,
+      detail: hooked.length ? `hook configs present for: ${hooked.join(", ")}` : "no external tools detected",
+    });
+  }
+
+  const ok = checks.every((c) => c.ok);
+  return { ok, machine, profile: profile || undefined, checks };
 }

--- a/mcp/src/memory-ui.ts
+++ b/mcp/src/memory-ui.ts
@@ -1,0 +1,261 @@
+import * as http from "http";
+import * as fs from "fs";
+import * as path from "path";
+import * as querystring from "querystring";
+import {
+  getProjectDirs,
+  addLearningToFile,
+  appendAuditLog,
+} from "./shared.js";
+
+interface QueueItem {
+  section: "Review" | "Stale" | "Conflicts";
+  line: string;
+  text: string;
+  date: string;
+}
+
+function queuePath(cortexPath: string, project: string): string {
+  return path.join(cortexPath, project, "MEMORY_QUEUE.md");
+}
+
+function parseQueueItems(cortexPath: string, project: string): QueueItem[] {
+  const file = queuePath(cortexPath, project);
+  if (!fs.existsSync(file)) return [];
+  const lines = fs.readFileSync(file, "utf8").split("\n");
+  let section: QueueItem["section"] = "Review";
+  const items: QueueItem[] = [];
+
+  for (const line of lines) {
+    if (line.trim() === "## Review") section = "Review";
+    if (line.trim() === "## Stale") section = "Stale";
+    if (line.trim() === "## Conflicts") section = "Conflicts";
+    if (!line.startsWith("- ")) continue;
+    const m = line.match(/^- \[(\d{4}-\d{2}-\d{2})\]\s*(.+)$/);
+    if (!m) continue;
+    items.push({
+      section,
+      line,
+      date: m[1],
+      text: m[2],
+    });
+  }
+
+  return items;
+}
+
+function rewriteQueue(cortexPath: string, project: string, items: QueueItem[]) {
+  const bySection: Record<QueueItem["section"], QueueItem[]> = {
+    Review: [],
+    Stale: [],
+    Conflicts: [],
+  };
+  for (const item of items) bySection[item.section].push(item);
+
+  const out: string[] = [`# ${project} Memory Queue`, "", "## Review", ""];
+  for (const item of bySection.Review) out.push(item.line);
+  out.push("", "## Stale", "");
+  for (const item of bySection.Stale) out.push(item.line);
+  out.push("", "## Conflicts", "");
+  for (const item of bySection.Conflicts) out.push(item.line);
+  out.push("");
+
+  fs.writeFileSync(queuePath(cortexPath, project), out.join("\n").replace(/\n{3,}/g, "\n\n"));
+}
+
+function recentUsage(cortexPath: string): string[] {
+  const usage = path.join(cortexPath, ".governance", "memory-usage.log");
+  if (!fs.existsSync(usage)) return [];
+  const lines = fs.readFileSync(usage, "utf8").trim().split("\n").filter(Boolean);
+  return lines.slice(-40).reverse();
+}
+
+function recentAccepted(cortexPath: string): string[] {
+  const audit = path.join(cortexPath, ".cortex-audit.log");
+  if (!fs.existsSync(audit)) return [];
+  const lines = fs.readFileSync(audit, "utf8").split("\n").filter((l) => l.includes("approve_memory"));
+  return lines.slice(-40).reverse();
+}
+
+function h(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderPage(cortexPath: string): string {
+  const projects = getProjectDirs(cortexPath).map((p) => path.basename(p)).filter((p) => p !== "global");
+  const usage = recentUsage(cortexPath);
+  const accepted = recentAccepted(cortexPath);
+  const rows: string[] = [];
+
+  for (const project of projects) {
+    const items = parseQueueItems(cortexPath, project);
+    if (!items.length) continue;
+    for (const item of items) {
+      rows.push(`
+        <tr>
+          <td>${h(project)}</td>
+          <td>${h(item.section)}</td>
+          <td>${h(item.date)}</td>
+          <td>${h(item.text)}</td>
+          <td class="actions">
+            <form method="POST" action="/approve">
+              <input type="hidden" name="project" value="${h(project)}" />
+              <input type="hidden" name="line" value="${h(item.line)}" />
+              <button type="submit">Approve</button>
+            </form>
+            <form method="POST" action="/reject">
+              <input type="hidden" name="project" value="${h(project)}" />
+              <input type="hidden" name="line" value="${h(item.line)}" />
+              <button type="submit">Reject</button>
+            </form>
+            <form method="POST" action="/edit">
+              <input type="hidden" name="project" value="${h(project)}" />
+              <input type="hidden" name="line" value="${h(item.line)}" />
+              <input type="text" name="new_text" value="${h(item.text)}" />
+              <button type="submit">Edit</button>
+            </form>
+          </td>
+        </tr>
+      `);
+    }
+  }
+
+  const acceptedItems = accepted.map((l) => `<li>${h(l)}</li>`).join("\n");
+  const usageItems = usage.map((l) => `<li>${h(l)}</li>`).join("\n");
+
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Cortex Memory UI</title>
+  <style>
+    :root {
+      --bg: #f4efe6;
+      --ink: #1f2937;
+      --muted: #6b7280;
+      --accent: #0f766e;
+      --line: #d6d3d1;
+    }
+    body { font-family: "IBM Plex Sans", "Segoe UI", sans-serif; background: linear-gradient(135deg,#f4efe6,#eaf5f2); color: var(--ink); margin: 0; padding: 24px; }
+    h1 { margin: 0 0 12px 0; font-size: 30px; }
+    .subtitle { color: var(--muted); margin-bottom: 16px; }
+    table { width: 100%; border-collapse: collapse; background: white; border: 1px solid var(--line); }
+    th, td { border-bottom: 1px solid var(--line); padding: 10px; vertical-align: top; text-align: left; }
+    th { background: #fafaf9; font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+    .actions { display: grid; gap: 6px; min-width: 280px; }
+    .actions form { display: flex; gap: 6px; margin: 0; }
+    .actions input[type="text"] { flex: 1; }
+    button { border: 1px solid var(--accent); background: var(--accent); color: white; padding: 5px 10px; cursor: pointer; }
+    button:hover { filter: brightness(0.95); }
+    .panes { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 20px; }
+    .card { background: white; border: 1px solid var(--line); padding: 12px; }
+    .card h2 { margin: 0 0 8px 0; font-size: 16px; }
+    .card ul { margin: 0; padding-left: 18px; max-height: 240px; overflow: auto; }
+    @media (max-width: 900px) { .panes { grid-template-columns: 1fr; } .actions { min-width: 0; } }
+  </style>
+</head>
+<body>
+  <h1>Cortex Memory Review</h1>
+  <div class="subtitle">Markdown is source-of-truth. Approve/reject/edit updates queue + learnings directly.</div>
+  <table>
+    <thead>
+      <tr><th>Project</th><th>Status</th><th>Date</th><th>Memory</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+      ${rows.join("\n") || `<tr><td colspan="5">No queued items.</td></tr>`}
+    </tbody>
+  </table>
+
+  <div class="panes">
+    <div class="card">
+      <h2>Accepted</h2>
+      <ul>${acceptedItems || "<li>None yet.</li>"}</ul>
+    </div>
+    <div class="card">
+      <h2>Recently Used</h2>
+      <ul>${usageItems || "<li>No usage events yet.</li>"}</ul>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function removeLine(cortexPath: string, project: string, line: string): boolean {
+  const items = parseQueueItems(cortexPath, project);
+  const idx = items.findIndex((i) => i.line === line);
+  if (idx === -1) return false;
+  items.splice(idx, 1);
+  rewriteQueue(cortexPath, project, items);
+  return true;
+}
+
+function editLine(cortexPath: string, project: string, line: string, newText: string): boolean {
+  const items = parseQueueItems(cortexPath, project);
+  const idx = items.findIndex((i) => i.line === line);
+  if (idx === -1) return false;
+  const date = items[idx].date;
+  items[idx].text = newText.trim();
+  items[idx].line = `- [${date}] ${items[idx].text}`;
+  rewriteQueue(cortexPath, project, items);
+  return true;
+}
+
+export async function startMemoryUi(cortexPath: string, port: number): Promise<void> {
+  const server = http.createServer(async (req, res) => {
+    const url = req.url || "/";
+    if (req.method === "GET" && url === "/") {
+      const html = renderPage(cortexPath);
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end(html);
+      return;
+    }
+
+    if (req.method === "POST" && ["/approve", "/reject", "/edit"].includes(url)) {
+      let body = "";
+      req.on("data", (chunk) => { body += String(chunk); });
+      req.on("end", () => {
+        const parsed = querystring.parse(body);
+        const project = String(parsed.project || "");
+        const line = String(parsed.line || "");
+        const newText = String(parsed.new_text || "");
+        if (!project || !line) {
+          res.writeHead(400, { "content-type": "text/plain" });
+          res.end("Missing project/line");
+          return;
+        }
+
+        if (url === "/approve") {
+          const m = line.match(/^- \[\d{4}-\d{2}-\d{2}\]\s*(.+)$/);
+          const text = m ? m[1] : line.replace(/^- /, "");
+          addLearningToFile(cortexPath, project, text);
+          removeLine(cortexPath, project, line);
+          appendAuditLog(cortexPath, "approve_memory", `project=${project} memory=${JSON.stringify(text)}`);
+        } else if (url === "/reject") {
+          removeLine(cortexPath, project, line);
+          appendAuditLog(cortexPath, "reject_memory", `project=${project} memory=${JSON.stringify(line)}`);
+        } else if (url === "/edit") {
+          editLine(cortexPath, project, line, newText);
+          appendAuditLog(cortexPath, "edit_memory", `project=${project} old=${JSON.stringify(line)} new=${JSON.stringify(newText)}`);
+        }
+
+        res.writeHead(302, { location: "/" });
+        res.end();
+      });
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("Not found");
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, "127.0.0.1", () => resolve());
+  });
+  process.stdout.write(`cortex memory-ui running at http://127.0.0.1:${port}\n`);
+  await new Promise<void>(() => { /* keep alive */ });
+}

--- a/mcp/src/shared.ts
+++ b/mcp/src/shared.ts
@@ -22,6 +22,409 @@ export function debugLog(msg: string): void {
   } catch { /* best effort */ }
 }
 
+type MemoryRole = "admin" | "maintainer" | "contributor" | "viewer";
+type MemoryAction = "read" | "write" | "queue" | "pin" | "policy" | "delete";
+
+interface AccessControl {
+  admins?: string[];
+  maintainers?: string[];
+  contributors?: string[];
+  viewers?: string[];
+}
+
+export interface AccessControlPatch {
+  admins?: string[];
+  maintainers?: string[];
+  contributors?: string[];
+  viewers?: string[];
+}
+
+export interface MemoryPolicy {
+  ttlDays: number;
+  retentionDays: number;
+  autoAcceptThreshold: number;
+  minInjectConfidence: number;
+  decay: {
+    d30: number;
+    d60: number;
+    d90: number;
+    d120: number;
+  };
+}
+
+export interface MemoryScore {
+  impressions: number;
+  helpful: number;
+  repromptPenalty: number;
+  regressionPenalty: number;
+  lastUsedAt: string;
+}
+
+interface CanonicalLock {
+  hash: string;
+  snapshot: string;
+  updatedAt: string;
+}
+
+const DEFAULT_POLICY: MemoryPolicy = {
+  ttlDays: 120,
+  retentionDays: 365,
+  autoAcceptThreshold: 0.75,
+  minInjectConfidence: 0.35,
+  decay: {
+    d30: 1.0,
+    d60: 0.85,
+    d90: 0.65,
+    d120: 0.45,
+  },
+};
+
+const DEFAULT_ACCESS: AccessControl = {
+  admins: [],
+  maintainers: [],
+  contributors: [],
+  viewers: [],
+};
+
+function governanceDir(cortexPath: string): string {
+  return path.join(cortexPath, ".governance");
+}
+
+function readJsonFile<T>(filePath: string, fallback: T): T {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJsonFile(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+}
+
+function actorName(): string {
+  const envActor = process.env.CORTEX_ACTOR || process.env.USER || process.env.USERNAME;
+  if (envActor) return envActor;
+  try {
+    return os.userInfo().username;
+  } catch {
+    return "unknown";
+  }
+}
+
+function accessFile(cortexPath: string): string {
+  return path.join(governanceDir(cortexPath), "access-control.json");
+}
+
+function policyFile(cortexPath: string): string {
+  return path.join(governanceDir(cortexPath), "memory-policy.json");
+}
+
+function scoreFile(cortexPath: string): string {
+  return path.join(governanceDir(cortexPath), "memory-scores.json");
+}
+
+function usageLogFile(cortexPath: string): string {
+  return path.join(governanceDir(cortexPath), "memory-usage.log");
+}
+
+function lockFile(cortexPath: string): string {
+  return path.join(governanceDir(cortexPath), "canonical-locks.json");
+}
+
+function resolveRole(cortexPath: string, actor: string = actorName()): MemoryRole {
+  const acl = readJsonFile<AccessControl>(accessFile(cortexPath), DEFAULT_ACCESS);
+  if ((acl.admins || []).includes(actor)) return "admin";
+  if ((acl.maintainers || []).includes(actor)) return "maintainer";
+  if ((acl.contributors || []).includes(actor)) return "contributor";
+  if ((acl.viewers || []).includes(actor)) return "viewer";
+  // Default to least privilege when actor is unknown.
+  return "viewer";
+}
+
+export function getAccessControl(cortexPath: string): AccessControl {
+  return readJsonFile<AccessControl>(accessFile(cortexPath), DEFAULT_ACCESS);
+}
+
+export function updateAccessControl(cortexPath: string, patch: AccessControlPatch): AccessControl | string {
+  const denial = checkMemoryPermission(cortexPath, "policy");
+  if (denial) return denial;
+  const current = getAccessControl(cortexPath);
+  const next: AccessControl = {
+    admins: patch.admins ?? current.admins ?? [],
+    maintainers: patch.maintainers ?? current.maintainers ?? [],
+    contributors: patch.contributors ?? current.contributors ?? [],
+    viewers: patch.viewers ?? current.viewers ?? [],
+  };
+  writeJsonFile(accessFile(cortexPath), next);
+  appendAuditLog(cortexPath, "update_access", JSON.stringify(next));
+  return next;
+}
+
+function can(role: MemoryRole, action: MemoryAction): boolean {
+  if (role === "admin") return true;
+  if (role === "maintainer") return action !== "policy";
+  if (role === "contributor") return action === "read" || action === "write" || action === "queue";
+  return action === "read";
+}
+
+export function checkMemoryPermission(cortexPath: string, action: MemoryAction, actor?: string): string | null {
+  const role = resolveRole(cortexPath, actor);
+  if (can(role, action)) return null;
+  return `Permission denied for ${actor || actorName()} (role=${role}) on action=${action}.`;
+}
+
+export function getMemoryPolicy(cortexPath: string): MemoryPolicy {
+  const parsed = readJsonFile<Partial<MemoryPolicy>>(policyFile(cortexPath), {});
+  return {
+    ttlDays: parsed.ttlDays ?? DEFAULT_POLICY.ttlDays,
+    retentionDays: parsed.retentionDays ?? DEFAULT_POLICY.retentionDays,
+    autoAcceptThreshold: parsed.autoAcceptThreshold ?? DEFAULT_POLICY.autoAcceptThreshold,
+    minInjectConfidence: parsed.minInjectConfidence ?? DEFAULT_POLICY.minInjectConfidence,
+    decay: {
+      d30: parsed.decay?.d30 ?? DEFAULT_POLICY.decay.d30,
+      d60: parsed.decay?.d60 ?? DEFAULT_POLICY.decay.d60,
+      d90: parsed.decay?.d90 ?? DEFAULT_POLICY.decay.d90,
+      d120: parsed.decay?.d120 ?? DEFAULT_POLICY.decay.d120,
+    },
+  };
+}
+
+export function updateMemoryPolicy(cortexPath: string, patch: Partial<MemoryPolicy>): MemoryPolicy | string {
+  const denial = checkMemoryPermission(cortexPath, "policy");
+  if (denial) return denial;
+  const current = getMemoryPolicy(cortexPath);
+  const next: MemoryPolicy = {
+    ...current,
+    ...patch,
+    decay: {
+      ...current.decay,
+      ...(patch.decay || {}),
+    },
+  };
+  writeJsonFile(policyFile(cortexPath), next);
+  appendAuditLog(cortexPath, "update_policy", JSON.stringify(next));
+  return next;
+}
+
+function loadMemoryScores(cortexPath: string): Record<string, MemoryScore> {
+  return readJsonFile<Record<string, MemoryScore>>(scoreFile(cortexPath), {});
+}
+
+function loadCanonicalLocks(cortexPath: string): Record<string, CanonicalLock> {
+  return readJsonFile<Record<string, CanonicalLock>>(lockFile(cortexPath), {});
+}
+
+function saveCanonicalLocks(cortexPath: string, locks: Record<string, CanonicalLock>) {
+  writeJsonFile(lockFile(cortexPath), locks);
+}
+
+function hashContent(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function saveMemoryScores(cortexPath: string, scores: Record<string, MemoryScore>) {
+  writeJsonFile(scoreFile(cortexPath), scores);
+}
+
+function ensureScoreEntry(scores: Record<string, MemoryScore>, key: string): MemoryScore {
+  if (!scores[key]) {
+    scores[key] = {
+      impressions: 0,
+      helpful: 0,
+      repromptPenalty: 0,
+      regressionPenalty: 0,
+      lastUsedAt: new Date(0).toISOString(),
+    };
+  }
+  return scores[key];
+}
+
+export function memoryScoreKey(project: string, filename: string, snippet: string): string {
+  const short = snippet.replace(/\s+/g, " ").slice(0, 200);
+  const digest = crypto.createHash("sha1").update(`${project}:${filename}:${short}`).digest("hex").slice(0, 12);
+  return `${project}/${filename}:${digest}`;
+}
+
+export function recordMemoryInjection(cortexPath: string, key: string, sessionId?: string): void {
+  const scores = loadMemoryScores(cortexPath);
+  const entry = ensureScoreEntry(scores, key);
+  entry.impressions += 1;
+  entry.lastUsedAt = new Date().toISOString();
+  saveMemoryScores(cortexPath, scores);
+  const session = sessionId || "none";
+  fs.mkdirSync(path.dirname(usageLogFile(cortexPath)), { recursive: true });
+  fs.appendFileSync(
+    usageLogFile(cortexPath),
+    `${new Date().toISOString()}\tinject\t${session}\t${key}\n`
+  );
+}
+
+export function recordMemoryFeedback(
+  cortexPath: string,
+  key: string,
+  feedback: "helpful" | "reprompt" | "regression"
+): void {
+  const scores = loadMemoryScores(cortexPath);
+  const entry = ensureScoreEntry(scores, key);
+  if (feedback === "helpful") entry.helpful += 1;
+  if (feedback === "reprompt") entry.repromptPenalty += 1;
+  if (feedback === "regression") entry.regressionPenalty += 1;
+  saveMemoryScores(cortexPath, scores);
+  appendAuditLog(cortexPath, "memory_feedback", `key=${key} feedback=${feedback}`);
+}
+
+export function getMemoryQualityMultiplier(cortexPath: string, key: string): number {
+  const scores = loadMemoryScores(cortexPath);
+  const entry = scores[key];
+  if (!entry) return 1;
+  const helpful = entry.helpful;
+  const penalties = entry.repromptPenalty + entry.regressionPenalty * 2;
+  const raw = 1 + helpful * 0.15 - penalties * 0.2;
+  return Math.max(0.2, Math.min(1.5, raw));
+}
+
+export function pruneDeadMemories(cortexPath: string, project?: string): string {
+  const denial = checkMemoryPermission(cortexPath, "delete");
+  if (denial) return denial;
+  const policy = getMemoryPolicy(cortexPath);
+  const dirs = project
+    ? [path.join(cortexPath, project)]
+    : getProjectDirs(cortexPath).filter((d) => path.basename(d) !== "global");
+  let pruned = 0;
+  const cutoffDays = policy.retentionDays;
+
+  for (const dir of dirs) {
+    const file = path.join(dir, "LEARNINGS.md");
+    if (!fs.existsSync(file)) continue;
+    const content = fs.readFileSync(file, "utf8");
+    const lines = content.split("\n");
+    let currentDate: string | null = null;
+    const next: string[] = [];
+    let inDetails = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.includes("<details>")) { inDetails = true; next.push(line); continue; }
+      if (line.includes("</details>")) { inDetails = false; next.push(line); continue; }
+      const m = line.match(/^## (\d{4}-\d{2}-\d{2})$/);
+      if (m) {
+        currentDate = m[1];
+        next.push(line);
+        continue;
+      }
+      if (line.startsWith("- ") && !inDetails && currentDate) {
+        const age = Math.floor((Date.now() - Date.parse(`${currentDate}T00:00:00Z`)) / 86400000);
+        if (!Number.isNaN(age) && age > cutoffDays) {
+          pruned++;
+          // Also drop citation line directly attached to this bullet.
+          const nextLine = lines[i + 1] || "";
+          if (nextLine.match(/^\s*<!--\s*cortex:cite\s+\{.*\}\s*-->\s*$/)) {
+            i++;
+          }
+          continue;
+        }
+      }
+      // Drop dangling citation comments with no preceding bullet in the kept output.
+      if (line.match(/^\s*<!--\s*cortex:cite\s+\{.*\}\s*-->\s*$/)) {
+        const prev = next.length ? next[next.length - 1] : "";
+        if (!prev.startsWith("- ")) continue;
+      }
+      next.push(line);
+    }
+    fs.writeFileSync(file, next.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n");
+  }
+
+  appendAuditLog(cortexPath, "prune_memories", `project=${project || "all"} pruned=${pruned}`);
+  return `Pruned ${pruned} stale memory entr${pruned === 1 ? "y" : "ies"}.`;
+}
+
+export function enforceCanonicalLocks(cortexPath: string, project?: string): string {
+  const locks = loadCanonicalLocks(cortexPath);
+  const projects = project
+    ? [project]
+    : getProjectDirs(cortexPath).map((d) => path.basename(d)).filter((p) => p !== "global");
+  let restored = 0;
+  let checked = 0;
+
+  for (const p of projects) {
+    const file = path.join(cortexPath, p, "CANONICAL_MEMORIES.md");
+    if (!fs.existsSync(file)) continue;
+    checked++;
+    const content = fs.readFileSync(file, "utf8");
+    const key = `${p}/CANONICAL_MEMORIES.md`;
+    const lock = locks[key];
+    if (!lock) {
+      locks[key] = { hash: hashContent(content), snapshot: content, updatedAt: new Date().toISOString() };
+      continue;
+    }
+    const currentHash = hashContent(content);
+    if (currentHash === lock.hash) continue;
+    fs.writeFileSync(file, lock.snapshot);
+    appendMemoryQueue(cortexPath, p, "Conflicts", ["Canonical memory drift detected and auto-restored"]);
+    appendAuditLog(cortexPath, "canonical_restore", `project=${p}`);
+    restored++;
+  }
+
+  saveCanonicalLocks(cortexPath, locks);
+  return `Canonical locks checked=${checked}, restored=${restored}`;
+}
+
+export function consolidateProjectLearnings(cortexPath: string, project: string): string {
+  const denial = checkMemoryPermission(cortexPath, "delete");
+  if (denial) return denial;
+  if (!isValidProjectName(project)) return `Invalid project name: "${project}".`;
+  const file = path.join(cortexPath, project, "LEARNINGS.md");
+  if (!fs.existsSync(file)) return `No LEARNINGS.md found for "${project}".`;
+
+  const raw = fs.readFileSync(file, "utf8");
+  const lines = raw.split("\n");
+  const byDate = new Map<string, Map<string, { bullet: string; citation?: string }>>();
+  let currentDate: string | null = null;
+  const title = lines.find((l) => l.startsWith("# ")) || `# ${project} LEARNINGS`;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const heading = line.match(/^## (\d{4}-\d{2}-\d{2})$/);
+    if (heading) {
+      currentDate = heading[1];
+      if (!byDate.has(currentDate)) byDate.set(currentDate, new Map());
+      continue;
+    }
+    if (line.startsWith("- ") && currentDate) {
+      const key = line.trim().toLowerCase();
+      const nextLine = lines[i + 1] || "";
+      const citation = nextLine.match(/^\s*<!--\s*cortex:cite\s+\{.*\}\s*-->\s*$/) ? nextLine : undefined;
+      const existing = byDate.get(currentDate)!.get(key);
+      if (!existing) {
+        byDate.get(currentDate)!.set(key, { bullet: line, citation });
+      } else if (!existing.citation && citation) {
+        existing.citation = citation;
+      }
+      if (citation) i++;
+    }
+  }
+
+  const dates = [...byDate.keys()].sort().reverse();
+  const out: string[] = [title, ""];
+  for (const d of dates) {
+    const items = [...(byDate.get(d)?.values() || [])];
+    if (!items.length) continue;
+    out.push(`## ${d}`, "");
+    for (const item of items) {
+      out.push(item.bullet);
+      if (item.citation) out.push(item.citation);
+    }
+    out.push("");
+  }
+  fs.writeFileSync(file, out.join("\n").trimEnd() + "\n");
+  appendAuditLog(cortexPath, "consolidate_project", `project=${project} dates=${dates.length}`);
+  return `Consolidated learnings for ${project}.`;
+}
+
 // Validate that a path is a safe, existing directory
 function requireDirectory(resolved: string, label: string): string {
   if (!fs.existsSync(resolved)) {
@@ -75,7 +478,7 @@ export function getProjectDirs(cortexPath: string, profile?: string): string[] {
       const data = yaml.load(fs.readFileSync(profilePath, "utf-8")) as Record<string, unknown>;
       const projects = data?.projects;
       if (Array.isArray(projects)) {
-        return projects
+        const listed = projects
           .map((p: unknown) => {
             const name = String(p);
             if (!isValidProjectName(name)) {
@@ -85,6 +488,13 @@ export function getProjectDirs(cortexPath: string, profile?: string): string[] {
             return safeProjectPath(cortexPath, name);
           })
           .filter((p): p is string => p !== null && fs.existsSync(p));
+
+        // Shared spaces are always visible when present.
+        const sharedDirs = ["shared", "org"]
+          .map((name) => safeProjectPath(cortexPath, name))
+          .filter((p): p is string => Boolean(p && fs.existsSync(p) && fs.statSync(p).isDirectory()));
+
+        return [...new Set([...listed, ...sharedDirs])];
       }
     }
   }
@@ -102,6 +512,8 @@ const FILE_TYPE_MAP: Record<string, string> = {
   "knowledge.md": "knowledge",
   "backlog.md": "backlog",
   "changelog.md": "changelog",
+  "canonical_memories.md": "canonical",
+  "memory_queue.md": "memory-queue",
 };
 
 function classifyFile(filename: string, relPath: string): string {
@@ -321,6 +733,26 @@ export interface ConsolidationNeeded {
   entriesSince: number;
   daysSince: number | null;
   lastConsolidated: string | null;
+}
+
+export interface LearningCitation {
+  created_at: string;
+  repo?: string;
+  file?: string;
+  line?: number;
+  commit?: string;
+}
+
+export interface LearningTrustIssue {
+  date: string;
+  bullet: string;
+  reason: "stale" | "invalid_citation";
+}
+
+export interface TrustFilterOptions {
+  ttlDays?: number;
+  minConfidence?: number;
+  decay?: Partial<MemoryPolicy["decay"]>;
 }
 
 // Check which projects have enough new learnings to warrant consolidation
@@ -582,8 +1014,356 @@ export function autoMergeConflicts(cortexPath: string): boolean {
   return allResolved;
 }
 
+function getHeadCommit(cwd: string): string | undefined {
+  const { execSync } = require("child_process") as typeof import("child_process");
+  try {
+    const commit = execSync("git rev-parse HEAD", { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    return commit || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getRepoRoot(cwd: string): string | undefined {
+  const { execSync } = require("child_process") as typeof import("child_process");
+  try {
+    const root = execSync("git rev-parse --show-toplevel", { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    return root || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function inferCitationLocation(repoPath: string, commit: string): { file?: string; line?: number } {
+  const { execFileSync } = require("child_process") as typeof import("child_process");
+  try {
+    const raw = execFileSync(
+      "git",
+      ["show", "--pretty=format:", "--unified=0", "--no-color", commit],
+      { cwd: repoPath, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+    );
+    let currentFile = "";
+    for (const line of raw.split("\n")) {
+      if (line.startsWith("+++ b/")) {
+        currentFile = line.slice(6).trim();
+        continue;
+      }
+      const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (hunk && currentFile) {
+        return { file: currentFile, line: Number.parseInt(hunk[1], 10) };
+      }
+    }
+  } catch {
+    // best effort
+  }
+  return {};
+}
+
+function buildCitationComment(citation: LearningCitation): string {
+  return `<!-- cortex:cite ${JSON.stringify(citation)} -->`;
+}
+
+function parseCitationComment(line: string): LearningCitation | null {
+  const match = line.match(/<!--\s*cortex:cite\s+(\{.*\})\s*-->/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1]) as LearningCitation;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (typeof parsed.created_at !== "string" || !parsed.created_at) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function resolveCitationFile(citation: LearningCitation): string | null {
+  if (!citation.file) return null;
+  if (path.isAbsolute(citation.file)) return citation.file;
+  if (citation.repo) return path.resolve(citation.repo, citation.file);
+  return path.resolve(citation.file);
+}
+
+function commitExists(repoPath: string, commit: string): boolean {
+  const { execFileSync } = require("child_process") as typeof import("child_process");
+  try {
+    execFileSync("git", ["cat-file", "-e", `${commit}^{commit}`], {
+      cwd: repoPath,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isCitationValid(citation: LearningCitation): boolean {
+  if (citation.repo && !fs.existsSync(citation.repo)) return false;
+  if (citation.commit && citation.repo && !commitExists(citation.repo, citation.commit)) return false;
+
+  const resolvedFile = resolveCitationFile(citation);
+  if (resolvedFile) {
+    if (!fs.existsSync(resolvedFile)) return false;
+    if (citation.line !== undefined) {
+      if (!Number.isInteger(citation.line) || citation.line < 1) return false;
+      const lineCount = fs.readFileSync(resolvedFile, "utf8").split("\n").length;
+      if (citation.line > lineCount) return false;
+      // Strong validation: if commit+repo are set, line blame must resolve to the cited commit.
+      if (citation.commit && citation.repo) {
+        const relFile = path.isAbsolute(resolvedFile)
+          ? path.relative(citation.repo, resolvedFile)
+          : resolvedFile;
+        const { execFileSync } = require("child_process") as typeof import("child_process");
+        try {
+          const out = execFileSync(
+            "git",
+            ["blame", "-L", `${citation.line},${citation.line}`, "--porcelain", relFile],
+            { cwd: citation.repo, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+          ).trim();
+          const first = out.split("\n")[0] || "";
+          if (!first.startsWith(citation.commit)) return false;
+        } catch {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+function parseLearningDateHeading(line: string): string | null {
+  const match = line.match(/^## (\d{4}-\d{2}-\d{2})$/);
+  return match ? match[1] : null;
+}
+
+function isDateStale(headingDate: string, ttlDays: number): boolean {
+  const ts = Date.parse(`${headingDate}T00:00:00Z`);
+  if (Number.isNaN(ts)) return false;
+  const ageDays = Math.floor((Date.now() - ts) / 86400000);
+  return ageDays > ttlDays;
+}
+
+function ageDaysForDate(headingDate: string): number | null {
+  const ts = Date.parse(`${headingDate}T00:00:00Z`);
+  if (Number.isNaN(ts)) return null;
+  return Math.floor((Date.now() - ts) / 86400000);
+}
+
+function confidenceForAge(ageDays: number, decay: MemoryPolicy["decay"]): number {
+  if (ageDays <= 30) return decay.d30;
+  if (ageDays <= 60) return decay.d60;
+  if (ageDays <= 90) return decay.d90;
+  return decay.d120;
+}
+
+// Keep only trustworthy learning bullets.
+// - Legacy bullets (no citation) are kept until they age out by date heading.
+// - Cited bullets are only kept if citation validates.
+export function filterTrustedLearnings(content: string, ttlDays: number): string {
+  return filterTrustedLearningsDetailed(content, { ttlDays }).content;
+}
+
+export function filterTrustedLearningsDetailed(content: string, opts: number | TrustFilterOptions): {
+  content: string;
+  issues: LearningTrustIssue[];
+} {
+  const options: TrustFilterOptions = typeof opts === "number" ? { ttlDays: opts } : opts;
+  const ttlDays = options.ttlDays ?? 120;
+  const minConfidence = options.minConfidence ?? 0.35;
+  const decay: MemoryPolicy["decay"] = {
+    ...DEFAULT_POLICY.decay,
+    ...(options.decay || {}),
+  };
+
+  const lines = content.split("\n");
+  const out: string[] = [];
+  const issues: LearningTrustIssue[] = [];
+  let currentDate: string | null = null;
+  let headingBuffer: string[] = [];
+  let inDetails = false;
+
+  const flushHeading = (hasEntries: boolean) => {
+    if (headingBuffer.length === 0) return;
+    if (hasEntries) {
+      out.push(...headingBuffer);
+      if (out.length > 0 && out[out.length - 1] !== "") out.push("");
+    }
+    headingBuffer = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.includes("<details>")) {
+      inDetails = true;
+      continue;
+    }
+    if (line.includes("</details>")) {
+      inDetails = false;
+      continue;
+    }
+    if (inDetails) continue;
+
+    const headingDate = parseLearningDateHeading(line);
+    if (headingDate) {
+      flushHeading(false);
+      currentDate = headingDate;
+      headingBuffer = [line];
+      continue;
+    }
+
+    if (line.startsWith("# ")) {
+      if (out.length === 0) out.push(line, "");
+      continue;
+    }
+
+    if (!line.startsWith("- ")) continue;
+
+    const stale = currentDate ? isDateStale(currentDate, ttlDays) : false;
+    if (stale) {
+      issues.push({ date: currentDate || "unknown", bullet: line, reason: "stale" });
+      continue;
+    }
+
+    let confidence = 1;
+    if (currentDate) {
+      const age = ageDaysForDate(currentDate);
+      if (age !== null) confidence *= confidenceForAge(age, decay);
+    }
+
+    const next = lines[i + 1] ?? "";
+    const citation = parseCitationComment(next);
+    if (citation && !isCitationValid(citation)) {
+      issues.push({ date: currentDate || "unknown", bullet: line, reason: "invalid_citation" });
+      continue;
+    }
+    if (!citation) confidence *= 0.8;
+    if (confidence < minConfidence) {
+      issues.push({ date: currentDate || "unknown", bullet: line, reason: "stale" });
+      continue;
+    }
+
+    flushHeading(true);
+    out.push(line);
+    if (citation) {
+      out.push(next);
+      i++;
+    }
+  }
+
+  return { content: out.join("\n").trim(), issues };
+}
+
+function normalizeBulletForQueue(line: string): string {
+  return line.startsWith("- ") ? line.slice(2).trim() : line.trim();
+}
+
+export function appendMemoryQueue(
+  cortexPath: string,
+  project: string,
+  section: "Review" | "Stale" | "Conflicts",
+  entries: string[]
+): number {
+  const denial = checkMemoryPermission(cortexPath, "queue");
+  if (denial) return 0;
+  if (!isValidProjectName(project)) return 0;
+  const resolvedDir = safeProjectPath(cortexPath, project);
+  if (!resolvedDir || !fs.existsSync(resolvedDir)) return 0;
+  const queuePath = path.join(resolvedDir, "MEMORY_QUEUE.md");
+  const today = new Date().toISOString().slice(0, 10);
+
+  const normalized = entries.map(normalizeBulletForQueue).filter(Boolean);
+  if (normalized.length === 0) return 0;
+
+  let content = "";
+  if (fs.existsSync(queuePath)) {
+    content = fs.readFileSync(queuePath, "utf8");
+  } else {
+    content = `# ${project} Memory Queue\n\n## Review\n\n## Stale\n\n## Conflicts\n`;
+  }
+
+  const lines = content.split("\n");
+  const secHeader = `## ${section}`;
+  let secIdx = lines.findIndex((l) => l.trim() === secHeader);
+  if (secIdx === -1) {
+    lines.push("", secHeader, "");
+    secIdx = lines.length - 2;
+  }
+
+  let insertAt = secIdx + 1;
+  while (insertAt < lines.length && !lines[insertAt].startsWith("## ")) insertAt++;
+
+  const existing = new Set(lines.map((l) => l.trim()));
+  const toInsert: string[] = [];
+  for (const entry of normalized) {
+    const line = `- [${today}] ${entry}`;
+    if (!existing.has(line)) toInsert.push(line);
+  }
+  if (!toInsert.length) return 0;
+
+  lines.splice(insertAt, 0, ...toInsert, "");
+  fs.writeFileSync(queuePath, lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n");
+  return toInsert.length;
+}
+
+export function appendAuditLog(cortexPath: string, event: string, details: string): void {
+  const logPath = path.join(cortexPath, ".cortex-audit.log");
+  const line = `[${new Date().toISOString()}] ${event} ${details}\n`;
+  try {
+    fs.appendFileSync(logPath, line);
+  } catch {
+    // best effort
+  }
+}
+
+export function upsertCanonicalMemory(cortexPath: string, project: string, memory: string): string {
+  const denial = checkMemoryPermission(cortexPath, "pin");
+  if (denial) return denial;
+  if (!isValidProjectName(project)) return `Invalid project name: "${project}".`;
+  const resolvedDir = safeProjectPath(cortexPath, project);
+  if (!resolvedDir || !fs.existsSync(resolvedDir)) return `Project "${project}" not found in cortex.`;
+  const canonicalPath = path.join(resolvedDir, "CANONICAL_MEMORIES.md");
+  const today = new Date().toISOString().slice(0, 10);
+  const bullet = memory.startsWith("- ") ? memory : `- ${memory}`;
+
+  if (!fs.existsSync(canonicalPath)) {
+    fs.writeFileSync(
+      canonicalPath,
+      `# ${project} Canonical Memories\n\n## Pinned\n\n${bullet} _(pinned ${today})_\n`
+    );
+  } else {
+    const content = fs.readFileSync(canonicalPath, "utf8");
+    const line = `${bullet} _(pinned ${today})_`;
+    if (!content.includes(bullet)) {
+      const updated = content.includes("## Pinned")
+        ? content.replace("## Pinned", `## Pinned\n\n${line}`)
+        : `${content.trimEnd()}\n\n## Pinned\n\n${line}\n`;
+      fs.writeFileSync(canonicalPath, updated.endsWith("\n") ? updated : updated + "\n");
+    }
+  }
+
+  const canonicalContent = fs.readFileSync(canonicalPath, "utf8");
+  const locks = loadCanonicalLocks(cortexPath);
+  const lockKey = `${project}/CANONICAL_MEMORIES.md`;
+  locks[lockKey] = {
+    hash: hashContent(canonicalContent),
+    snapshot: canonicalContent,
+    updatedAt: new Date().toISOString(),
+  };
+  saveCanonicalLocks(cortexPath, locks);
+  appendAuditLog(cortexPath, "pin_memory", `project=${project} memory=${JSON.stringify(memory)}`);
+  return `Pinned canonical memory in ${project}.`;
+}
+
 // Add a learning to a project's LEARNINGS.md
-export function addLearningToFile(cortexPath: string, project: string, learning: string): string {
+export function addLearningToFile(
+  cortexPath: string,
+  project: string,
+  learning: string,
+  citationInput?: Partial<LearningCitation>
+): string {
+  const denial = checkMemoryPermission(cortexPath, "write");
+  if (denial) return denial;
   if (!isValidProjectName(project)) return `Invalid project name: "${project}".`;
   const resolvedDir = safeProjectPath(cortexPath, project);
   if (!resolvedDir) return `Invalid project name: "${project}".`;
@@ -591,11 +1371,32 @@ export function addLearningToFile(cortexPath: string, project: string, learning:
 
   const today = new Date().toISOString().slice(0, 10);
   const bullet = learning.startsWith("- ") ? learning : `- ${learning}`;
+  const nowIso = new Date().toISOString();
+  const cwd = process.cwd();
+  const inferredRepo = getRepoRoot(cwd);
+  const citation: LearningCitation = {
+    created_at: nowIso,
+    repo: citationInput?.repo || inferredRepo,
+    file: citationInput?.file,
+    line: citationInput?.line,
+    commit: citationInput?.commit || (inferredRepo ? getHeadCommit(inferredRepo) : undefined),
+  };
+  if (citation.repo && citation.commit && (!citation.file || !citation.line)) {
+    const inferred = inferCitationLocation(citation.repo, citation.commit);
+    citation.file = citation.file || inferred.file;
+    citation.line = citation.line || inferred.line;
+  }
+  const citationComment = `  ${buildCitationComment(citation)}`;
 
   if (!fs.existsSync(learningsPath)) {
     if (!fs.existsSync(resolvedDir)) return `Project "${project}" not found in cortex.`;
-    const newContent = `# ${project} LEARNINGS\n\n## ${today}\n\n${bullet}\n`;
+    const newContent = `# ${project} LEARNINGS\n\n## ${today}\n\n${bullet}\n${citationComment}\n`;
     fs.writeFileSync(learningsPath, newContent);
+    appendAuditLog(
+      cortexPath,
+      "add_learning",
+      `project=${project} created=true citation_commit=${citation.commit ?? "none"} citation_file=${citation.file ?? "none"}`
+    );
     return `Created LEARNINGS.md for "${project}" and added insight.`;
   }
 
@@ -610,17 +1411,22 @@ export function addLearningToFile(cortexPath: string, project: string, learning:
   const todayHeader = `## ${today}`;
 
   if (content.includes(todayHeader)) {
-    const updated = content.replace(todayHeader, `${todayHeader}\n\n${bullet}`);
+    const updated = content.replace(todayHeader, `${todayHeader}\n\n${bullet}\n${citationComment}`);
     fs.writeFileSync(learningsPath, updated);
   } else {
     const firstHeading = content.match(/^(## \d{4}-\d{2}-\d{2})/m);
     if (firstHeading) {
-      const updated = content.replace(firstHeading[0], `${todayHeader}\n\n${bullet}\n\n${firstHeading[0]}`);
+      const updated = content.replace(firstHeading[0], `${todayHeader}\n\n${bullet}\n${citationComment}\n\n${firstHeading[0]}`);
       fs.writeFileSync(learningsPath, updated);
     } else {
-      fs.writeFileSync(learningsPath, content.trimEnd() + `\n\n## ${today}\n\n${bullet}\n`);
+      fs.writeFileSync(learningsPath, content.trimEnd() + `\n\n## ${today}\n\n${bullet}\n${citationComment}\n`);
     }
   }
 
-  return `Added learning to ${project}: ${bullet}`;
+  appendAuditLog(
+    cortexPath,
+    "add_learning",
+    `project=${project} citation_commit=${citation.commit ?? "none"} citation_file=${citation.file ?? "none"}`
+  );
+  return `Added learning to ${project}: ${bullet} (with citation metadata)`;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaarab/cortex",
-  "version": "1.7.5",
+  "version": "1.8.4",
   "description": "Long-term memory for Claude Code",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- ship the full session work on a dedicated branch (no main changes)
- add memory governance pipeline updates, trust filtering, and quality feedback paths
- add MCP on/off mode controls via init/link and runtime toggle command
- add memory review UI and supporting tests/docs/changelog updates
- harden command execution in link setup paths and centralize governance bootstrap

## Notes
- branch: codex/mcp-hardening-pr
- this PR includes all modifications from the session