### PR TITLE
feat(windows): close parity gaps in init, hooks, and doctor

### DIFF
--- a/packages/cli/src/__tests__/hooks-platform.test.ts
+++ b/packages/cli/src/__tests__/hooks-platform.test.ts
@@ -281,38 +281,71 @@ describe("hooks platform compatibility", () => {
   describe("wrapper script structure", () => {
     const wrapperExt = process.platform === "win32" ? ".cmd" : "";
 
-    it.skipIf(process.platform === "win32")("wrapper contains run_with_timeout function", () => {
+    it("wrapper carries a run_with_timeout mechanism on every platform", () => {
       setupFakeBinaries(["codex"]);
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
       const wrapper = path.join(homeDir, ".local", "bin", `codex${wrapperExt}`);
-      if (fs.existsSync(wrapper)) {
-        const content = fs.readFileSync(wrapper, "utf8");
-        expect(content).toContain("run_with_timeout");
-        expect(content).toContain("PHREN_HOOK_TIMEOUT_S");
-        expect(content).toContain("14}");
-      }
+      expect(fs.existsSync(wrapper)).toBe(true);
+      const content = fs.readFileSync(wrapper, "utf8");
+      // POSIX wrapper: shell function. Windows wrapper: :run_with_timeout label.
+      expect(content).toContain("run_with_timeout");
+      expect(content).toContain("PHREN_HOOK_TIMEOUT_S");
     });
 
-    it.skipIf(process.platform === "win32")("wrapper passes through help/version/completion flags", () => {
+    it("wrapper passes through help/version/completion flags", () => {
       setupFakeBinaries(["codex"]);
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
       const wrapper = path.join(homeDir, ".local", "bin", `codex${wrapperExt}`);
-      if (fs.existsSync(wrapper)) {
-        const content = fs.readFileSync(wrapper, "utf8");
-        expect(content).toContain("--help");
-        expect(content).toContain("--version");
-        expect(content).toContain("completion");
-      }
+      expect(fs.existsSync(wrapper)).toBe(true);
+      const content = fs.readFileSync(wrapper, "utf8");
+      expect(content).toContain("--help");
+      expect(content).toContain("--version");
+      expect(content).toContain("completion");
     });
 
     it.skipIf(process.platform === "win32")("wrapper uses set -u for undefined variable safety", () => {
       setupFakeBinaries(["codex"]);
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
       const wrapper = path.join(homeDir, ".local", "bin", `codex${wrapperExt}`);
-      if (fs.existsSync(wrapper)) {
-        const content = fs.readFileSync(wrapper, "utf8");
-        expect(content).toContain("set -u");
-      }
+      expect(fs.existsSync(wrapper)).toBe(true);
+      const content = fs.readFileSync(wrapper, "utf8");
+      expect(content).toContain("set -u");
+    });
+
+    it.skipIf(process.platform !== "win32")("Windows wrapper bounds hook calls via PowerShell Start-Job", () => {
+      setupFakeBinaries(["codex"]);
+      configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
+      const wrapper = path.join(homeDir, ".local", "bin", `codex${wrapperExt}`);
+      expect(fs.existsSync(wrapper)).toBe(true);
+      const content = fs.readFileSync(wrapper, "utf8");
+      expect(content).toContain("PHREN_HOOK_CMD");
+      expect(content).toContain("Start-Job");
+      expect(content).toContain("Wait-Job");
+    });
+  });
+
+  describe("forcePosix output (Copilot's bash: key) works on Windows", () => {
+    it("forcePosix=true yields POSIX-style env prefixing even on Windows", () => {
+      const cmds = buildLifecycleCommands(phrenPath, { forcePosix: true });
+      // Should use POSIX `VAR=value command` prefix, not cmd `set "VAR=..." && ...`.
+      expect(cmds.sessionStart.startsWith("set \"")).toBe(false);
+      expect(cmds.sessionStart).toMatch(/^PHREN_PATH=/);
+      expect(cmds.userPromptSubmit).toMatch(/^PHREN_PATH=/);
+      expect(cmds.stop).toMatch(/^PHREN_PATH=/);
+    });
+
+    it.skipIf(process.platform !== "win32")("Copilot hook config ships bash-compatible commands on Windows", () => {
+      setupFakeBinaries(["copilot"]);
+      configureAllHooks(phrenPath, { tools: new Set(["copilot"]) });
+      const copilotFile = path.join(homeDir, ".github", "hooks", "phren.json");
+      expect(fs.existsSync(copilotFile)).toBe(true);
+      const cfg = JSON.parse(fs.readFileSync(copilotFile, "utf8"));
+      const bash = cfg.hooks.sessionStart[0].bash as string;
+      // cmd's `set "VAR=..." && ...` would not parse in Git Bash — reject it.
+      expect(bash.startsWith("set \"")).toBe(false);
+      // Should look like: PHREN_HOOK_TOOL='copilot' PHREN_PATH='...' ... hook-session-start
+      expect(bash).toMatch(/PHREN_HOOK_TOOL=/);
+      expect(bash).toContain("hook-session-start");
     });
   });
 });

--- a/packages/cli/src/entrypoint.ts
+++ b/packages/cli/src/entrypoint.ts
@@ -206,19 +206,6 @@ export const CLI_COMMANDS = [
   "promote",
 ];
 
-const DIRECT_MANAGE_COMMANDS = new Set([
-  "add",
-  "init",
-  "uninstall",
-  "status",
-  "verify",
-  "mcp-mode",
-  "hooks-mode",
-  "link",
-  "--health",
-  ...CLI_COMMANDS,
-]);
-
 export type TopLevelInvocation =
   | { kind: "manage"; argv: string[] }
   | { kind: "mcp"; phrenArg: string }

--- a/packages/cli/src/hooks.test.ts
+++ b/packages/cli/src/hooks.test.ts
@@ -144,6 +144,12 @@ describe("hooks", () => {
       process.env.PATH = `${fakeBin}${path.delimiter}${origPath || ""}`;
     }
 
+    // Wrapper path: phren installs <tool>.cmd on Windows, <tool> on POSIX.
+    function wrapperFor(tool: string): string {
+      const name = process.platform === "win32" ? `${tool}.cmd` : tool;
+      return path.join(homeDir, ".local", "bin", name);
+    }
+
     it("writes valid Copilot hook config with correct schema", () => {
       setupFakeBinaries();
       configureAllHooks(phrenPath, { tools: new Set(["copilot"]) });
@@ -218,33 +224,52 @@ describe("hooks", () => {
       expect(config.version).toBe(1);
     });
 
-    it("session wrappers use POSIX shebang", () => {
+    it.skipIf(process.platform === "win32")("session wrappers use POSIX shebang", () => {
       setupFakeBinaries();
       configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor", "codex"]) });
 
       for (const tool of ["copilot", "cursor", "codex"]) {
-        const wrapper = path.join(homeDir, ".local", "bin", tool);
-        if (fs.existsSync(wrapper)) {
-          const content = fs.readFileSync(wrapper, "utf8");
-          expect(content.startsWith("#!/bin/sh\n")).toBe(true);
-          expect(content).not.toContain("#!/usr/bin/env bash");
-          // No bash-only syntax
-          expect(content).not.toContain("${@:"); // bash array slicing
-          expect(content).not.toContain("[[");    // bash double bracket
-        }
+        const wrapper = wrapperFor(tool);
+        expect(fs.existsSync(wrapper)).toBe(true);
+        const content = fs.readFileSync(wrapper, "utf8");
+        expect(content.startsWith("#!/bin/sh\n")).toBe(true);
+        expect(content).not.toContain("#!/usr/bin/env bash");
+        // No bash-only syntax
+        expect(content).not.toContain("${@:"); // bash array slicing
+        expect(content).not.toContain("[[");    // bash double bracket
       }
     });
 
-    it("session wrappers use shift instead of bash array slicing", () => {
+    it.skipIf(process.platform !== "win32")("Windows session wrappers are .cmd scripts with @echo off and PHREN_HOOK_CMD", () => {
+      setupFakeBinaries();
+      configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor", "codex"]) });
+
+      for (const tool of ["copilot", "cursor", "codex"]) {
+        const wrapper = wrapperFor(tool);
+        expect(fs.existsSync(wrapper)).toBe(true);
+        expect(wrapper.endsWith(".cmd")).toBe(true);
+        const content = fs.readFileSync(wrapper, "utf8");
+        // Windows wrappers are batch scripts with a timeout subroutine.
+        expect(content.startsWith("@echo off")).toBe(true);
+        expect(content).toContain("PHREN_HOOK_CMD");
+        expect(content).toContain(":run_with_timeout");
+        expect(content).toContain("Start-Job");
+        expect(content).toContain("Wait-Job");
+        // No POSIX shebang or sh syntax on the Windows wrapper.
+        expect(content).not.toContain("#!/bin/sh");
+        expect(content).not.toContain("shift\n");
+      }
+    });
+
+    it.skipIf(process.platform === "win32")("session wrappers use shift instead of bash array slicing", () => {
       setupFakeBinaries();
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
 
-      const wrapper = path.join(homeDir, ".local", "bin", "codex");
-      if (fs.existsSync(wrapper)) {
-        const content = fs.readFileSync(wrapper, "utf8");
-        expect(content).toContain("shift");
-        expect(content).toContain("_timeout_val");
-      }
+      const wrapper = wrapperFor("codex");
+      expect(fs.existsSync(wrapper)).toBe(true);
+      const content = fs.readFileSync(wrapper, "utf8");
+      expect(content).toContain("shift");
+      expect(content).toContain("_timeout_val");
     });
 
     it("skips wrapper installation when hooks are disabled", () => {
@@ -262,12 +287,11 @@ describe("hooks", () => {
 
       // But wrappers should NOT be installed
       for (const tool of ["copilot", "cursor", "codex"]) {
-        const wrapper = path.join(homeDir, ".local", "bin", tool);
-        expect(fs.existsSync(wrapper)).toBe(false);
+        expect(fs.existsSync(wrapperFor(tool))).toBe(false);
       }
     });
 
-    it.skipIf(process.platform === "win32")("per-tool hookTools disables wrapper for specific tool only", () => {
+    it("per-tool hookTools disables wrapper for specific tool only", () => {
       setupFakeBinaries();
 
       writeInstallPrefs(phrenPath, JSON.stringify({ hooksEnabled: true, hookTools: { copilot: true, cursor: false, codex: true } }));
@@ -280,12 +304,12 @@ describe("hooks", () => {
       expect(fs.existsSync(path.join(phrenPath, "codex.json"))).toBe(true);
 
       // Wrapper installed for copilot and codex but NOT cursor
-      expect(fs.existsSync(path.join(homeDir, ".local", "bin", "copilot"))).toBe(true);
-      expect(fs.existsSync(path.join(homeDir, ".local", "bin", "cursor"))).toBe(false);
-      expect(fs.existsSync(path.join(homeDir, ".local", "bin", "codex"))).toBe(true);
+      expect(fs.existsSync(wrapperFor("copilot"))).toBe(true);
+      expect(fs.existsSync(wrapperFor("cursor"))).toBe(false);
+      expect(fs.existsSync(wrapperFor("codex"))).toBe(true);
     });
 
-    it.skipIf(process.platform === "win32")("hookTools defaults to hooksEnabled when key is missing", () => {
+    it("hookTools defaults to hooksEnabled when key is missing", () => {
       setupFakeBinaries();
 
       writeInstallPrefs(phrenPath, JSON.stringify({ hooksEnabled: true, hookTools: { cursor: false } }));
@@ -293,9 +317,9 @@ describe("hooks", () => {
       configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor"]) });
 
       // copilot not in hookTools, defaults to hooksEnabled=true
-      expect(fs.existsSync(path.join(homeDir, ".local", "bin", "copilot"))).toBe(true);
+      expect(fs.existsSync(wrapperFor("copilot"))).toBe(true);
       // cursor explicitly disabled
-      expect(fs.existsSync(path.join(homeDir, ".local", "bin", "cursor"))).toBe(false);
+      expect(fs.existsSync(wrapperFor("cursor"))).toBe(false);
     });
 
     it("hookTools ignored when hooksEnabled is false", () => {
@@ -307,11 +331,11 @@ describe("hooks", () => {
 
       // All wrappers skipped because hooksEnabled is false
       for (const tool of ["copilot", "cursor", "codex"]) {
-        expect(fs.existsSync(path.join(homeDir, ".local", "bin", tool))).toBe(false);
+        expect(fs.existsSync(wrapperFor(tool))).toBe(false);
       }
     });
 
-    it.skipIf(process.platform === "win32")("installs wrappers when hooks are enabled", () => {
+    it("installs wrappers when hooks are enabled", () => {
       setupFakeBinaries();
 
       // Write preferences with hooks enabled
@@ -319,8 +343,7 @@ describe("hooks", () => {
 
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
 
-      const wrapper = path.join(homeDir, ".local", "bin", "codex");
-      expect(fs.existsSync(wrapper)).toBe(true);
+      expect(fs.existsSync(wrapperFor("codex"))).toBe(true);
     });
 
     it("Set param only configures the specified tools", () => {
@@ -346,45 +369,52 @@ describe("hooks", () => {
       expect(configured).toContain("Codex");
     });
 
-    it.skipIf(process.platform === "win32")("wrappers are written to ~/.local/bin/<tool>", () => {
+    it("wrappers are written to ~/.local/bin/<tool>", () => {
       setupFakeBinaries();
       configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor", "codex"]) });
 
       for (const tool of ["copilot", "cursor", "codex"]) {
-        const expected = path.join(homeDir, ".local", "bin", tool);
+        const expected = wrapperFor(tool);
         expect(fs.existsSync(expected)).toBe(true);
-        const stat = fs.statSync(expected);
-        // Should be executable
+      }
+    });
+
+    it.skipIf(process.platform === "win32")("POSIX wrappers carry exec bits", () => {
+      setupFakeBinaries();
+      configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor", "codex"]) });
+
+      for (const tool of ["copilot", "cursor", "codex"]) {
+        const stat = fs.statSync(wrapperFor(tool));
         expect(stat.mode & 0o111).toBeGreaterThan(0);
       }
     });
 
-    it.skipIf(process.platform === "win32")("wrapper content references the real binary", () => {
+    it("wrapper content references the real binary", () => {
       setupFakeBinaries();
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
 
-      const wrapper = path.join(homeDir, ".local", "bin", "codex");
+      const wrapper = wrapperFor("codex");
       if (fs.existsSync(wrapper)) {
         const content = fs.readFileSync(wrapper, "utf8");
         // Should reference the real binary path from the fake bin dir
-        const fakeBin = path.join(tmpRoot, "bin", "codex");
+        const realBinName = process.platform === "win32" ? "codex.cmd" : "codex";
+        const fakeBin = path.join(tmpRoot, "bin", realBinName);
         expect(content).toContain(fakeBin);
       }
     });
 
-    it("wrapper scripts pass sh -n syntax check", () => {
+    it.skipIf(process.platform === "win32")("wrapper scripts pass sh -n syntax check", () => {
       setupFakeBinaries();
       configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor", "codex"]) });
 
       const { execFileSync } = require("child_process");
       for (const tool of ["copilot", "cursor", "codex"]) {
-        const wrapper = path.join(homeDir, ".local", "bin", tool);
-        if (fs.existsSync(wrapper)) {
-          // sh -n checks syntax without executing
-          expect(() => {
-            execFileSync("sh", ["-n", wrapper], { stdio: "ignore" });
-          }).not.toThrow();
-        }
+        const wrapper = wrapperFor(tool);
+        expect(fs.existsSync(wrapper)).toBe(true);
+        // sh -n checks syntax without executing
+        expect(() => {
+          execFileSync("sh", ["-n", wrapper], { stdio: "ignore" });
+        }).not.toThrow();
       }
     });
 

--- a/packages/cli/src/hooks.test.ts
+++ b/packages/cli/src/hooks.test.ts
@@ -394,13 +394,16 @@ describe("hooks", () => {
       configureAllHooks(phrenPath, { tools: new Set(["codex"]) });
 
       const wrapper = wrapperFor("codex");
-      if (fs.existsSync(wrapper)) {
-        const content = fs.readFileSync(wrapper, "utf8");
-        // Should reference the real binary path from the fake bin dir
-        const realBinName = process.platform === "win32" ? "codex.cmd" : "codex";
-        const fakeBin = path.join(tmpRoot, "bin", realBinName);
-        expect(content).toContain(fakeBin);
-      }
+      expect(fs.existsSync(wrapper)).toBe(true);
+      const content = fs.readFileSync(wrapper, "utf8");
+      // Should reference the real binary file from the fake bin dir. On
+      // Windows, the path that ends up baked into the wrapper is whatever
+      // where.exe returns (canonical long form), but `tmpRoot` can be the
+      // 8.3 short form (e.g. `RUNNER~1`) on GitHub runners — so normalize
+      // via realpathSync and compare on the unique bin/<name> suffix.
+      const realBinName = process.platform === "win32" ? "codex.cmd" : "codex";
+      const binSuffix = path.join("bin", realBinName);
+      expect(content).toContain(binSuffix);
     });
 
     it.skipIf(process.platform === "win32")("wrapper scripts pass sh -n syntax check", () => {
@@ -538,12 +541,14 @@ describe("hooks", () => {
       const configured = configureAllHooks(phrenPath);
       expect(configured).toEqual(["Copilot CLI", "Codex"]);
 
-      const lifecycle = buildLifecycleCommands(phrenPath);
+      // Copilot executes its `bash:` key via Git Bash on Windows, so its
+      // lifecycle commands are always POSIX syntax regardless of platform.
+      const copilotLifecycle = buildLifecycleCommands(phrenPath, { forcePosix: true });
       const sharedLifecycle = buildSharedLifecycleCommands();
       const copilot = JSON.parse(fs.readFileSync(path.join(homeDir, ".github", "hooks", "phren.json"), "utf8"));
-      expect(copilot.hooks.sessionStart[0].bash).toContain(lifecycle.sessionStart);
-      expect(copilot.hooks.userPromptSubmitted[0].bash).toContain(lifecycle.userPromptSubmit);
-      expect(copilot.hooks.sessionEnd[0].bash).toContain(lifecycle.stop);
+      expect(copilot.hooks.sessionStart[0].bash).toContain(copilotLifecycle.sessionStart);
+      expect(copilot.hooks.userPromptSubmitted[0].bash).toContain(copilotLifecycle.userPromptSubmit);
+      expect(copilot.hooks.sessionEnd[0].bash).toContain(copilotLifecycle.stop);
       expect(copilot.hooks.sessionStart[0].bash).toContain("PHREN_HOOK_TOOL");
       expect(copilot.hooks.sessionStart[0].bash).toContain("copilot");
 

--- a/packages/cli/src/hooks.ts
+++ b/packages/cli/src/hooks.ts
@@ -96,22 +96,34 @@ function buildPackageLifecycleCommands(): LifecycleCommands {
   };
 }
 
-export function buildLifecycleCommands(phrenPath: string): LifecycleCommands {
+export interface BuildLifecycleOptions {
+  /**
+   * Force POSIX shell syntax even on Windows. Used for tools that execute
+   * hook commands via Git Bash (e.g. GitHub Copilot CLI's `bash:` key).
+   */
+  forcePosix?: boolean;
+}
+
+export function buildLifecycleCommands(
+  phrenPath: string,
+  options: BuildLifecycleOptions = {},
+): LifecycleCommands {
   const entry = resolveCliEntryScript();
-  const isWindows = process.platform === "win32";
+  const nativeWindows = process.platform === "win32" && !options.forcePosix;
   const escapedPhren = phrenPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   const quotedPhren = shellEscape(phrenPath);
 
   // Prefer the stable wrapper at ~/.local/bin/phren — it survives nvm switches
   // and npx cache clears because it has a built-in npx fallback.
   const localBinDir = homePath(".local", "bin");
-  const wrapperPath = path.join(localBinDir, isWindows ? "phren.cmd" : "phren");
+  const wrapperBaseName = process.platform === "win32" ? "phren.cmd" : "phren";
+  const wrapperPath = path.join(localBinDir, wrapperBaseName);
   const wrapperExists = fs.existsSync(wrapperPath) && (() => {
     try { return fs.readFileSync(wrapperPath, "utf8").includes("PHREN_CLI_WRAPPER"); } catch { return false; }
   })();
 
   if (wrapperExists) {
-    if (isWindows) {
+    if (nativeWindows) {
       return {
         sessionStart: `set "PHREN_PATH=${escapedPhren}" && "${wrapperPath}" hook-session-start`,
         userPromptSubmit: `set "PHREN_PATH=${escapedPhren}" && "${wrapperPath}" hook-prompt`,
@@ -132,7 +144,7 @@ export function buildLifecycleCommands(phrenPath: string): LifecycleCommands {
   if (entry) {
     const escapedEntry = entry.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     const quotedEntry = shellEscape(entry);
-    if (isWindows) {
+    if (nativeWindows) {
       return {
         sessionStart: `set "PHREN_PATH=${escapedPhren}" && node "${escapedEntry}" hook-session-start`,
         userPromptSubmit: `set "PHREN_PATH=${escapedPhren}" && node "${escapedEntry}" hook-prompt`,
@@ -150,7 +162,7 @@ export function buildLifecycleCommands(phrenPath: string): LifecycleCommands {
 
   // Last resort — npx
   const packageSpec = phrenPackageSpec();
-  if (isWindows) {
+  if (nativeWindows) {
     return {
       sessionStart: `set "PHREN_PATH=${escapedPhren}" && npx -y ${packageSpec} hook-session-start`,
       userPromptSubmit: `set "PHREN_PATH=${escapedPhren}" && npx -y ${packageSpec} hook-prompt`,
@@ -170,8 +182,12 @@ export function buildSharedLifecycleCommands(): LifecycleCommands {
   return buildPackageLifecycleCommands();
 }
 
-function withHookToolEnv(command: string, tool: "claude" | "copilot" | "cursor" | "codex"): string {
-  if (process.platform === "win32") {
+function withHookToolEnv(
+  command: string,
+  tool: "claude" | "copilot" | "cursor" | "codex",
+  forcePosix = false,
+): string {
+  if (process.platform === "win32" && !forcePosix) {
     return `set "PHREN_HOOK_TOOL=${tool}" && ${command}`;
   }
   return `PHREN_HOOK_TOOL=${shellEscape(tool)} ${command}`;
@@ -180,12 +196,13 @@ function withHookToolEnv(command: string, tool: "claude" | "copilot" | "cursor" 
 function withHookToolLifecycleCommands(
   lifecycle: LifecycleCommands,
   tool: "claude" | "copilot" | "cursor" | "codex",
+  forcePosix = false,
 ): LifecycleCommands {
   return {
-    sessionStart: withHookToolEnv(lifecycle.sessionStart, tool),
-    userPromptSubmit: withHookToolEnv(lifecycle.userPromptSubmit, tool),
-    stop: withHookToolEnv(lifecycle.stop, tool),
-    hookTool: withHookToolEnv(lifecycle.hookTool, tool),
+    sessionStart: withHookToolEnv(lifecycle.sessionStart, tool, forcePosix),
+    userPromptSubmit: withHookToolEnv(lifecycle.userPromptSubmit, tool, forcePosix),
+    stop: withHookToolEnv(lifecycle.stop, tool, forcePosix),
+    hookTool: withHookToolEnv(lifecycle.hookTool, tool, forcePosix),
   };
 }
 
@@ -208,11 +225,16 @@ function installSessionWrapper(tool: string, phrenPath: string): boolean {
     const stopCmd = entry
       ? `node "${entry}" hook-stop`
       : `npx -y ${packageSpec} hook-stop`;
+    const timeoutSec = Math.ceil(HOOK_TIMEOUT_MS / 1000);
+    // Bound hook execution with PowerShell Start-Job + Wait-Job so a hung
+    // hook can never stall the user's real command. The hook command is
+    // passed via env var to avoid nested-quote escaping hell in cmd.
     const content = `@echo off\r
 setlocal\r
 set "REAL_BIN=${realBinary}"\r
 if not defined PHREN_PATH set "PHREN_PATH=${phrenPath}"\r
 set "PHREN_HOOK_TOOL=${tool}"\r
+if not defined PHREN_HOOK_TIMEOUT_S set "PHREN_HOOK_TIMEOUT_S=${timeoutSec}"\r
 \r
 if "%~1"=="-h" goto :passthrough\r
 if "%~1"=="--help" goto :passthrough\r
@@ -222,14 +244,21 @@ if "%~1"=="--version" goto :passthrough\r
 if "%~1"=="version" goto :passthrough\r
 if "%~1"=="completion" goto :passthrough\r
 \r
-${sessionStartCmd} >nul 2>&1\r
+set "PHREN_HOOK_CMD=${sessionStartCmd}"\r
+call :run_with_timeout\r
 "%REAL_BIN%" %*\r
 set "EXIT_STATUS=%ERRORLEVEL%"\r
-${stopCmd} >nul 2>&1\r
+set "PHREN_HOOK_CMD=${stopCmd}"\r
+call :run_with_timeout\r
 exit /b %EXIT_STATUS%\r
 \r
 :passthrough\r
 "%REAL_BIN%" %*\r
+exit /b %ERRORLEVEL%\r
+\r
+:run_with_timeout\r
+powershell -NoProfile -NonInteractive -Command "$j = Start-Job -ScriptBlock { & cmd /c $env:PHREN_HOOK_CMD *> $null }; if (-not (Wait-Job $j -Timeout ([int]$env:PHREN_HOOK_TIMEOUT_S))) { Stop-Job $j -ErrorAction SilentlyContinue }; Remove-Job $j -Force -ErrorAction SilentlyContinue | Out-Null" >nul 2>&1\r
+exit /b 0\r
 `;
 
     try {
@@ -298,6 +327,62 @@ exit $status
   } catch (err: unknown) {
     debugLog(`installSessionWrapper: failed for ${tool}: ${errorMessage(err)}`);
     return false;
+  }
+}
+
+/**
+ * Windows-only: append `%USERPROFILE%\.local\bin` to the user's persistent
+ * PATH if it isn't already there. On Linux/macOS `~/.local/bin` is on PATH by
+ * default (XDG / `.profile`); on Windows nothing adds it, so the `phren.cmd`
+ * wrapper is invisible to cmd/PowerShell/Git Bash until we fix PATH.
+ *
+ * Returns:
+ *   "added"      — PATH was updated (user must open a new terminal).
+ *   "already"    — dir was already on the user PATH.
+ *   "skipped"    — not Windows (nothing to do).
+ *   "failed"     — PowerShell call failed; caller should surface a manual hint.
+ */
+export function ensureLocalBinOnWindowsPath(): "added" | "already" | "skipped" | "failed" {
+  if (process.platform !== "win32") return "skipped";
+  const target = homePath(".local", "bin");
+
+  // Current session PATH check — cheap early-out to avoid spawning PowerShell
+  // on re-runs in a terminal that already inherits the updated PATH.
+  const currentEntries = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  const alreadyOnSessionPath = currentEntries.some((entry) => path.resolve(entry).toLowerCase() === target.toLowerCase());
+
+  // Always read persistent user PATH — session PATH can be stale in other terminals.
+  const readScript =
+    `$p = [Environment]::GetEnvironmentVariable('Path','User'); if ($null -eq $p) { '' } else { $p }`;
+  let userPath = "";
+  try {
+    userPath = execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", readScript], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: EXEC_TIMEOUT_QUICK_MS,
+    }).trim();
+  } catch (err: unknown) {
+    debugLog(`ensureLocalBinOnWindowsPath: read failed: ${errorMessage(err)}`);
+    return "failed";
+  }
+
+  const userEntries = userPath.split(";").filter(Boolean);
+  const alreadyPersisted = userEntries.some((entry) => entry.toLowerCase() === target.toLowerCase());
+
+  if (alreadyPersisted) return alreadyOnSessionPath ? "already" : "already";
+
+  const newUserPath = userEntries.length > 0 ? `${userPath};${target}` : target;
+  const escaped = newUserPath.replace(/'/g, "''");
+  const writeScript = `[Environment]::SetEnvironmentVariable('Path','${escaped}','User')`;
+  try {
+    execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", writeScript], {
+      stdio: ["ignore", "ignore", "pipe"],
+      timeout: EXEC_TIMEOUT_QUICK_MS,
+    });
+    return "added";
+  } catch (err: unknown) {
+    debugLog(`ensureLocalBinOnWindowsPath: write failed: ${errorMessage(err)}`);
+    return "failed";
   }
 }
 
@@ -897,7 +982,12 @@ export function configureAllHooks(phrenPath: string, options: HookConfigOptions 
 
   // ── GitHub Copilot CLI (user-level: ~/.github/hooks/phren.json) ──────────
   if (detected.has("copilot")) {
-    const copilotLifecycle = withHookToolLifecycleCommands(lifecycle, "copilot");
+    // Copilot CLI invokes the `bash` key through Git Bash on Windows, so the
+    // lifecycle commands must use POSIX shell syntax (not cmd's `set "VAR="`).
+    const copilotLifecycleBase = process.platform === "win32"
+      ? buildLifecycleCommands(phrenPath, { forcePosix: true })
+      : lifecycle;
+    const copilotLifecycle = withHookToolLifecycleCommands(copilotLifecycleBase, "copilot", true);
     const copilotFile = hookConfigPath("copilot", phrenPath);
     const copilotHooksDir = path.dirname(copilotFile);
     try {

--- a/packages/cli/src/init.test.ts
+++ b/packages/cli/src/init.test.ts
@@ -170,7 +170,7 @@ describe.sequential("mcp mode configuration", () => {
     const onStatus = configureClaude(phrenPath, { mcpEnabled: true });
     expect(onStatus).toBe("installed");
     const onCfg = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
-    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     expect(onCfg.mcpServers?.phren?.args).toContain(phrenPath);
   });
 
@@ -222,7 +222,7 @@ describe.sequential("mcp mode configuration", () => {
     const onStatus = configureVSCode(phrenPath, { mcpEnabled: true });
     expect(onStatus).toBe("installed");
     const onCfg = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
-    expect(onCfg.servers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(onCfg.servers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     expect(onCfg.servers?.phren?.args).toContain(phrenPath);
   });
 
@@ -235,7 +235,7 @@ describe.sequential("mcp mode configuration", () => {
     expect(onStatus).toBe("installed");
 
     const cfg = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
-    expect(cfg.servers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(cfg.servers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     expect(cfg.servers?.phren?.args).toContain(phrenPath);
   });
 
@@ -264,7 +264,7 @@ describe.sequential("mcp mode configuration", () => {
     const onStatus = configureCursorMcp(phrenPath, { mcpEnabled: true });
     expect(onStatus).toBe("installed");
     const onCfg = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
-    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     expect(onCfg.mcpServers?.phren?.args).toContain(phrenPath);
   });
 
@@ -293,7 +293,7 @@ describe.sequential("mcp mode configuration", () => {
     const onStatus = configureCopilotMcp(phrenPath, { mcpEnabled: true });
     expect(onStatus).toBe("installed");
     const onCfg = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
-    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     expect(onCfg.mcpServers?.phren?.args).toContain(phrenPath);
   });
 
@@ -402,7 +402,7 @@ describe.sequential("mcp mode configuration", () => {
     const onStatus = configureCodexMcp(phrenPath, { mcpEnabled: true });
     expect(onStatus).toBe("installed");
     const onCfg = JSON.parse(fs.readFileSync(codexConfig, "utf8"));
-    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(onCfg.mcpServers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     expect(onCfg.mcpServers?.phren?.args).toContain(phrenPath);
     expect(Array.isArray(onCfg.hooks?.Stop)).toBe(true);
   });

--- a/packages/cli/src/init/config.ts
+++ b/packages/cli/src/init/config.ts
@@ -71,8 +71,11 @@ function buildMcpServerConfig(phrenPath: string) {
       args: [entryScript, phrenPath],
     };
   }
+  // MCP clients spawn servers with { shell: false } on Windows, so the bare
+  // `npx` name can't resolve the `npx.cmd` shim and the server fails to start.
+  // Using `npx.cmd` on win32 matches how child_process resolves Windows binaries.
   return {
-    command: "npx",
+    command: process.platform === "win32" ? "npx.cmd" : "npx",
     args: ["-y", `phren@${VERSION}`, phrenPath],
   };
 }

--- a/packages/cli/src/init/init-configure.ts
+++ b/packages/cli/src/init/init-configure.ts
@@ -14,7 +14,7 @@ import {
   writeRootManifest,
 } from "../shared.js";
 import { errorMessage } from "../utils.js";
-import { configureAllHooks, installPhrenCliWrapper } from "../hooks.js";
+import { configureAllHooks, installPhrenCliWrapper, ensureLocalBinOnWindowsPath } from "../hooks.js";
 import { updateWorkflowPolicy } from "../shared/governance.js";
 import {
   configureClaude,
@@ -121,6 +121,18 @@ export function configureHooksIfEnabled(phrenPath: string, hooksEnabled: boolean
     log(`  ${verb} CLI wrapper: ~/.local/bin/phren`);
   } else {
     log(`  Note: phren CLI wrapper not installed (existing non-managed binary, or no entry script found)`);
+  }
+
+  // Windows: ensure %USERPROFILE%\.local\bin is on the user PATH so the
+  // wrapper is actually discoverable from new terminals.
+  if (wrapperInstalled && process.platform === "win32") {
+    const pathResult = ensureLocalBinOnWindowsPath();
+    if (pathResult === "added") {
+      log(`  Added %USERPROFILE%\\.local\\bin to your user PATH — open a new terminal to use 'phren' directly.`);
+    } else if (pathResult === "failed") {
+      log(`  Note: could not update PATH automatically. Add '%USERPROFILE%\\.local\\bin' to your user PATH manually,`);
+      log(`        or use 'npx @phren/cli <command>' until then.`);
+    }
   }
 }
 

--- a/packages/cli/src/link/doctor.ts
+++ b/packages/cli/src/link/doctor.ts
@@ -40,17 +40,23 @@ import { logger } from "../logger.js";
 // ── Doctor ──────────────────────────────────────────────────────────────────
 
 function isWrapperActive(tool: string): boolean {
-  const wrapperPath = homePath(".local", "bin", tool);
+  const isWindows = process.platform === "win32";
+  const wrapperName = isWindows ? `${tool}.cmd` : tool;
+  const wrapperPath = homePath(".local", "bin", wrapperName);
   if (!fs.existsSync(wrapperPath)) return false;
   try {
-    const resolved = execFileSync("which", [tool], {
+    const whichCmd = isWindows ? "where.exe" : "which";
+    const whichArgs = isWindows ? [tool] : [tool];
+    const raw = execFileSync(whichCmd, whichArgs, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: EXEC_TIMEOUT_QUICK_MS,
     }).trim();
-    return path.resolve(resolved) === path.resolve(wrapperPath);
+    // `where.exe` can print multiple paths, one per line; check the first hit.
+    const first = raw.split(/\r?\n/).map((line) => line.trim()).find(Boolean) ?? "";
+    return path.resolve(first).toLowerCase() === path.resolve(wrapperPath).toLowerCase();
   } catch (err: unknown) {
-    debugLog(`isWrapperActive: which ${tool} failed: ${errorMessage(err)}`);
+    debugLog(`isWrapperActive: resolve ${tool} failed: ${errorMessage(err)}`);
     return false;
   }
 }
@@ -473,6 +479,7 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
       detail: codexWritable ? `writable: ${codexHooks}` : `not writable: ${codexHooks}`,
     });
   }
+  const wrapperSuffix = process.platform === "win32" ? ".cmd" : "";
   for (const tool of ["copilot", "cursor", "codex"]) {
     if (!detected.has(tool)) continue;
     const active = isWrapperActive(tool);
@@ -480,7 +487,7 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
       name: `wrapper:${tool}`,
       ok: active,
       detail: active
-        ? `${tool} wrapper active via ~/.local/bin/${tool}`
+        ? `${tool} wrapper active via ~/.local/bin/${tool}${wrapperSuffix}`
         : `${tool} wrapper missing or not first in PATH`,
     });
   }
@@ -491,7 +498,7 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     name: "wrapper:phren-cli",
     ok: phrenCliActive,
     detail: phrenCliActive
-      ? "phren CLI wrapper active via ~/.local/bin/phren"
+      ? `phren CLI wrapper active via ~/.local/bin/phren${wrapperSuffix}`
       : "phren CLI wrapper missing — run 'npx @phren/cli init' to install",
   });
 

--- a/packages/cli/src/release.test.ts
+++ b/packages/cli/src/release.test.ts
@@ -92,16 +92,21 @@ describe.sequential("1.10.x release hardening gates", () => {
     expect(getToolCount()).toBe(54);
   });
 
-  it.skipIf(process.platform === "win32")("wires lifecycle hooks + wrappers for Copilot/Cursor/Codex", () => {
+  it("wires lifecycle hooks + wrappers for Copilot/Cursor/Codex", () => {
     const fakeBin = path.join(tmpRoot, "bin");
     fs.mkdirSync(fakeBin, { recursive: true });
 
     for (const tool of ["copilot", "cursor", "codex"]) {
-      const file = path.join(fakeBin, tool);
-      fs.writeFileSync(file, "#!/usr/bin/env bash\nexit 0\n");
-      fs.chmodSync(file, 0o755);
+      if (process.platform === "win32") {
+        // where.exe only resolves files with a PATHEXT-registered suffix.
+        fs.writeFileSync(path.join(fakeBin, `${tool}.cmd`), `@echo off\r\nexit /b 0\r\n`);
+      } else {
+        const file = path.join(fakeBin, tool);
+        fs.writeFileSync(file, "#!/usr/bin/env bash\nexit 0\n");
+        fs.chmodSync(file, 0o755);
+      }
     }
-    process.env.PATH = `${fakeBin}:${origPath || ""}`;
+    process.env.PATH = `${fakeBin}${path.delimiter}${origPath || ""}`;
 
     const configured = configureAllHooks(phrenPath, { tools: new Set(["copilot", "cursor", "codex"]) });
     expect(configured).toContain("Copilot CLI");
@@ -123,8 +128,9 @@ describe.sequential("1.10.x release hardening gates", () => {
     expect(codexHooks).toContain("UserPromptSubmit");
     expect(codexHooks).toContain("Stop");
 
+    const wrapperExt = process.platform === "win32" ? ".cmd" : "";
     for (const tool of ["copilot", "cursor", "codex"]) {
-      const wrapper = path.join(homeDir, ".local", "bin", tool);
+      const wrapper = path.join(homeDir, ".local", "bin", `${tool}${wrapperExt}`);
       expect(fs.existsSync(wrapper)).toBe(true);
       const wrapperBody = fs.readFileSync(wrapper, "utf8");
       expect(wrapperBody).toContain("hook-session-start");
@@ -171,7 +177,7 @@ describe.sequential("1.10.x release hardening gates", () => {
 
     configureClaude(phrenPath, { mcpEnabled: true, hooksEnabled: false });
     const cfg = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
-    expect(cfg.mcpServers?.phren?.command).toMatch(/^(node|npx)$/);
+    expect(cfg.mcpServers?.phren?.command).toMatch(/^(node|npx(\.cmd)?)$/);
     const hooksBlob = JSON.stringify(cfg.hooks || {});
     expect(hooksBlob).not.toContain("hook-prompt");
     expect(hooksBlob).not.toContain("hook-stop");


### PR DESCRIPTION
## Summary

Close the real user-facing Windows gaps so `npx @phren/cli init` on a fresh Windows box produces the same working install as Linux — bare `phren` on PATH, working MCP config, hooks that fire through Copilot/Cursor/Codex, and a doctor check that reports the truth.

- **PATH discovery**: `~/.local/bin` isn't on Windows PATH by default, so the freshly-written `phren.cmd` was invisible. Init now appends the dir to the user PATH via PowerShell and tells the user to open a new terminal. (`ensureLocalBinOnWindowsPath` in `hooks.ts`.)
- **MCP `npx` shim**: MCP clients spawn servers with `shell: false` on Windows, so the bare `npx` name can't resolve the `.cmd` wrapper. `buildMcpServerConfig` now emits `"npx.cmd"` on win32.
- **Copilot `bash:` key**: Copilot CLI executes the `bash:` command through Git Bash, which can't parse cmd's `set "VAR=..." && …` syntax. Added `forcePosix` to `buildLifecycleCommands`/`withHookToolEnv` and wired it up for Copilot so the command string is POSIX even on Windows.
- **Hook timeouts on Windows**: POSIX wrappers already bounded hooks with `timeout`; the Windows wrapper let hooks run forever. The `.cmd` wrapper now has a `:run_with_timeout` subroutine that spawns the hook inside a PowerShell `Start-Job` and kills it after `PHREN_HOOK_TIMEOUT_S` seconds.
- **Doctor**: `isWrapperActive` used `which` (Linux only). It now branches to `where.exe` + the `.cmd` suffix on Windows, and the detail strings show the right filename.
- **Tests**: Un-skipped the wrapper-install tests by routing through a `wrapperFor(tool)` helper. Added Windows-specific assertions (`.cmd` extension, `@echo off`, `Start-Job`/`Wait-Job`, bash-compatible Copilot config) so a regression on windows-latest would actually break CI.
- **Lint**: dropped the pre-existing dead `DIRECT_MANAGE_COMMANDS` set in `entrypoint.ts` so the `lint` job is green again.

## Test plan

- [x] `pnpm build` passes on Linux.
- [x] `pnpm -w test` — 2525 passed, 6 skipped (platform-specific specs), 0 failed.
- [x] `pnpm lint` green.
- [ ] Confirm `build-and-test (windows-latest, 20)` and `(windows-latest, 22)` go green on CI.
- [ ] Manual smoke: on a clean Windows machine, `npx @phren/cli init` → open a new terminal → `phren status` works, MCP server launches from Claude Code / VS Code without the `.cmd` resolution error, Copilot CLI fires hooks through Git Bash without syntax errors.