### PR TITLE
fix(init): refuse to repoint global wiring at different phren root (v0.1.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.23] - 2026-04-25
+
+### Fixed
+- **Critical**: `phren init` silently rewrote `~/.local/bin/phren` and `~/.claude/settings.json` (4 lifecycle hooks + `mcpServers.phren`) to point at whatever `PHREN_PATH` was set in the invoking environment, even when those files already pointed at a valid different root. A smoke or test invocation like `PHREN_PATH=/tmp/foo phren init --yes` would clobber the real wiring; once `/tmp/foo` was cleaned up the user's next session got `NOT_FOUND: phren root not found. Run 'phren init'.` from every session-start, prompt, stop, and tool hook, plus the phren MCP server. Init now scans the wrapper and Claude hooks/MCP entry up-front, and aborts with a clear list of conflicts when any references a different path that still resolves to a valid phren root (`phren.root.yaml`, `machines.yaml`, or `global/`). Stale wiring (existing path missing or not a phren root) is intentionally not treated as a conflict so init can still repair it. Tests/smoke runs that intentionally install into a fresh root must isolate `HOME` (and `USERPROFILE` on Windows) to a sandbox dir, or pass `--force`.
+
+### Added
+- `phren init --force` overrides the new global-wiring conflict guard for intentional re-points (machine moves, real test environments).
+
 ## [0.1.22] - 2026-04-25
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/init-guard-globals.test.ts
+++ b/packages/cli/src/__tests__/init-guard-globals.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  findConflictingGlobalWiring,
+  assertNoGlobalWiringConflict,
+} from "../init/guard-globals.js";
+
+function makeRealRoot(parent: string, name = "real-phren"): string {
+  const root = path.join(parent, name);
+  fs.mkdirSync(path.join(root, "global"), { recursive: true });
+  fs.writeFileSync(path.join(root, "phren.root.yaml"), "version: 1\n");
+  fs.writeFileSync(path.join(root, "machines.yaml"), "");
+  return root;
+}
+
+function writeWrapper(homeDir: string, defaultPhrenPath: string): string {
+  const binDir = path.join(homeDir, ".local", "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const wrapperPath = path.join(binDir, "phren");
+  const content = [
+    "#!/bin/sh",
+    "# PHREN_CLI_WRAPPER — managed by phren init; safe to delete",
+    "set -u",
+    `PHREN_PATH="\${PHREN_PATH:-${defaultPhrenPath}}"`,
+    "export PHREN_PATH",
+    'exec node /tmp/index.js "$@"',
+    "",
+  ].join("\n");
+  fs.writeFileSync(wrapperPath, content);
+  return wrapperPath;
+}
+
+function writeClaudeSettings(homeDir: string, phrenPathInWiring: string): string {
+  const dir = path.join(homeDir, ".claude");
+  fs.mkdirSync(dir, { recursive: true });
+  const settingsPath = path.join(dir, "settings.json");
+  fs.writeFileSync(
+    settingsPath,
+    JSON.stringify(
+      {
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: "",
+              hooks: [
+                {
+                  type: "command",
+                  command: `PHREN_PATH='${phrenPathInWiring}' '${homeDir}/.local/bin/phren' hook-prompt`,
+                  timeout: 3,
+                },
+              ],
+            },
+          ],
+        },
+        mcpServers: {
+          phren: {
+            command: "node",
+            args: ["/tmp/index.js", phrenPathInWiring],
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  return settingsPath;
+}
+
+describe("init guard against repointing global wiring", () => {
+  let tmp: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "phren-guard-test-"));
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmp;
+    process.env.USERPROFILE = tmp;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns no conflicts when no wrapper or settings exist", () => {
+    const conflicts = findConflictingGlobalWiring(makeRealRoot(tmp));
+    expect(conflicts).toEqual([]);
+  });
+
+  it("returns no conflicts when existing wrapper points at the same root", () => {
+    const realRoot = makeRealRoot(tmp);
+    writeWrapper(tmp, realRoot);
+    expect(findConflictingGlobalWiring(realRoot)).toEqual([]);
+  });
+
+  it("flags wrapper, mcpServers entry, and hook command when they reference a different valid root", () => {
+    const realRoot = makeRealRoot(tmp, "real-phren");
+    const newRoot = path.join(tmp, "new-phren");
+    fs.mkdirSync(newRoot, { recursive: true });
+    writeWrapper(tmp, realRoot);
+    writeClaudeSettings(tmp, realRoot);
+
+    const conflicts = findConflictingGlobalWiring(newRoot);
+    const locations = conflicts.map((c) => c.location).sort();
+    expect(locations).toEqual([
+      "~/.claude/settings.json hooks.UserPromptSubmit",
+      "~/.claude/settings.json mcpServers.phren",
+      "~/.local/bin/phren wrapper",
+    ]);
+    for (const c of conflicts) {
+      expect(path.resolve(c.existingPath)).toBe(path.resolve(realRoot));
+    }
+  });
+
+  it("does not flag wiring that points at a stale (missing or non-phren) path", () => {
+    const stalePath = path.join(tmp, "ghost-phren");
+    writeWrapper(tmp, stalePath);
+    writeClaudeSettings(tmp, stalePath);
+    const newRoot = makeRealRoot(tmp, "new-phren");
+    expect(findConflictingGlobalWiring(newRoot)).toEqual([]);
+  });
+
+  it("ignores wrapper files that lack the PHREN_CLI_WRAPPER marker", () => {
+    const realRoot = makeRealRoot(tmp);
+    const binDir = path.join(tmp, ".local", "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, "phren"), "#!/bin/sh\necho not ours\n");
+    expect(findConflictingGlobalWiring(path.join(tmp, "new-phren"))).toEqual([]);
+    void realRoot; // ensure realRoot isn't garbage collected/unused warning
+  });
+
+  it("assertNoGlobalWiringConflict throws on conflict but is silenced by force", () => {
+    const realRoot = makeRealRoot(tmp);
+    const newRoot = path.join(tmp, "smoke");
+    fs.mkdirSync(newRoot, { recursive: true });
+    writeWrapper(tmp, realRoot);
+
+    expect(() => assertNoGlobalWiringConflict(newRoot, false)).toThrow(/refusing to repoint/);
+    expect(() => assertNoGlobalWiringConflict(newRoot, true)).not.toThrow();
+  });
+});

--- a/packages/cli/src/__tests__/init-guard-globals.test.ts
+++ b/packages/cli/src/__tests__/init-guard-globals.test.ts
@@ -18,19 +18,30 @@ function makeRealRoot(parent: string, name = "real-phren"): string {
 function writeWrapper(homeDir: string, defaultPhrenPath: string): string {
   const binDir = path.join(homeDir, ".local", "bin");
   fs.mkdirSync(binDir, { recursive: true });
-  const wrapperPath = path.join(binDir, "phren");
-  const content = [
-    "#!/bin/sh",
-    "# PHREN_CLI_WRAPPER — managed by phren init; safe to delete",
-    "set -u",
-    `PHREN_PATH="\${PHREN_PATH:-${defaultPhrenPath}}"`,
-    "export PHREN_PATH",
-    'exec node /tmp/index.js "$@"',
-    "",
-  ].join("\n");
+  const isWindows = process.platform === "win32";
+  const wrapperPath = path.join(binDir, isWindows ? "phren.cmd" : "phren");
+  const content = isWindows
+    ? [
+        "@echo off",
+        "rem PHREN_CLI_WRAPPER — managed by phren init; safe to delete",
+        `if not defined PHREN_PATH set "PHREN_PATH=${defaultPhrenPath}"`,
+        'node "C:\\tmp\\index.js" %*',
+        "",
+      ].join("\r\n")
+    : [
+        "#!/bin/sh",
+        "# PHREN_CLI_WRAPPER — managed by phren init; safe to delete",
+        "set -u",
+        `PHREN_PATH="\${PHREN_PATH:-${defaultPhrenPath}}"`,
+        "export PHREN_PATH",
+        'exec node /tmp/index.js "$@"',
+        "",
+      ].join("\n");
   fs.writeFileSync(wrapperPath, content);
   return wrapperPath;
 }
+
+const wrapperLocationLabel = `~/.local/bin/${process.platform === "win32" ? "phren.cmd" : "phren"} wrapper`;
 
 function writeClaudeSettings(homeDir: string, phrenPathInWiring: string): string {
   const dir = path.join(homeDir, ".claude");
@@ -112,8 +123,8 @@ describe("init guard against repointing global wiring", () => {
     expect(locations).toEqual([
       "~/.claude/settings.json hooks.UserPromptSubmit",
       "~/.claude/settings.json mcpServers.phren",
-      "~/.local/bin/phren wrapper",
-    ]);
+      wrapperLocationLabel,
+    ].sort());
     for (const c of conflicts) {
       expect(path.resolve(c.existingPath)).toBe(path.resolve(realRoot));
     }
@@ -131,7 +142,8 @@ describe("init guard against repointing global wiring", () => {
     const realRoot = makeRealRoot(tmp);
     const binDir = path.join(tmp, ".local", "bin");
     fs.mkdirSync(binDir, { recursive: true });
-    fs.writeFileSync(path.join(binDir, "phren"), "#!/bin/sh\necho not ours\n");
+    const wrapperName = process.platform === "win32" ? "phren.cmd" : "phren";
+    fs.writeFileSync(path.join(binDir, wrapperName), "#!/bin/sh\necho not ours\n");
     expect(findConflictingGlobalWiring(path.join(tmp, "new-phren"))).toEqual([]);
     void realRoot; // ensure realRoot isn't garbage collected/unused warning
   });

--- a/packages/cli/src/entrypoint.ts
+++ b/packages/cli/src/entrypoint.ts
@@ -428,22 +428,28 @@ export async function runTopLevelCommand(
       return finish(1);
     }
     const cloneUrl = getOptionValue(initArgs, "--clone-url");
-    await runInit({
-      mode: modeArg as "shared" | "project-local" | undefined,
-      machine: machineIdx !== -1 ? initArgs[machineIdx + 1] : undefined,
-      profile: profileIdx !== -1 ? initArgs[profileIdx + 1] : undefined,
-      mcp: mcpMode,
-      projectOwnershipDefault: ownershipMode,
-      taskMode,
-      findingsProactivity,
-      taskProactivity,
-      template: templateIdx !== -1 ? initArgs[templateIdx + 1] : undefined,
-      applyStarterUpdate: initArgs.includes("--apply-starter-update"),
-      dryRun: initArgs.includes("--dry-run"),
-      yes: initArgs.includes("--yes") || initArgs.includes("-y"),
-      express: initArgs.includes("--express"),
-      _walkthroughCloneUrl: cloneUrl,
-    });
+    try {
+      await runInit({
+        mode: modeArg as "shared" | "project-local" | undefined,
+        machine: machineIdx !== -1 ? initArgs[machineIdx + 1] : undefined,
+        profile: profileIdx !== -1 ? initArgs[profileIdx + 1] : undefined,
+        mcp: mcpMode,
+        projectOwnershipDefault: ownershipMode,
+        taskMode,
+        findingsProactivity,
+        taskProactivity,
+        template: templateIdx !== -1 ? initArgs[templateIdx + 1] : undefined,
+        applyStarterUpdate: initArgs.includes("--apply-starter-update"),
+        dryRun: initArgs.includes("--dry-run"),
+        yes: initArgs.includes("--yes") || initArgs.includes("-y"),
+        express: initArgs.includes("--express"),
+        force: initArgs.includes("--force"),
+        _walkthroughCloneUrl: cloneUrl,
+      });
+    } catch (err: unknown) {
+      console.error(errorMessage(err));
+      return finish(1);
+    }
     return finish();
   }
 

--- a/packages/cli/src/init/guard-globals.ts
+++ b/packages/cli/src/init/guard-globals.ts
@@ -1,0 +1,154 @@
+/**
+ * Guards against `phren init` silently repointing the user's global wiring
+ * (CLI wrapper at ~/.local/bin/phren and Claude settings.json hooks/MCP) at a
+ * different phren root than the one currently in use.
+ *
+ * Why: `phren init` is also exercised by tests/smoke scripts that invoke it
+ * with `PHREN_PATH=/tmp/...`. Without an isolated $HOME the install logic
+ * cheerfully rewrites the user's real wrapper and Claude hooks to point at
+ * the throwaway path, which then disappears with `rm -rf /tmp/foo`. The next
+ * Claude session boots with a SessionStart hook that throws
+ *   `NOT_FOUND: phren root not found. Run 'phren init'.`
+ *
+ * Behavior: before any global file is rewritten, scan the three known
+ * locations. If any of them already references a *different* path that
+ * resolves to a valid phren root, refuse to proceed unless `--force` is
+ * passed. Stale wiring (existing path missing or not a phren root) is not a
+ * conflict — init is the right tool to repair it.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { homePath, isRecord } from "../shared.js";
+import { hookConfigPath } from "../provider-adapters.js";
+
+export interface WiringConflict {
+  location: string;
+  existingPath: string;
+}
+
+const WRAPPER_POSIX_RE = /PHREN_PATH="\$\{PHREN_PATH:-([^}]+)\}"/;
+const WRAPPER_WIN_RE = /set "PHREN_PATH=([^"]+)"/;
+const HOOK_PHREN_PATH_RE = /PHREN_PATH=(?:'([^']+)'|"([^"]+)"|(\S+))/;
+
+function samePath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+/**
+ * A path counts as a "valid phren root" only if it currently looks like one
+ * — root manifest, machines.yaml, or the global skills tree. We deliberately
+ * tolerate partial roots so a clean `phren init` repair still works.
+ */
+function looksLikePhrenRoot(candidate: string): boolean {
+  if (!fs.existsSync(candidate)) return false;
+  if (fs.existsSync(path.join(candidate, "phren.root.yaml"))) return true;
+  if (fs.existsSync(path.join(candidate, "machines.yaml"))) return true;
+  if (fs.existsSync(path.join(candidate, "global"))) return true;
+  return false;
+}
+
+function readWrapperPath(): string | null {
+  const wrapperName = process.platform === "win32" ? "phren.cmd" : "phren";
+  const wrapperFile = path.join(homePath(".local", "bin"), wrapperName);
+  if (!fs.existsSync(wrapperFile)) return null;
+  let content: string;
+  try {
+    content = fs.readFileSync(wrapperFile, "utf8");
+  } catch {
+    return null;
+  }
+  if (!content.includes("PHREN_CLI_WRAPPER")) return null;
+  const re = process.platform === "win32" ? WRAPPER_WIN_RE : WRAPPER_POSIX_RE;
+  const m = content.match(re);
+  return m?.[1] ?? null;
+}
+
+function extractHookPhrenPath(command: string): string | null {
+  const m = command.match(HOOK_PHREN_PATH_RE);
+  if (!m) return null;
+  return m[1] ?? m[2] ?? m[3] ?? null;
+}
+
+function readClaudeSettings(): unknown {
+  const settingsPath = hookConfigPath("claude");
+  if (!fs.existsSync(settingsPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function findConflictingGlobalWiring(newPhrenPath: string): WiringConflict[] {
+  const conflicts: WiringConflict[] = [];
+  const seen = new Set<string>();
+  const record = (location: string, existingPath: string) => {
+    if (samePath(existingPath, newPhrenPath)) return;
+    if (!looksLikePhrenRoot(existingPath)) return;
+    const key = `${location}:${path.resolve(existingPath)}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    conflicts.push({ location, existingPath });
+  };
+
+  const wrapperPath = readWrapperPath();
+  if (wrapperPath) {
+    record(`~/.local/bin/${process.platform === "win32" ? "phren.cmd" : "phren"} wrapper`, wrapperPath);
+  }
+
+  const settings = readClaudeSettings();
+  if (isRecord(settings)) {
+    const mcpServers = settings.mcpServers;
+    if (isRecord(mcpServers)) {
+      const phrenServer = mcpServers.phren;
+      if (isRecord(phrenServer) && Array.isArray(phrenServer.args) && phrenServer.args.length > 0) {
+        const last = phrenServer.args[phrenServer.args.length - 1];
+        if (typeof last === "string") {
+          record("~/.claude/settings.json mcpServers.phren", last);
+        }
+      }
+    }
+
+    const hooks = settings.hooks;
+    if (isRecord(hooks)) {
+      for (const eventName of ["UserPromptSubmit", "Stop", "SessionStart", "PostToolUse"] as const) {
+        const eventHooks = hooks[eventName];
+        if (!Array.isArray(eventHooks)) continue;
+        for (const entry of eventHooks) {
+          if (!isRecord(entry)) continue;
+          const inner = entry.hooks;
+          if (!Array.isArray(inner)) continue;
+          for (const h of inner) {
+            if (!isRecord(h)) continue;
+            const command = typeof h.command === "string" ? h.command : "";
+            if (!command) continue;
+            const extracted = extractHookPhrenPath(command);
+            if (extracted) {
+              record(`~/.claude/settings.json hooks.${eventName}`, extracted);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+export function assertNoGlobalWiringConflict(newPhrenPath: string, force: boolean): void {
+  if (force) return;
+  const conflicts = findConflictingGlobalWiring(newPhrenPath);
+  if (conflicts.length === 0) return;
+  const lines: string[] = [
+    `phren init: refusing to repoint global wiring at ${newPhrenPath}.`,
+    "",
+    "Existing files reference a different phren root that still looks valid:",
+  ];
+  for (const c of conflicts) {
+    lines.push(`  - ${c.location} → ${c.existingPath}`);
+  }
+  lines.push("");
+  lines.push("If you intend to switch the global wiring to the new path, re-run with --force.");
+  lines.push("If you're running a smoke test, set HOME (and XDG_*) to a sandbox before invoking init.");
+  throw new Error(lines.join("\n"));
+}

--- a/packages/cli/src/init/init.ts
+++ b/packages/cli/src/init/init.ts
@@ -84,6 +84,7 @@ import {
   runProjectLocalInit,
 } from "./init-configure.js";
 import { runWalkthrough, createWalkthroughPrompts, createWalkthroughStyle } from "./init-walkthrough.js";
+import { assertNoGlobalWiringConflict } from "./guard-globals.js";
 
 
 import {
@@ -172,6 +173,14 @@ export interface InitOptions {
   yes?: boolean;
   /** Skip walkthrough entirely with recommended defaults (express mode) */
   express?: boolean;
+  /**
+   * Allow init to repoint global wiring (~/.local/bin/phren wrapper and
+   * Claude settings.json hooks/mcpServers.phren) at a different phren root
+   * than the one currently in use. Without this, init refuses when an
+   * existing global file references a different valid phren root — protects
+   * against tests/smoke runs that forget to sandbox $HOME.
+   */
+  force?: boolean;
   // Built-in template names are directory-based under starter/templates/.
   // Keep string-compatible so custom package templates continue to work.
   template?: "python-project" | "monorepo" | "library" | "frontend" | string;
@@ -240,6 +249,10 @@ export async function runInit(opts: InitOptions = {}) {
   }
   let phrenPath = resolveInitPhrenPath(opts);
   const dryRun = Boolean(opts.dryRun);
+
+  if (!dryRun) {
+    assertNoGlobalWiringConflict(phrenPath, Boolean(opts.force));
+  }
 
   // Migrate the legacy hidden store directory into ~/.phren when upgrading
   // from the previous product name. Only runs when the resolved phrenPath


### PR DESCRIPTION
## Summary

- `phren init` was silently rewriting `~/.local/bin/phren` and `~/.claude/settings.json` (4 lifecycle hooks + `mcpServers.phren`) to whatever `PHREN_PATH` was exported when init ran — even when those files already pointed at a valid different root. A smoke/test invocation like `PHREN_PATH=/tmp/foo phren init --yes` would clobber the user's real wiring; once `/tmp/foo` was rm'd the next session got `NOT_FOUND: phren root not found. Run 'phren init'.` from every hook and MCP call.
- New `packages/cli/src/init/guard-globals.ts` scans the wrapper, `mcpServers.phren` args, and `PHREN_PATH=` prefixes in each Claude hook command. Any reference to a different path that still resolves to a valid phren root (`phren.root.yaml`, `machines.yaml`, or `global/`) blocks init with a clear conflict list. Stale wiring (missing/non-phren target) is intentionally not a conflict so init can still repair it.
- `phren init --force` overrides the guard for intentional re-points (machine moves, real test environments). Tests/smoke runs that intentionally install into a fresh root should isolate `HOME` (and `USERPROFILE` on Windows) to a sandbox dir.
- Cuts the `runInit` call site over to try/catch so the guard error prints cleanly and exits 1 instead of leaking an uncaught stack trace.
- Bumps `@phren/cli` to **0.1.23** with a CHANGELOG entry under the existing convention.

How the bug got into a real user's machine: a Claude session running in `~/projects/phren` ran `mkdir -p /tmp/phren-smoke && cd /tmp/phren-smoke && PHREN_PATH=/tmp/phren-smoke/.phren node packages/cli/dist/index.js init --no-interactive --skip-link` then `rm -rf /tmp/phren-smoke`. Real `~/.local/bin/phren` and `~/.claude/settings.json` were left pointing at the smoke path; every subsequent SessionStart, prompt, stop, and PostToolUse hook crashed.

## Test plan

- [x] New `packages/cli/src/__tests__/init-guard-globals.test.ts` — 6 tests: no wiring, matching wiring, conflicting wrapper+mcp+hooks, stale wiring is ignored, non-managed wrapper is ignored, `--force` bypass.
- [x] Full vitest suite: `132 passed | 1 skipped (133)` test files, `2546 passed | 6 skipped (2552)` tests.
- [x] `pnpm lint` clean.
- [x] `pnpm run validate-docs` clean (recognizes `0.1.23` in both `packages/cli/package.json` and `CHANGELOG.md`).
- [x] End-to-end: replayed the original bug command (`PHREN_PATH=/tmp/phren-smoke-verify/.phren node dist/index.js init --yes`) — guard now blocks with a 6-line conflict list, exits 1, no stack trace.
- [ ] After merge: trigger the Release workflow via `gh workflow run release.yml -f version=0.1.23`.