### PR TITLE
fix(vscode): read fragments from read_graph MCP response

### DIFF
--- a/packages/cli/browser/memory-ui-graph-app.ts
+++ b/packages/cli/browser/memory-ui-graph-app.ts
@@ -502,7 +502,7 @@ function nodeMatchesFilters(node: RuntimeNode): boolean {
       else if (ref.doc.includes("/")) connectedProjects.add(ref.doc.slice(0, ref.doc.indexOf("/")));
     });
     if (node.kind === "project") {
-      if (node.id !== project) return false;
+      if ((node.project || "") !== project) return false;
     } else if (!connectedProjects.has(project)) {
       return false;
     }
@@ -571,7 +571,7 @@ function buildVisibleData(): { nodes: RuntimeNode[]; links: RawLink[] } {
   });
   // Keep nodes if: not a project, OR has visible connections, OR is the selected project, OR project type is filtered but has no connections
   const prunedNodes = limitedNodes.filter((node) =>
-    node.kind !== "project" || connectedIds.has(node.id) || node.id === state.filterProject || state.filterTypes.project
+    node.kind !== "project" || connectedIds.has(node.id) || (node.project || "") === state.filterProject || state.filterTypes.project
   );
   return { nodes: prunedNodes, links: visibleLinks };
 }
@@ -1283,10 +1283,11 @@ function buildFilterBar(): void {
   const limitRow = document.getElementById("graph-limit-row");
   if (!filterEl) return;
 
-  const projectNames = state.rawNodes
-    .filter((node) => node.kind === "project")
-    .map((node) => node.id)
-    .sort((a, b) => a.localeCompare(b));
+  const projectNames = Array.from(new Set(
+    state.rawNodes
+      .filter((node) => node.kind === "project")
+      .map((node) => node.project || node.id)
+  )).sort((a, b) => a.localeCompare(b));
 
   const storeNames = Array.from(new Set(
     state.rawNodes

--- a/packages/vscode/src/graphWebview.ts
+++ b/packages/vscode/src/graphWebview.ts
@@ -807,10 +807,11 @@ async function fetchEntities(client: PhrenClient): Promise<EntityData[]> {
     const raw = await client.readGraph();
     const data = responseData(raw);
     const parsed: EntityData[] = [];
-    for (const entry of asArray(data?.entities)) {
+    for (const entry of asArray(data?.fragments)) {
       const record = asRecord(entry);
       if (!record) continue;
       parsed.push({
+        id: asString(record.id),
         name: asString(record.name) ?? "",
         type: asString(record.type) ?? "unknown",
         refCount: typeof record.refCount === "number" ? record.refCount : 0,


### PR DESCRIPTION
The graph webview's fetchEntities() iterated data.entities, but the
read_graph MCP tool returns the list under data.fragments. The mismatch
left the entities array empty, so no fragment nodes (or the project /
cross-project / reference-doc edges derived from them) were ever added
to the VS Code fragment graph, even though the web UI rendered them.

Also populate EntityData.id from the response so callers don't fall
back to synthesizing an id from the name.