### PR TITLE
feat: team finding provenance with actor + machine attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.24] - 2026-04-27
+
+### Added
+- **Team finding provenance.** Findings now carry inline `<!-- source:human machine:X actor:Y -->` metadata so teammates can tell who recorded a finding and on which machine. `add_finding` captures this automatically (machine via `getMachineName()`, actor via `PHREN_ACTOR`/`USER`). Both single-store and team-store (journal) write paths are wired. Reading paths surface the attribution: `get_findings` MCP output appends `[from:actor@machine]`, and the FTS5 indexer transforms the source comment to the same format so `search_knowledge` snippets and the per-prompt phren-context injection carry attribution as well. Findings without attribution are implicitly team-verified.
+- `formatActorAttribution(actor, machine)` and `getCurrentActor()` helpers in `content/citation.ts` and `machine-identity.ts` for reuse across write/read paths.
+
+### Fixed
+- `materializeTeamFindings()` previously emitted `<!-- author:${actor} -->` (a non-standard format that nothing parsed). Now relies on the embedded source comment from journal entries; for older entries that lack one, injects a fallback source comment built from the journal filename actor so attribution is preserved through materialization.
+
+### Performance
+- `getMachineName()` now caches its result at module level. Previously hit `fs.existsSync` + `fs.readFileSync` on every call; the file content does not change during a process lifetime. `persistMachineName()` invalidates the cache.
+
 ## [0.1.23] - 2026-04-25
 
 ### Fixed

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/content/citation.ts
+++ b/packages/cli/src/content/citation.ts
@@ -111,6 +111,12 @@ function readSourceToken(match: RegExpMatchArray | null | undefined): string | u
   return raw;
 }
 
+/** Format actor/machine attribution for human-readable display. */
+export function formatActorAttribution(actor: string | undefined, machine: string | undefined): string {
+  if (!actor && !machine) return "";
+  return `[from:${actor ?? "?"}${machine ? `@${machine}` : ""}]`;
+}
+
 export function buildSourceComment(source: FindingProvenance): string {
   const parts: string[] = [];
   if (source.source) parts.push(source.source);

--- a/packages/cli/src/content/learning.ts
+++ b/packages/cli/src/content/learning.ts
@@ -7,8 +7,10 @@ import { withFileLock } from "../shared/governance.js";
 import { isValidProjectName, safeProjectPath } from "../utils.js";
 import {
   type FindingCitation,
+  type FindingProvenance,
   buildCitationComment,
   buildScopeComment,
+  buildSourceComment,
   getHeadCommit,
   getRepoRoot,
   inferCitationLocation,
@@ -49,6 +51,7 @@ interface AddFindingOptions {
   extraAnnotations?: string[];
   sessionId?: string;
   scope?: string;
+  provenance?: FindingProvenance;
 }
 
 export interface AddFindingResult {
@@ -147,6 +150,7 @@ interface PrepareFindingOpts {
   extraAnnotations?: string[];
   citationInput?: Partial<FindingCitation>;
   scope?: string;
+  provenance?: FindingProvenance;
   nowIso?: string;
   inferredRepo?: string;
   headCommit?: string;
@@ -156,7 +160,7 @@ interface PrepareFindingOpts {
 function prepareFinding(
   opts: PrepareFindingOpts,
 ): { status: "added"; finding: PreparedFinding } | { status: "duplicate" } | { status: "rejected"; reason: string } {
-  const { finding: learning, project, fullHistory, extraAnnotations, citationInput, scope, nowIso, inferredRepo, headCommit, phrenPath } = opts;
+  const { finding: learning, project, fullHistory, extraAnnotations, citationInput, scope, provenance, nowIso, inferredRepo, headCommit, phrenPath } = opts;
   const secretType = scanForSecrets(learning);
   if (secretType) {
     return { status: "rejected", reason: `Contains ${secretType}` };
@@ -182,6 +186,8 @@ function prepareFinding(
   let lifecycle: FindingLifecycleMetadata = { status: "active", status_updated: today };
   let bullet = `${normalizedLearning.startsWith("- ") ? normalizedLearning : `- ${normalizedLearning}`} ${fidComment} ${createdComment}`;
   if (scopeComment) bullet += ` ${scopeComment}`;
+  const sourceComment = provenance ? buildSourceComment(provenance) : "";
+  if (sourceComment) bullet += ` ${sourceComment}`;
 
   if (isDuplicateFinding(fullHistory, bullet)) {
     return { status: "duplicate" };
@@ -337,7 +343,7 @@ export function addFindingToFile(
   const result: PhrenResult<AddFindingWriteResult | string> = withFileLock(learningsPath, () => {
     const preparedForNewFile = prepareFinding({
       finding: learning, project, fullHistory: "", extraAnnotations: opts?.extraAnnotations,
-      citationInput: resolvedCitationInput, scope, nowIso, inferredRepo, headCommit, phrenPath,
+      citationInput: resolvedCitationInput, scope, provenance: opts?.provenance, nowIso, inferredRepo, headCommit, phrenPath,
     });
     if (!fs.existsSync(learningsPath)) {
       if (preparedForNewFile.status === "rejected") {
@@ -371,7 +377,7 @@ export function addFindingToFile(
       : content;
     const prepared = prepareFinding({
       finding: learning, project, fullHistory: historyForDedup, extraAnnotations: opts?.extraAnnotations,
-      citationInput: resolvedCitationInput, scope, nowIso, inferredRepo, headCommit, phrenPath,
+      citationInput: resolvedCitationInput, scope, provenance: opts?.provenance, nowIso, inferredRepo, headCommit, phrenPath,
     });
     if (prepared.status === "rejected") {
       return phrenErr(`Rejected: finding appears to contain a secret (${prepared.reason.replace(/^Contains /, "")}). Strip credentials before saving.`, PhrenError.VALIDATION_ERROR);
@@ -466,7 +472,7 @@ export function addFindingsToFile(
   phrenPath: string,
   project: string,
   learnings: string[],
-  opts?: { extraAnnotationsByFinding?: string[][]; sessionId?: string; scope?: string }
+  opts?: { extraAnnotationsByFinding?: string[][]; sessionId?: string; scope?: string; provenance?: FindingProvenance }
 ): PhrenResult<{ added: string[]; skipped: string[]; rejected: { text: string; reason: string }[] }> {
   if (!isValidProjectName(project)) return phrenErr(`Invalid project name: "${project}".`, PhrenError.INVALID_PROJECT_NAME);
   const resolvedDir = safeProjectPath(phrenPath, project);
@@ -501,7 +507,7 @@ export function addFindingsToFile(
         }
         const prepared = prepareFinding({
           finding: learning, project, fullHistory: content, extraAnnotations,
-          citationInput: resolvedCitationInput, scope, nowIso, inferredRepo, headCommit, phrenPath,
+          citationInput: resolvedCitationInput, scope, provenance: opts?.provenance, nowIso, inferredRepo, headCommit, phrenPath,
         });
         if (prepared.status === "rejected") {
           rejected.push({ text: learning, reason: prepared.reason });

--- a/packages/cli/src/data/access.ts
+++ b/packages/cli/src/data/access.ts
@@ -101,6 +101,10 @@ export interface FindingItem {
   taskItem?: string;
   confidence?: number;
   scope?: string;
+  /** Machine hostname where this finding was originally recorded. */
+  machine?: string;
+  /** Actor (username) who recorded this finding. */
+  actor?: string;
   /** First 60 chars of the newer finding that supersedes this one. Set when this finding is stale. */
   supersededBy?: string;
   /** First 60 chars of the older finding this one replaces. */
@@ -323,7 +327,10 @@ export function readFindings(phrenPath: string, project: string, opts: ReadFindi
     const next = lines[i + 1] || "";
     const citation = isCitationLine(next) ? next.trim() : undefined;
     const citationData = citation ? parseCitationComment(citation) ?? undefined : undefined;
-    const scope = parseScopeComment(line) ?? parseSourceComment(line)?.scope;
+    const provenance = parseSourceComment(line);
+    const scope = parseScopeComment(line) ?? provenance?.scope;
+    const machine = provenance?.machine;
+    const actor = provenance?.actor;
     const stableId = parseFindingId(line);
     const rawText = line.replace(/^-\s+/, "").trim();
     const textWithoutComments = stripComments(rawText);
@@ -349,6 +356,8 @@ export function readFindings(phrenPath: string, project: string, opts: ReadFindi
       citationData,
       taskItem: citationData?.task_item,
       scope,
+      machine,
+      actor,
       supersededBy: supersededByMatch ? supersededByMatch[1] : undefined,
       supersedes: supersedesMatch ? supersedesMatch[1] : undefined,
       contradicts: contradictsMatches.length > 0 ? contradictsMatches : undefined,

--- a/packages/cli/src/finding/journal.ts
+++ b/packages/cli/src/finding/journal.ts
@@ -5,7 +5,8 @@ import { runtimeDir, PhrenResult, phrenOk, phrenErr, PhrenError, atomicWriteText
 import { withFileLock } from "../shared/governance.js";
 import { addFindingToFile } from "../shared/content.js";
 import { isValidProjectName, errorMessage } from "../utils.js";
-import type { FindingProvenanceSource } from "../content/citation.js";
+import { buildSourceComment, type FindingProvenanceSource } from "../content/citation.js";
+import { getCurrentActor } from "../machine-identity.js";
 import { FINDINGS_FILENAME } from "../data/access.js";
 
 interface FindingJournalEntry {
@@ -154,8 +155,9 @@ export function appendTeamJournal(
   project: string,
   finding: string,
   actor?: string,
+  machine?: string,
 ): PhrenResult<string> {
-  const resolvedActor = actor || process.env.PHREN_ACTOR || process.env.USER || "unknown";
+  const resolvedActor = actor || getCurrentActor();
   const date = new Date().toISOString().slice(0, 10);
   const journalDir = path.join(storePath, project, TEAM_JOURNAL_DIR);
   const journalFile = `${date}-${resolvedActor}.md`;
@@ -163,7 +165,8 @@ export function appendTeamJournal(
 
   try {
     fs.mkdirSync(journalDir, { recursive: true });
-    const entry = `- ${finding}\n`;
+    const sourceComment = buildSourceComment({ source: "human", machine, actor: resolvedActor });
+    const entry = `- ${finding}${sourceComment ? ` ${sourceComment}` : ""}\n`;
     if (fs.existsSync(journalPath)) {
       fs.appendFileSync(journalPath, entry);
     } else {
@@ -227,7 +230,9 @@ export function materializeTeamFindings(
     lines.push(`## ${date}`);
     for (const { actor, entries } of actors) {
       for (const entry of entries) {
-        lines.push(`- ${entry} <!-- author:${actor} -->`);
+        const hasSource = /<!--\s*source:.*?-->/.test(entry);
+        const fallback = hasSource ? "" : ` ${buildSourceComment({ source: "human", actor })}`;
+        lines.push(`- ${entry}${fallback}`);
         count++;
       }
     }

--- a/packages/cli/src/machine-identity.ts
+++ b/packages/cli/src/machine-identity.ts
@@ -17,17 +17,25 @@ export function defaultMachineName(): string {
   return os.hostname();
 }
 
+let cachedMachineName: string | null = null;
+
 export function getMachineName(): string {
+  if (cachedMachineName !== null) return cachedMachineName;
   const filePath = machineFilePath();
   if (fs.existsSync(filePath)) {
     const persisted = fs.readFileSync(filePath, "utf8").trim();
-    if (persisted) return persisted;
+    if (persisted) return (cachedMachineName = persisted);
   }
-  return defaultMachineName();
+  return (cachedMachineName = defaultMachineName());
 }
 
 export function persistMachineName(machine: string): void {
   const normalized = machine.trim();
   if (!normalized) return;
   atomicWriteText(machineFilePath(), `${normalized}\n`);
+  cachedMachineName = normalized;
+}
+
+export function getCurrentActor(): string {
+  return process.env.PHREN_ACTOR || process.env.USER || "unknown";
 }

--- a/packages/cli/src/shared/index.ts
+++ b/packages/cli/src/shared/index.ts
@@ -75,6 +75,7 @@ import { isInactiveFindingLine } from "../finding/lifecycle.js";
 import { invalidateDfCache } from "./search-fallback.js";
 import { errorMessage } from "../utils.js";
 import { logger } from "../logger.js";
+import { formatActorAttribution, parseSourceComment } from "../content/citation.js";
 import {
   beginUserFragmentBuildCache,
   endUserFragmentBuildCache,
@@ -583,7 +584,10 @@ export function normalizeIndexedContent(content: string, type: string, phrenPath
     .replace(/<!-- phren:archive:start -->[\s\S]*?<!-- phren:archive:end -->/g, "")
     .replace(/<details>[\s\S]*?<\/details>/gi, "")
     .replace(/<!--\s*created:\s*.*?-->/g, "")
-    .replace(/<!--\s*source:\s*.*?-->/g, "")
+    .replace(/<!--\s*source:.*?-->/g, (match) => {
+      const parsed = parseSourceComment(match);
+      return formatActorAttribution(parsed?.actor, parsed?.machine);
+    })
     .replace(/<!--\s*phren:cite\s+\{[\s\S]*?\}\s*-->/g, "");
   normalized = resolveImports(normalized, phrenPath);
   if (type === "task") {

--- a/packages/cli/src/tools/finding.ts
+++ b/packages/cli/src/tools/finding.ts
@@ -15,6 +15,8 @@ import {
   FINDING_TYPES,
   normalizeMemoryScope,
 } from "../shared.js";
+import { getCurrentActor, getMachineName } from "../machine-identity.js";
+import { type FindingProvenance } from "../content/citation.js";
 import {
   addFindingToFile,
   addFindingsToFile,
@@ -149,6 +151,13 @@ async function handleAddFinding(
   const addFindingDenied = permissionDeniedError(phrenPath, "add_finding", project);
   if (addFindingDenied) return mcpResponse({ ok: false, error: addFindingDenied });
 
+  const provenance: FindingProvenance = {
+    source: "human",
+    machine: getMachineName(),
+    actor: getCurrentActor(),
+    session_id: sessionId,
+  };
+
   // Team stores: use append-only journal (no FINDINGS.md mutation, no merge conflicts)
   {
     const storeResolved = resolveStoreForProject(ctx, params.project);
@@ -158,7 +167,7 @@ async function handleAddFinding(
       const added: string[] = [];
       for (const f of findings) {
         const taggedFinding = findingType ? `[${findingType}] ${f}` : f;
-        const result = appendTeamJournal(phrenPath, project, taggedFinding);
+        const result = appendTeamJournal(phrenPath, project, taggedFinding, provenance.actor, provenance.machine);
         if (result.ok) added.push(taggedFinding);
       }
       return mcpResponse({
@@ -195,6 +204,7 @@ async function handleAddFinding(
         extraAnnotationsByFinding,
         sessionId,
         scope: normalizedScope,
+        provenance,
       });
       if (!result.ok) return mcpResponse({ ok: false, error: result.error });
       const { added, skipped, rejected } = result.data;
@@ -232,6 +242,7 @@ async function handleAddFinding(
         sessionId,
         scope: normalizedScope,
         extraAnnotations: semanticConflicts.checked ? semanticConflicts.annotations : undefined,
+        provenance,
       });
       if (!result.ok) {
         return mcpResponse({ ok: false, error: result.error });

--- a/packages/cli/src/tools/search.ts
+++ b/packages/cli/src/tools/search.ts
@@ -35,7 +35,7 @@ import { runCustomHooks } from "../hooks.js";
 import { entryScoreKey, getQualityMultiplier, getRetentionPolicy } from "../shared/governance.js";
 import { callLlm } from "../content/dedup.js";
 import { rankResults, searchKnowledgeRows, applyTrustFilter, searchFederatedStores, type FederatedDocRow } from "../shared/retrieval.js";
-import { parseScopeComment, parseSourceComment } from "../content/citation.js";
+import { formatActorAttribution, parseScopeComment, parseSourceComment } from "../content/citation.js";
 import { resolveActiveSessionScope } from "./session.js";
 import { logger } from "../logger.js";
 
@@ -726,7 +726,8 @@ async function handleGetFindings(
     if (entry.contradicts?.length) metadata.push(`contradicts=${entry.contradicts.length}`);
     if (entry.tier === "archived") metadata.push("tier=archived");
     const idLabel = entry.stableId ? `${entry.id}|fid:${entry.stableId}` : entry.id;
-    return `- [${idLabel}] ${entry.date}: ${entry.text}${entry.confidence !== undefined ? ` [confidence ${entry.confidence.toFixed(2)}]` : ""}${metadata.length > 0 ? ` [${metadata.join(" ")}]` : ""}${entry.citation ? ` (${entry.citation})` : ""}`;
+    const attribution = formatActorAttribution(entry.actor, entry.machine);
+    return `- [${idLabel}] ${entry.date}: ${entry.text}${attribution ? ` ${attribution}` : ""}${entry.confidence !== undefined ? ` [confidence ${entry.confidence.toFixed(2)}]` : ""}${metadata.length > 0 ? ` [${metadata.join(" ")}]` : ""}${entry.citation ? ` (${entry.citation})` : ""}`;
   });
   const hiddenHistoryCount = includeHistory ? 0 : historyCount;
   const historyNote = hiddenHistoryCount > 0 ? ` (${hiddenHistoryCount} historical hidden)` : "";


### PR DESCRIPTION
## Summary

Findings now carry inline `<!-- source:human machine:X actor:Y -->` metadata so teammates can tell who recorded a finding on which machine before assuming machine-specific knowledge applies to them.

**Problem:** When team members share a phren team store, machine-specific knowledge (local tool paths, installed software, credentials) gets written as team-wide findings. Other teammates read these and assume they apply universally.

**Fix:** Every finding now carries `actor` + `machine` provenance at write time. At read time, `get_findings`, `search_knowledge`, and the per-prompt phren-context injection all surface `[from:actor@machine]` so Claude (and humans) know to verify before assuming applicability. Findings without attribution are implicitly team-verified (the convention).

## What changed

- `add_finding` captures machine + actor automatically on both single-store and team-store (journal) write paths
- `get_findings` MCP output appends `[from:actor@machine]`
- FTS5 indexer transforms `<!-- source:... -->` into `[from:actor@machine]` so search snippets and hook context injection also carry attribution
- `materializeTeamFindings` now relies on the embedded source comment, with a fallback that injects one from the journal filename actor for older entries (replaces non-standard `<!-- author:X -->` emission that nothing parsed)
- `getMachineName()` caches at module level (no longer per-call file I/O)
- New helpers: `formatActorAttribution()`, `getCurrentActor()`

Bumps `@phren/cli` to **0.1.24**.

## Files

| File | What |
|------|------|
| `content/citation.ts` | `formatActorAttribution()` helper |
| `content/learning.ts` | `provenance?: FindingProvenance` plumbed through `AddFindingOptions` / `addFindingsToFile`; bullet now appends `buildSourceComment(provenance)` |
| `data/access.ts` | `FindingItem.machine` + `FindingItem.actor` parsed via existing `parseSourceComment()` call |
| `finding/journal.ts` | `appendTeamJournal` accepts machine, embeds source comment; `materializeTeamFindings` injects fallback for old entries |
| `machine-identity.ts` | Cached `getMachineName()`; new `getCurrentActor()` |
| `shared/index.ts` | FTS5 indexer transforms source comment → `[from:...]` instead of stripping |
| `tools/finding.ts` | Captures provenance, passes to all three write paths |
| `tools/search.ts` | `get_findings` output uses `formatActorAttribution()` |

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm -w test` — all 2546 tests pass (verified on dirty branch; rerunning on clean branch)
- [x] Single-finding `add_finding` writes `<!-- source:... -->` inline (manual)
- [x] `get_findings` output shows `[from:actor@machine]` (manual)
- [x] Old journal entries without source comment get fallback injected during materialize (verified by code review)
- [ ] Team store: write a finding, run `materializeTeamFindings`, confirm attribution survives