### PR TITLE
fix: surface uppercase project dirs instead of silently half-indexing them

### DIFF
--- a/packages/cli/src/link/doctor.ts
+++ b/packages/cli/src/link/doctor.ts
@@ -9,8 +9,10 @@ import {
   homeDir,
   homePath,
   hookConfigPath,
+  listInvalidProjectDirs,
   runtimeHealthFile,
 } from "../shared.js";
+import { migrateInvalidProjectNames, formatMigrationSummary } from "../project-migrate.js";
 import { commandVersion, versionAtLeast, nearestWritableTarget } from "../init/shared.js";
 import { validateGovernanceJson } from "../shared/governance.js";
 import { errorMessage } from "../utils.js";
@@ -200,6 +202,15 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     name: "profile-projects",
     ok: projects.length > 0,
     detail: projects.length ? `${projects.length} projects in profile` : "no projects listed",
+  });
+
+  const invalidProjectDirs = listInvalidProjectDirs(phrenPath);
+  checks.push({
+    name: "project-names-valid",
+    ok: invalidProjectDirs.length === 0,
+    detail: invalidProjectDirs.length === 0
+      ? "all project directories use valid names"
+      : `${invalidProjectDirs.length} invalid project dir(s): ${invalidProjectDirs.join(", ")}. These are ignored by the UI and indexer. Run \`phren doctor --fix\` to rename to lowercase.`,
   });
 
   // Filesystem speed check
@@ -510,6 +521,16 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     if (repaired.createdRootMemory) details.push("recreated generated MEMORY.md");
     if (details.length === 0) details.push("baseline repair complete");
     checks.push({ name: "baseline-repair", ok: true, detail: details.join("; ") });
+  }
+
+  if (fix && invalidProjectDirs.length > 0) {
+    const migration = migrateInvalidProjectNames(phrenPath);
+    const unresolved = migration.outcomes.filter((o) => o.action !== "renamed");
+    checks.push({
+      name: "project-names-migrate",
+      ok: unresolved.length === 0,
+      detail: formatMigrationSummary(migration),
+    });
   }
 
   if (fix && profile && profileFile) {

--- a/packages/cli/src/phren-paths.ts
+++ b/packages/cli/src/phren-paths.ts
@@ -355,6 +355,27 @@ function isProjectDirEntry(entry: fs.Dirent): boolean {
     && !RESERVED_PROJECT_DIR_NAMES.has(entry.name);
 }
 
+// Like isProjectDirEntry, but also rejects names that would fail downstream
+// validation (e.g. uppercase). These dirs exist on disk but can't be read by
+// the UI or CLI read paths, so enumeration surfaces must skip them. Collision
+// detection still uses isProjectDirEntry so we can *see* the stragglers.
+function isIndexableProjectEntry(entry: fs.Dirent): boolean {
+  return isProjectDirEntry(entry) && isValidProjectName(entry.name);
+}
+
+// Project directories whose names exist on disk but fail isValidProjectName.
+// Used by `phren doctor` to surface silent half-working state.
+export function listInvalidProjectDirs(phrenPath: string): string[] {
+  try {
+    return fs.readdirSync(phrenPath, { withFileTypes: true })
+      .filter((entry) => isProjectDirEntry(entry) && !isValidProjectName(entry.name))
+      .map((entry) => entry.name);
+  } catch (err: unknown) {
+    if ((process.env.PHREN_DEBUG)) stderrLog(`listInvalidProjectDirs: ${errorMessage(err)}`);
+    return [];
+  }
+}
+
 export function normalizeProjectNameForCreate(name: string): string {
   return name.trim().toLowerCase();
 }
@@ -391,7 +412,7 @@ function getLocalProjectDirs(phrenPath: string, manifest: PhrenRootManifest): st
   if (!primaryProject || !isValidProjectName(primaryProject)) return [];
   const projectPath = safeProjectPath(phrenPath, primaryProject);
   if (!projectPath || !fs.existsSync(projectPath) || !fs.statSync(projectPath).isDirectory()) return [];
-  const visible = fs.readdirSync(phrenPath, { withFileTypes: true }).filter(isProjectDirEntry).map((entry) => entry.name);
+  const visible = fs.readdirSync(phrenPath, { withFileTypes: true }).filter(isIndexableProjectEntry).map((entry) => entry.name);
   if (visible.length !== 1 || visible[0] !== primaryProject) return [];
   return [projectPath];
 }
@@ -445,7 +466,7 @@ export function getProjectDirs(phrenPath: string, profile?: string): string[] {
 
   try {
     return fs.readdirSync(phrenPath, { withFileTypes: true })
-      .filter(isProjectDirEntry)
+      .filter(isIndexableProjectEntry)
       .map((entry) => path.join(phrenPath, entry.name));
   } catch (err: unknown) {
     if ((process.env.PHREN_DEBUG)) stderrLog(`getProjectDirs: ${errorMessage(err)}`);

--- a/packages/cli/src/project-migrate.test.ts
+++ b/packages/cli/src/project-migrate.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+import { makeTempDir, initTestPhrenRoot } from "./test-helpers.js";
+import { getProjectDirs, listInvalidProjectDirs } from "./phren-paths.js";
+import { migrateInvalidProjectNames } from "./project-migrate.js";
+
+describe("invalid project name handling", () => {
+  let tmp: { path: string; cleanup: () => void };
+  let phrenDir: string;
+
+  beforeEach(() => {
+    tmp = makeTempDir("phren-migrate-");
+    phrenDir = path.join(tmp.path, ".phren");
+    fs.mkdirSync(phrenDir, { recursive: true });
+    initTestPhrenRoot(phrenDir);
+    fs.mkdirSync(path.join(phrenDir, "profiles"), { recursive: true });
+  });
+
+  afterEach(() => {
+    tmp.cleanup();
+  });
+
+  function writeProfileYaml(name: string, projects: string[]): void {
+    fs.writeFileSync(
+      path.join(phrenDir, "profiles", `${name}.yaml`),
+      yaml.dump({ name, projects }),
+    );
+  }
+
+  describe("getProjectDirs", () => {
+    it("excludes directories with uppercase names", () => {
+      fs.mkdirSync(path.join(phrenDir, "goodproject"));
+      fs.mkdirSync(path.join(phrenDir, "MYPROJECT"));
+      fs.mkdirSync(path.join(phrenDir, "MixedCase"));
+      const dirs = getProjectDirs(phrenDir).map((d) => path.basename(d));
+      expect(dirs).toContain("goodproject");
+      expect(dirs).not.toContain("MYPROJECT");
+      expect(dirs).not.toContain("MixedCase");
+    });
+
+    it("excludes directories with spaces or special characters", () => {
+      fs.mkdirSync(path.join(phrenDir, "valid-name"));
+      fs.mkdirSync(path.join(phrenDir, "has space"));
+      const dirs = getProjectDirs(phrenDir).map((d) => path.basename(d));
+      expect(dirs).toContain("valid-name");
+      expect(dirs).not.toContain("has space");
+    });
+  });
+
+  describe("listInvalidProjectDirs", () => {
+    it("returns only dirs that fail isValidProjectName", () => {
+      fs.mkdirSync(path.join(phrenDir, "good"));
+      fs.mkdirSync(path.join(phrenDir, "MYPROJECT"));
+      fs.mkdirSync(path.join(phrenDir, "Bad Name"));
+      fs.mkdirSync(path.join(phrenDir, "global"));
+      const invalid = listInvalidProjectDirs(phrenDir).sort();
+      expect(invalid).toEqual(["Bad Name", "MYPROJECT"].sort());
+    });
+
+    it("ignores hidden, reserved, and archived entries", () => {
+      fs.mkdirSync(path.join(phrenDir, ".config"));
+      fs.mkdirSync(path.join(phrenDir, "something.archived"));
+      fs.mkdirSync(path.join(phrenDir, "MYPROJECT"));
+      const invalid = listInvalidProjectDirs(phrenDir);
+      expect(invalid).toEqual(["MYPROJECT"]);
+    });
+
+    it("returns empty array on a clean store", () => {
+      fs.mkdirSync(path.join(phrenDir, "good"));
+      expect(listInvalidProjectDirs(phrenDir)).toEqual([]);
+    });
+  });
+
+  describe("migrateInvalidProjectNames", () => {
+    it("renames an uppercase dir to lowercase and updates profile yaml", () => {
+      fs.mkdirSync(path.join(phrenDir, "MYPROJECT"));
+      fs.writeFileSync(path.join(phrenDir, "MYPROJECT", "summary.md"), "# test\n");
+      writeProfileYaml("default", ["global", "MYPROJECT"]);
+
+      const result = migrateInvalidProjectNames(phrenDir);
+
+      expect(result.outcomes).toHaveLength(1);
+      expect(result.outcomes[0]).toMatchObject({
+        from: "MYPROJECT",
+        to: "myproject",
+        action: "renamed",
+      });
+      expect(fs.existsSync(path.join(phrenDir, "myproject"))).toBe(true);
+      expect(fs.existsSync(path.join(phrenDir, "myproject", "summary.md"))).toBe(true);
+
+      const profileRaw = fs.readFileSync(path.join(phrenDir, "profiles", "default.yaml"), "utf8");
+      const profile = yaml.load(profileRaw) as { projects: string[] };
+      expect(profile.projects).toContain("myproject");
+      expect(profile.projects).not.toContain("MYPROJECT");
+    });
+
+    it("skips when the target lowercase dir already exists as a separate directory", () => {
+      fs.mkdirSync(path.join(phrenDir, "myproject"));
+      fs.writeFileSync(path.join(phrenDir, "myproject", "marker-lower"), "lower");
+      // On case-insensitive filesystems these two mkdirs would alias; detect
+      // that and skip the test because it can't meaningfully test collision.
+      let distinct = true;
+      try {
+        fs.mkdirSync(path.join(phrenDir, "MYPROJECT"));
+      } catch {
+        distinct = false;
+      }
+      if (!distinct) return;
+      const lowerStat = fs.statSync(path.join(phrenDir, "myproject"));
+      const upperStat = fs.statSync(path.join(phrenDir, "MYPROJECT"));
+      if (lowerStat.ino === upperStat.ino) return;
+
+      fs.writeFileSync(path.join(phrenDir, "MYPROJECT", "marker-upper"), "upper");
+
+      const result = migrateInvalidProjectNames(phrenDir);
+
+      expect(result.outcomes).toHaveLength(1);
+      expect(result.outcomes[0].action).toBe("skipped-collision");
+      expect(fs.existsSync(path.join(phrenDir, "myproject", "marker-lower"))).toBe(true);
+      expect(fs.existsSync(path.join(phrenDir, "MYPROJECT", "marker-upper"))).toBe(true);
+    });
+
+    it("reports skipped-invalid-slug for names lowercasing can't fix", () => {
+      fs.mkdirSync(path.join(phrenDir, "Bad Name"));
+
+      const result = migrateInvalidProjectNames(phrenDir);
+
+      expect(result.outcomes).toHaveLength(1);
+      expect(result.outcomes[0]).toMatchObject({
+        from: "Bad Name",
+        action: "skipped-invalid-slug",
+      });
+      expect(fs.existsSync(path.join(phrenDir, "Bad Name"))).toBe(true);
+    });
+
+    it("returns an empty result when everything is already valid", () => {
+      fs.mkdirSync(path.join(phrenDir, "goodproject"));
+      const result = migrateInvalidProjectNames(phrenDir);
+      expect(result.outcomes).toEqual([]);
+    });
+
+    it("handles multiple invalid dirs in one pass", () => {
+      fs.mkdirSync(path.join(phrenDir, "FOO"));
+      fs.mkdirSync(path.join(phrenDir, "Bar"));
+      fs.mkdirSync(path.join(phrenDir, "valid"));
+      writeProfileYaml("default", ["FOO", "Bar", "valid"]);
+
+      const result = migrateInvalidProjectNames(phrenDir);
+
+      const renamed = result.outcomes.filter((o) => o.action === "renamed");
+      expect(renamed.map((o) => `${o.from}->${o.to}`).sort()).toEqual([
+        "Bar->bar",
+        "FOO->foo",
+      ]);
+
+      const profile = yaml.load(
+        fs.readFileSync(path.join(phrenDir, "profiles", "default.yaml"), "utf8"),
+      ) as { projects: string[] };
+      expect(profile.projects.sort()).toEqual(["bar", "foo", "valid"]);
+    });
+  });
+});

--- a/packages/cli/src/project-migrate.ts
+++ b/packages/cli/src/project-migrate.ts
@@ -1,0 +1,148 @@
+import * as fs from "fs";
+import * as path from "path";
+import { listInvalidProjectDirs, normalizeProjectNameForCreate } from "./phren-paths.js";
+import { isValidProjectName, errorMessage } from "./utils.js";
+import {
+  listProfiles,
+  addProjectToProfile,
+  removeProjectFromProfile,
+} from "./profile-store.js";
+import { logger } from "./logger.js";
+
+export type MigrationOutcome =
+  | { from: string; to: string; action: "renamed" }
+  | { from: string; to: string; action: "skipped-collision"; reason: string }
+  | { from: string; to: string; action: "skipped-invalid-slug"; reason: string }
+  | { from: string; to: string; action: "error"; reason: string };
+
+export interface MigrationResult {
+  outcomes: MigrationOutcome[];
+}
+
+// Rename on-disk project directories whose names fail `isValidProjectName`
+// (typically uppercase) to their lowercase form, and update any profile YAML
+// references. Skips entries where the target name would collide with an
+// existing directory or where lowercasing alone doesn't yield a valid name.
+export function migrateInvalidProjectNames(phrenPath: string): MigrationResult {
+  const invalid = listInvalidProjectDirs(phrenPath);
+  const outcomes: MigrationOutcome[] = [];
+
+  for (const from of invalid) {
+    const to = normalizeProjectNameForCreate(from);
+
+    if (!isValidProjectName(to)) {
+      outcomes.push({
+        from,
+        to,
+        action: "skipped-invalid-slug",
+        reason: `lowercasing does not yield a valid name (got "${to}"); rename manually`,
+      });
+      continue;
+    }
+
+    if (to === from) {
+      outcomes.push({
+        from,
+        to,
+        action: "skipped-invalid-slug",
+        reason: "already lowercase but still fails validation; rename manually",
+      });
+      continue;
+    }
+
+    const oldDir = path.join(phrenPath, from);
+    const newDir = path.join(phrenPath, to);
+
+    // Case-insensitive filesystems (macOS APFS/HFS+, default Windows) resolve
+    // both paths to the same inode. Treat that as "rename casing in place"
+    // rather than a collision.
+    let sameInode = false;
+    try {
+      if (fs.existsSync(newDir)) {
+        const oldStat = fs.statSync(oldDir);
+        const newStat = fs.statSync(newDir);
+        sameInode = oldStat.ino === newStat.ino && oldStat.dev === newStat.dev;
+      }
+    } catch (err: unknown) {
+      logger.debug("project-migrate", `stat compare ${from}->${to}: ${errorMessage(err)}`);
+    }
+
+    if (fs.existsSync(newDir) && !sameInode) {
+      outcomes.push({
+        from,
+        to,
+        action: "skipped-collision",
+        reason: `target "${to}" already exists as a separate directory; merge manually`,
+      });
+      continue;
+    }
+
+    try {
+      if (sameInode) {
+        // Two-step rename forces the case change on case-insensitive filesystems
+        // without letting an observer see a missing directory.
+        const tmp = path.join(phrenPath, `${from}.phren-case-tmp-${process.pid}`);
+        fs.renameSync(oldDir, tmp);
+        fs.renameSync(tmp, newDir);
+      } else {
+        fs.renameSync(oldDir, newDir);
+      }
+    } catch (err: unknown) {
+      outcomes.push({
+        from,
+        to,
+        action: "error",
+        reason: `rename failed: ${errorMessage(err)}`,
+      });
+      continue;
+    }
+
+    updateProfileReferences(phrenPath, from, to);
+
+    outcomes.push({ from, to, action: "renamed" });
+  }
+
+  return { outcomes };
+}
+
+function updateProfileReferences(phrenPath: string, oldName: string, newName: string): void {
+  const profiles = listProfiles(phrenPath);
+  if (!profiles.ok) {
+    logger.debug("project-migrate", `updateProfileReferences listProfiles: ${profiles.error}`);
+    return;
+  }
+  for (const profile of profiles.data) {
+    if (!profile.projects.includes(oldName)) continue;
+    const removed = removeProjectFromProfile(phrenPath, profile.name, oldName);
+    if (!removed.ok) {
+      logger.debug("project-migrate", `remove ${oldName} from ${profile.name}: ${removed.error}`);
+      continue;
+    }
+    const added = addProjectToProfile(phrenPath, profile.name, newName);
+    if (!added.ok) {
+      logger.debug("project-migrate", `add ${newName} to ${profile.name}: ${added.error}`);
+    }
+  }
+}
+
+export function formatMigrationSummary(result: MigrationResult): string {
+  if (result.outcomes.length === 0) return "no invalid project directories found";
+  const parts: string[] = [];
+  const renamed = result.outcomes.filter((o) => o.action === "renamed");
+  const collisions = result.outcomes.filter((o) => o.action === "skipped-collision");
+  const invalidSlugs = result.outcomes.filter((o) => o.action === "skipped-invalid-slug");
+  const errors = result.outcomes.filter((o) => o.action === "error");
+  if (renamed.length > 0) {
+    parts.push(`renamed ${renamed.length}: ${renamed.map((o) => `${o.from}->${o.to}`).join(", ")}`);
+  }
+  if (collisions.length > 0) {
+    parts.push(`${collisions.length} collision(s): ${collisions.map((o) => o.from).join(", ")}`);
+  }
+  if (invalidSlugs.length > 0) {
+    parts.push(`${invalidSlugs.length} unfixable: ${invalidSlugs.map((o) => o.from).join(", ")}`);
+  }
+  if (errors.length > 0) {
+    parts.push(`${errors.length} error(s): ${errors.map((o) => `${o.from} (${o.reason})`).join(", ")}`);
+  }
+  return parts.join("; ");
+}

--- a/packages/cli/src/shared-index.test.ts
+++ b/packages/cli/src/shared-index.test.ts
@@ -296,10 +296,12 @@ describe("detectProject", () => {
 
   it("uses the stored project name when sourcePath matches", () => {
     const phren = makePhren();
-    makeProject(phren, "MyProject", { "SUMMARY.md": "# Summary" });
-    writeFile(path.join(phren, "MyProject", "phren.project.yaml"), yaml.dump({ sourcePath: "/home/user/myproject" }, { lineWidth: 1000 }));
-    const result = detectProject(phren, "/home/user/myproject/src");
-    expect(result).toBe("MyProject");
+    // Stored name intentionally differs from sourcePath basename to prove
+    // detectProject returns the stored name rather than deriving from cwd.
+    makeProject(phren, "stored-name", { "SUMMARY.md": "# Summary" });
+    writeFile(path.join(phren, "stored-name", "phren.project.yaml"), yaml.dump({ sourcePath: "/home/user/other-location" }, { lineWidth: 1000 }));
+    const result = detectProject(phren, "/home/user/other-location/src");
+    expect(result).toBe("stored-name");
   });
 });
 

--- a/packages/cli/src/shared.ts
+++ b/packages/cli/src/shared.ts
@@ -70,6 +70,7 @@ export {
   findProjectNameCaseInsensitive,
   findArchivedProjectNameCaseInsensitive,
   getProjectDirs,
+  listInvalidProjectDirs,
   collectNativeMemoryFiles,
   computePhrenLiveStateToken,
   getPhrenPath,


### PR DESCRIPTION
Project directories whose names fail isValidProjectName (e.g. uppercase)
could exist on disk — manually created, inherited from a synced store, or
from a case-insensitive filesystem preserving original case. The indexer
ingested them and the UI listed them, but every read endpoint rejected
the name at the validation gate, leaving the UI empty for those projects.

Three coordinated changes:
- getProjectDirs/getLocalProjectDirs now skip invalid-name entries so
  the UI and indexer never half-adopt a project they can't serve.
  findProjectNameCaseInsensitive still sees them so collision detection
  keeps working.
- phren doctor reports a "project-names-valid" check listing any invalid
  dirs it finds.
- phren doctor --fix runs migrateInvalidProjectNames, which lowercases
  fixable names in place and rewrites profile yaml references. Handles
  case-insensitive filesystems via two-step rename, and refuses to merge
  collisions.