### PR TITLE
fix: auto-extract noise sweep (0.1.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-05-03
+
+### Fixed
+
+Auto-extract noise sweep — seven targeted bugs that filled review queues and task lists with garbage at `proactivity*=high`. Each fix has a regression test.
+
+- **`extractToolFindings` reads tool exit codes instead of grepping stdout for "error".** Pre-fix any Bash response containing the word `error`/`failed`/`ENOENT` produced a `[bug] command 'X' failed:` candidate — `ls` listing a file named `error.js`, `grep` returning exit 1 because nothing matched, `curl` printing `failed` in a JSON body, all became phantom bugs. Now reads `tool_response.is_error` / `exit_code` and only emits when there's a definite error signal. Adds a noisy-command allowlist (`grep`/`rg`/`find`/`test`/`[`/`pgrep`/`git diff --quiet`/anything piped through `|| true` or `2>/dev/null`) so non-zero exits from those commands no longer count.
+- **Removed the `error handling added near "..."` pitfall heuristic.** Adding a `try`/`catch` block in an `Edit` or `Write` is normal code, not a pitfall — the heuristic produced ~21 false positives for every real one in observed stores. Deleted outright.
+- **`EXPLICIT_TAG_PATTERN` ignores markdown link/anchor patterns.** A README TOC like `- [Architecture](#architecture)` used to match the regex and emit `[architecture] (#architecture)` review-queue rows. Added negative lookahead `(?!\(|\[)` after the closing `]` so markdown links and reference links no longer pollute the queue.
+- **`add_finding` no longer double-prepends a tag** when the finding text already starts with one. `add_finding({finding: "[pattern] foo", findingType: "pattern"})` now stores `[pattern] foo`, not `[pattern] [pattern] foo`. Same path produced `[bug] [critical bug]` and `[pitfall] [pitfall]` rows in the wild. New `applyFindingTypePrefix` helper centralizes the guard across all three call sites (single, bulk, team-store).
+- **`update_task` priority tag is now idempotent.** `stripPriorityTag` looped only once and required `[pinned]` (if present) to be the absolute last token, so a pinned task accumulated one extra `[high]` per priority update. Observed: 48× `[high]` on a single deltek-ops task. Strip now repeats until no further trailing priority tag can be removed; `normalizeTaskItemLine` strips `[pinned]` first so the priority strip can clear ALL trailing priority tags in one pass.
+- **Zombie blocked-task prevention.** `finalizeTaskSession` used to promote the user's tracked task to Active and stamp it `Blocked: Command failed: git add -A` on transient git auto-stage failures, leaving a permanent task that re-blocked every subsequent session. Now detects `Command failed: git (add|commit|push|stage|pull|fetch|stash)` patterns and skips the update entirely; the task captured for the user's prompt stays as it was.
+- **Substance gate in `isActionablePrompt`.** At `proactivityTasks=high` the lifecycle captured nearly any prompt that wasn't an exact match against `CONVERSATIONAL_NOISE_RE`. Observed in the wild: `Bro`, `<`, `OK`, `IDK man`, `Yeah do that`, `Here's the thing`, `Need this fixed`, `I just clicked on to this page` — all became permanent tasks. New floor (4+ words, 12+ chars, plus at least one signal: actionable verb / path-like fragment / `#N` / 4+ digit ticket / file extension / URL) runs before the intent branch; independent of the proactivity dial.
+
+### Migrated
+
+- `phren doctor` gained a `zombie-blocked-tasks` check that scans every project's `tasks.md` for Active items whose `Context:` line matches the legacy `Blocked: Command failed: git ...` shape. Reports the count by default; with `--fix`, archives them to `## Done` with a `<!-- phren: archived zombie git-failure block -->` comment so they stop bubbling up.
+
 ## [0.1.24] - 2026-04-27
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/data-tasks.test.ts
+++ b/packages/cli/src/__tests__/data-tasks.test.ts
@@ -608,6 +608,37 @@ describe("updateTask", () => {
     expect(item?.priority).toBe("high");
   });
 
+  it("idempotent: priority tag does not accumulate across repeated updates", () => {
+    // Regression for the 48× [high] bug: stripPriorityTag failed to remove the trailing
+    // tag when it was followed by [pinned], so each update appended another [high].
+    writeTaskFile(SAMPLE_TASKS);
+    for (let i = 0; i < 50; i++) {
+      const r = updateTask(tmpDir, PROJECT, "Add rate limiting", { priority: "high" });
+      expect(r.ok).toBe(true);
+    }
+    const raw = fs.readFileSync(path.join(tmpDir, PROJECT, "tasks.md"), "utf-8");
+    const matchingLine = raw.split("\n").find((l) => l.includes("rate limiting"));
+    expect(matchingLine).toBeDefined();
+    const occurrences = matchingLine!.match(/\[high\]/g)?.length ?? 0;
+    expect(occurrences).toBe(1);
+    expect(matchingLine).not.toContain("[high] [high]");
+  });
+
+  it("idempotent: priority tag does not accumulate when [pinned] is also present", () => {
+    // Pin then repeatedly bump priority — the [pinned] used to block the trailing-tag
+    // strip, so accumulated [high]s sat between the text and [pinned].
+    writeTaskFile(SAMPLE_TASKS);
+    pinTask(tmpDir, PROJECT, "Add rate limiting");
+    for (let i = 0; i < 30; i++) {
+      updateTask(tmpDir, PROJECT, "Add rate limiting", { priority: "high" });
+    }
+    const raw = fs.readFileSync(path.join(tmpDir, PROJECT, "tasks.md"), "utf-8");
+    const matchingLine = raw.split("\n").find((l) => l.includes("rate limiting"));
+    expect(matchingLine).toBeDefined();
+    expect(matchingLine!.match(/\[high\]/g)?.length ?? 0).toBe(1);
+    expect(matchingLine!.match(/\[pinned\]/g)?.length ?? 0).toBe(1);
+  });
+
   it("moves task to different section", () => {
     writeTaskFile(SAMPLE_TASKS);
     const result = updateTask(tmpDir, PROJECT, "Add rate limiting", { section: "Active" });

--- a/packages/cli/src/__tests__/finding-types.test.ts
+++ b/packages/cli/src/__tests__/finding-types.test.ts
@@ -178,3 +178,35 @@ describe("typed findings (decision|pitfall|pattern)", () => {
     expect(content).toContain("[pattern]");
   });
 });
+
+// ── findingType prefix application ──────────────────────────────────────────
+// Regression guard for the "doubled tag" bug where add_finding(finding="[pattern] X",
+// findingType="pattern") used to store "[pattern] [pattern] X". Same shape produced
+// "[bug] [critical bug]" and "[pitfall] [pitfall]" rows in the wild.
+
+describe("applyFindingTypePrefix", () => {
+  it("prepends findingType when text has no tag", async () => {
+    const { applyFindingTypePrefix } = await import("../core/finding.js");
+    expect(applyFindingTypePrefix("plain text", "pattern")).toBe("[pattern] plain text");
+  });
+
+  it("does not double-prepend when text already starts with the same tag", async () => {
+    const { applyFindingTypePrefix } = await import("../core/finding.js");
+    expect(applyFindingTypePrefix("[pattern] foo", "pattern")).toBe("[pattern] foo");
+  });
+
+  it("preserves a user-supplied refinement tag instead of replacing it", async () => {
+    const { applyFindingTypePrefix } = await import("../core/finding.js");
+    expect(applyFindingTypePrefix("[critical bug] X", "bug")).toBe("[critical bug] X");
+  });
+
+  it("returns text unchanged when findingType is undefined", async () => {
+    const { applyFindingTypePrefix } = await import("../core/finding.js");
+    expect(applyFindingTypePrefix("plain text", undefined)).toBe("plain text");
+  });
+
+  it("handles leading whitespace before existing tag", async () => {
+    const { applyFindingTypePrefix } = await import("../core/finding.js");
+    expect(applyFindingTypePrefix("  [pattern] foo", "pattern")).toBe("  [pattern] foo");
+  });
+});

--- a/packages/cli/src/__tests__/task-lifecycle-proactivity.test.ts
+++ b/packages/cli/src/__tests__/task-lifecycle-proactivity.test.ts
@@ -220,4 +220,76 @@ describe("task lifecycle task proactivity gating", () => {
     expect(task.data.items.Active).toHaveLength(0);
     expect(task.data.items.Queue).toHaveLength(0);
   });
+
+  // ── Substance gate (regression for the conversational-fragment task spam) ────
+  // At proactivityTasks=high the task lifecycle used to capture every prompt that
+  // wasn't an exact match against CONVERSATIONAL_NOISE_RE. That left fragments like
+  // "I just clicked on to this page", "Here's the thing", "Need this fixed", "<"
+  // in tasks.md. The substance gate (min words + min chars + signal verb / path /
+  // ticket / file extension / URL) rejects them all without losing real tasks.
+
+  const observedJunkPrompts = [
+    "Bro",
+    "Here's the thing",
+    "I just clicked on to this page",
+    "Need this fixed",
+    "OK",
+    "<",
+    "IDK man",
+    "Yeah do that",
+    "Wait why are those hiding by preference",
+  ];
+
+  for (const junk of observedJunkPrompts) {
+    it(`substance gate at high rejects: "${junk}"`, () => {
+      process.env.PHREN_PROACTIVITY_TASKS = "high";
+      const result = handleTaskPromptLifecycle({
+        phrenPath: tmp.path,
+        prompt: junk,
+        project,
+        sessionId: `session-junk-${junk.slice(0, 4)}`,
+        intent: "general",
+        taskLevel: "high",
+      });
+      expect(result.noticeLines).toEqual([]);
+      const tasks = readTasks(tmp.path, project);
+      expect(tasks.ok).toBe(true);
+      if (!tasks.ok) return;
+      expect(tasks.data.items.Active).toHaveLength(0);
+    });
+  }
+
+  it("substance gate accepts a real ticket-referenced prompt", () => {
+    process.env.PHREN_PROACTIVITY_TASKS = "high";
+    const result = handleTaskPromptLifecycle({
+      phrenPath: tmp.path,
+      prompt: "Investigate ticket 43062 — Power Portal reports tile not loading",
+      project,
+      sessionId: "session-real-ticket",
+      intent: "general",
+      taskLevel: "high",
+    });
+    const tasks = readTasks(tmp.path, project);
+    expect(tasks.ok).toBe(true);
+    if (!tasks.ok) return;
+    expect(tasks.data.items.Active).toHaveLength(1);
+    expect(result.noticeLines.join("\n")).toContain("Active task");
+  });
+
+  it("substance gate accepts a file-path-referenced prompt", () => {
+    process.env.PHREN_PROACTIVITY_TASKS = "high";
+    const result = handleTaskPromptLifecycle({
+      phrenPath: tmp.path,
+      prompt: "Update the regex in src/utils.ts to handle empty input",
+      project,
+      sessionId: "session-real-path",
+      intent: "general",
+      taskLevel: "high",
+    });
+    const tasks = readTasks(tmp.path, project);
+    expect(tasks.ok).toBe(true);
+    if (!tasks.ok) return;
+    expect(tasks.data.items.Active).toHaveLength(1);
+    expect(result.noticeLines.join("\n")).toContain("Active task");
+  });
 });

--- a/packages/cli/src/beta-hooks.test.ts
+++ b/packages/cli/src/beta-hooks.test.ts
@@ -245,27 +245,81 @@ describe("extractToolFindings", () => {
     expect(todo!.confidence).toBe(0.45);
   });
 
-  it("extracts try/catch pattern from Write tool input", () => {
+  it("does not emit a pitfall for try/catch additions (heuristic deleted)", () => {
+    // Adding error handling is normal code, not a pitfall. The old heuristic produced
+    // ~21 false positives for every real one in observed stores; it's removed in 0.1.25.
     const candidates = extractToolFindings(
       "Write",
       { file_path: "/src/handler.ts", content: "try {\n  await fetchData();\n} catch (err) {\n  log(err);\n}" },
       "ok"
     );
-    const tryCatch = candidates.find((c) => c.text.includes("error handling added"));
-    expect(tryCatch).toBeDefined();
-    expect(tryCatch!.confidence).toBe(0.45);
+    const errorHandling = candidates.find((c) => c.text.includes("error handling added"));
+    expect(errorHandling).toBeUndefined();
   });
 
-  it("extracts Bash error candidates", () => {
+  it("emits [bug] for Bash with explicit is_error signal on a non-noisy command", () => {
     const candidates = extractToolFindings(
       "Bash",
       { command: "npm run build" },
-      "Error: Cannot find module '@/utils'\n  at Module._resolveFilename"
+      "Error: Cannot find module '@/utils'\n  at Module._resolveFilename",
+      { is_error: true, stdout: "", stderr: "Error: Cannot find module" }
     );
     const bug = candidates.find((c) => c.text.includes("[bug]"));
     expect(bug).toBeDefined();
     expect(bug!.confidence).toBe(0.55);
     expect(bug!.text).toContain("npm run build");
+  });
+
+  it("does NOT emit [bug] for Bash without an explicit error signal (no exit_code, no is_error)", () => {
+    // Pre-0.1.25 this matched the word "error" in stdout and produced a [bug].
+    // grep/find/curl etc. routinely contain "error" in their output without failing.
+    const candidates = extractToolFindings(
+      "Bash",
+      { command: "ls /src" },
+      "error.js\nhandler.js"
+    );
+    expect(candidates.find((c) => c.text.startsWith("[bug] command"))).toBeUndefined();
+  });
+
+  it("does NOT emit [bug] for grep with exit_code=1 (no-match is not a bug)", () => {
+    const candidates = extractToolFindings(
+      "Bash",
+      { command: "grep -rn 'never-matches' src/" },
+      "",
+      { is_error: true, exit_code: 1, stdout: "", stderr: "" }
+    );
+    expect(candidates.find((c) => c.text.startsWith("[bug] command"))).toBeUndefined();
+  });
+
+  it("does NOT emit [bug] for find with non-zero exit (noisy command allowlist)", () => {
+    const candidates = extractToolFindings(
+      "Bash",
+      { command: "find . -name '*.tmp'" },
+      "find: '/restricted': Permission denied",
+      { is_error: true, exit_code: 1 }
+    );
+    expect(candidates.find((c) => c.text.startsWith("[bug] command"))).toBeUndefined();
+  });
+
+  it("does NOT emit [bug] for `cmd || true` (user already silencing failure)", () => {
+    const candidates = extractToolFindings(
+      "Bash",
+      { command: "rm -f /nonexistent || true" },
+      "rm: cannot remove '/nonexistent': No such file or directory",
+      { is_error: true, exit_code: 1 }
+    );
+    expect(candidates.find((c) => c.text.startsWith("[bug] command"))).toBeUndefined();
+  });
+
+  it("emits [bug] for non-noisy command with non-zero exit_code even without is_error", () => {
+    const candidates = extractToolFindings(
+      "Bash",
+      { command: "cargo test" },
+      "test result: FAILED. 0 passed; 3 failed",
+      { exit_code: 101 }
+    );
+    const bug = candidates.find((c) => c.text.startsWith("[bug] command"));
+    expect(bug).toBeDefined();
   });
 
   it("returns empty for normal successful tool output", () => {

--- a/packages/cli/src/beta-hooks.test.ts
+++ b/packages/cli/src/beta-hooks.test.ts
@@ -338,6 +338,39 @@ describe("extractToolFindings", () => {
     expect(bug!.confidence).toBe(0.85);
   });
 
+  it("does NOT capture markdown TOC anchors as [architecture] (#architecture) entries", () => {
+    // Regression: a README with `- [Architecture](#architecture)` used to match
+    // EXPLICIT_TAG_PATTERN and emit "[architecture] (#architecture)" candidates.
+    const candidates = extractToolFindings(
+      "Read",
+      { file_path: "/repo/README.md" },
+      "## Table of Contents\n- [Architecture](#architecture)\n- [Releases](#releases)\n"
+    );
+    const arch = candidates.find((c) => c.text.includes("(#architecture)"));
+    expect(arch).toBeUndefined();
+  });
+
+  it("does NOT capture markdown reference links as tagged findings", () => {
+    const candidates = extractToolFindings(
+      "Read",
+      { file_path: "/repo/notes.md" },
+      "See [bug][1] for context.\n\n[1]: https://example.com/issue/42\n"
+    );
+    const bug = candidates.find((c) => c.text === "[bug] [1]");
+    expect(bug).toBeUndefined();
+  });
+
+  it("still extracts genuine inline tags when followed by space then content (positive guard)", () => {
+    const candidates = extractToolFindings(
+      "Read",
+      { file_path: "/repo/notes.md" },
+      "Notes: [pattern] Wrap retry budgets per request, never per call site."
+    );
+    const pattern = candidates.find((c) => c.text.startsWith("[pattern]"));
+    expect(pattern).toBeDefined();
+    expect(pattern!.text).toContain("Wrap retry budgets");
+  });
+
   it("prefers changed content over escaped tool-response blobs for Edit explicit tags", () => {
     const candidates = extractToolFindings(
       "Edit",

--- a/packages/cli/src/cli-hooks-prompt.ts
+++ b/packages/cli/src/cli-hooks-prompt.ts
@@ -256,7 +256,7 @@ export async function handleHookTool() {
     if (activeProject && findingsLevelForTool !== "low") {
       try {
         const candidates = filterToolFindingsForProactivity(
-          extractToolFindings(toolName, input, responseStr),
+          extractToolFindings(toolName, input, responseStr, data.tool_response),
           findingsLevelForTool
         );
         for (const { text, confidence } of candidates) {
@@ -317,10 +317,50 @@ export function filterToolFindingsForProactivity(
   return candidates.filter((candidate) => candidate.explicit === true);
 }
 
+// Bash commands whose non-zero exit codes are routine signal, not bugs.
+// grep/rg/ag/find returning exit 1 (no match) is the common case; conditional
+// shell tests evaluating false is another. Don't surface these as findings.
+const NOISY_BASH_COMMAND_PATTERNS: RegExp[] = [
+  /^\s*(?:grep|rg|ag|ack)\b/,
+  /^\s*find\b/,
+  /^\s*which\b/,
+  /^\s*command\s+-v\b/,
+  /^\s*test\b/,
+  /^\s*\[\s/,
+  /^\s*\[\[\s/,
+  /^\s*pgrep\b/,
+  /^\s*pkill\b/,
+  /^\s*git\s+diff\s+--quiet/,
+];
+
+function isNoisyBashCommand(cmd: string): boolean {
+  if (/\|\|\s*true\b/.test(cmd)) return true;
+  if (/2>\s*\/dev\/null/.test(cmd)) return true;
+  return NOISY_BASH_COMMAND_PATTERNS.some((re) => re.test(cmd));
+}
+
+interface ToolErrorSignal {
+  isError: boolean;
+  exitCode?: number;
+  hasExitCode: boolean;
+}
+
+function extractToolErrorSignal(toolResponse: unknown): ToolErrorSignal {
+  if (!toolResponse || typeof toolResponse !== "object") {
+    return { isError: false, hasExitCode: false };
+  }
+  const tr = toolResponse as Record<string, unknown>;
+  const isError = Boolean(tr.is_error ?? tr.isError);
+  const rawExit = tr.exit_code ?? tr.exitCode;
+  const exitCode = typeof rawExit === "number" ? rawExit : undefined;
+  return { isError, exitCode, hasExitCode: exitCode !== undefined };
+}
+
 export function extractToolFindings(
   toolName: string,
   input: Record<string, unknown>,
-  responseStr: string
+  responseStr: string,
+  toolResponse?: unknown
 ): LearningCandidate[] {
   const candidates: LearningCandidate[] = [];
   const changedContent = (toolName === "Edit" || toolName === "Write")
@@ -350,30 +390,28 @@ export function extractToolFindings(
         });
       }
     }
-    if (/\btry\s*\{[\s\S]*?\bcatch\b/.test(changedContent)) {
-      const meaningfulLine = changedContent.split("\n").find(
-        (l) => l.trim().length > 10 && !/^\s*(try|catch|\{|\})/.test(l)
-      );
-      if (meaningfulLine) {
-        candidates.push({
-          text: `[pitfall] ${filename}: error handling added near "${meaningfulLine.trim().slice(0, 100)}"`,
-          confidence: 0.45,
-          explicit: false,
-        });
-      }
-    }
+    // (Removed: try/catch additions used to emit "[pitfall] ... error handling added near ..."
+    //  candidates. Adding error handling is normal code, not a pitfall — the heuristic produced
+    //  ~21 false positives for every real one in observed stores. If we ever need this back,
+    //  gate on a *removed* try/catch, not an added one.)
   }
 
   if (toolName === "Bash") {
-    const cmd = String(input.command ?? "").slice(0, 30);
-    const hasError = /(error|exception|failed|ENOENT|command not found|permission denied)/i.test(responseStr);
-    if (hasError && cmd) {
+    const fullCmd = String(input.command ?? "");
+    const cmdShort = fullCmd.slice(0, 30);
+    const errorSignal = extractToolErrorSignal(toolResponse);
+    // Only emit a [bug] candidate when (a) we have a definite error signal from the tool
+    // result (is_error or non-zero exit_code) and (b) the command isn't a known-noisy one
+    // like grep/find/test where exit 1 just means "didn't match" rather than a failure.
+    const hasDefiniteError = errorSignal.isError || (errorSignal.hasExitCode && (errorSignal.exitCode ?? 0) !== 0);
+    if (hasDefiniteError && cmdShort && !isNoisyBashCommand(fullCmd)) {
       const firstErrorLine = responseStr.split("\n").find(
         (l) => /(error|exception|failed|ENOENT|command not found|permission denied)/i.test(l)
       );
-      if (firstErrorLine) {
+      const detail = (firstErrorLine ?? responseStr.split("\n")[0] ?? "").trim().slice(0, 150);
+      if (detail) {
         candidates.push({
-          text: `[bug] command '${cmd}' failed: ${firstErrorLine.trim().slice(0, 150)}`,
+          text: `[bug] command '${cmdShort}' failed: ${detail}`,
           confidence: 0.55,
           explicit: false,
         });

--- a/packages/cli/src/cli-hooks-prompt.ts
+++ b/packages/cli/src/cli-hooks-prompt.ts
@@ -306,7 +306,11 @@ interface LearningCandidate {
   explicit?: boolean;
 }
 
-const EXPLICIT_TAG_PATTERN = /\[(pitfall|decision|pattern|tradeoff|architecture|bug)\]\s*(.+)/i;
+// Negative lookahead `(?!\(|\[)` rejects markdown link/reference patterns:
+//   [Architecture](#architecture)  ← TOC anchor, content was being captured as "(#architecture)"
+//   [bug][1]                       ← markdown reference link, content was being captured as "[1]"
+// produced garbage review-queue entries like "[architecture] (#architecture)".
+const EXPLICIT_TAG_PATTERN = /\[(pitfall|decision|pattern|tradeoff|architecture|bug)\](?!\(|\[)\s*(.+)/i;
 
 export function filterToolFindingsForProactivity(
   candidates: Array<{ text: string; confidence: number; explicit?: boolean }>,

--- a/packages/cli/src/cli/session-tool-hook.ts
+++ b/packages/cli/src/cli/session-tool-hook.ts
@@ -241,7 +241,11 @@ interface LearningCandidate {
   explicit?: boolean;
 }
 
-const EXPLICIT_TAG_PATTERN = /\[(pitfall|decision|pattern|tradeoff|architecture|bug)\]\s*(.+)/i;
+// Negative lookahead `(?!\(|\[)` rejects markdown link/reference patterns:
+//   [Architecture](#architecture)  ← TOC anchor, content was being captured as "(#architecture)"
+//   [bug][1]                       ← markdown reference link, content was being captured as "[1]"
+// produced garbage review-queue entries like "[architecture] (#architecture)".
+const EXPLICIT_TAG_PATTERN = /\[(pitfall|decision|pattern|tradeoff|architecture|bug)\](?!\(|\[)\s*(.+)/i;
 
 export function filterToolFindingsForProactivity(
   candidates: Array<{ text: string; confidence: number; explicit?: boolean }>,

--- a/packages/cli/src/cli/session-tool-hook.ts
+++ b/packages/cli/src/cli/session-tool-hook.ts
@@ -191,7 +191,7 @@ export async function handleHookTool() {
     if (activeProject && findingsLevelForTool !== "low") {
       try {
         const candidates = filterToolFindingsForProactivity(
-          extractToolFindings(toolName, input, responseStr),
+          extractToolFindings(toolName, input, responseStr, data.tool_response),
           findingsLevelForTool
         );
         for (const { text, confidence } of candidates) {
@@ -252,10 +252,50 @@ export function filterToolFindingsForProactivity(
   return candidates.filter((candidate) => candidate.explicit === true);
 }
 
+// Bash commands whose non-zero exit codes are routine signal, not bugs.
+// grep/rg/ag/find returning exit 1 (no match) is the common case; conditional
+// shell tests evaluating false is another. Don't surface these as findings.
+const NOISY_BASH_COMMAND_PATTERNS: RegExp[] = [
+  /^\s*(?:grep|rg|ag|ack)\b/,
+  /^\s*find\b/,
+  /^\s*which\b/,
+  /^\s*command\s+-v\b/,
+  /^\s*test\b/,
+  /^\s*\[\s/,
+  /^\s*\[\[\s/,
+  /^\s*pgrep\b/,
+  /^\s*pkill\b/,
+  /^\s*git\s+diff\s+--quiet/,
+];
+
+function isNoisyBashCommand(cmd: string): boolean {
+  if (/\|\|\s*true\b/.test(cmd)) return true;
+  if (/2>\s*\/dev\/null/.test(cmd)) return true;
+  return NOISY_BASH_COMMAND_PATTERNS.some((re) => re.test(cmd));
+}
+
+interface ToolErrorSignal {
+  isError: boolean;
+  exitCode?: number;
+  hasExitCode: boolean;
+}
+
+function extractToolErrorSignal(toolResponse: unknown): ToolErrorSignal {
+  if (!toolResponse || typeof toolResponse !== "object") {
+    return { isError: false, hasExitCode: false };
+  }
+  const tr = toolResponse as Record<string, unknown>;
+  const isError = Boolean(tr.is_error ?? tr.isError);
+  const rawExit = tr.exit_code ?? tr.exitCode;
+  const exitCode = typeof rawExit === "number" ? rawExit : undefined;
+  return { isError, exitCode, hasExitCode: exitCode !== undefined };
+}
+
 export function extractToolFindings(
   toolName: string,
   input: Record<string, unknown>,
-  responseStr: string
+  responseStr: string,
+  toolResponse?: unknown
 ): LearningCandidate[] {
   const candidates: LearningCandidate[] = [];
   const changedContent = (toolName === "Edit" || toolName === "Write")
@@ -285,30 +325,27 @@ export function extractToolFindings(
         });
       }
     }
-    if (/\btry\s*\{[\s\S]*?\bcatch\b/.test(changedContent)) {
-      const meaningfulLine = changedContent.split("\n").find(
-        (l) => l.trim().length > 10 && !/^\s*(try|catch|\{|\})/.test(l)
-      );
-      if (meaningfulLine) {
-        candidates.push({
-          text: `[pitfall] ${filename}: error handling added near "${meaningfulLine.trim().slice(0, 100)}"`,
-          confidence: 0.45,
-          explicit: false,
-        });
-      }
-    }
+    // (Removed: try/catch additions used to emit "[pitfall] ... error handling added near ..."
+    //  candidates. Adding error handling is normal code, not a pitfall — the heuristic produced
+    //  ~21 false positives for every real one in observed stores.)
   }
 
   if (toolName === "Bash") {
-    const cmd = String(input.command ?? "").slice(0, 30);
-    const hasError = /(error|exception|failed|ENOENT|command not found|permission denied)/i.test(responseStr);
-    if (hasError && cmd) {
+    const fullCmd = String(input.command ?? "");
+    const cmdShort = fullCmd.slice(0, 30);
+    const errorSignal = extractToolErrorSignal(toolResponse);
+    // Only emit a [bug] candidate when (a) we have a definite error signal from the tool
+    // result (is_error or non-zero exit_code) and (b) the command isn't a known-noisy one
+    // like grep/find/test where exit 1 just means "didn't match".
+    const hasDefiniteError = errorSignal.isError || (errorSignal.hasExitCode && (errorSignal.exitCode ?? 0) !== 0);
+    if (hasDefiniteError && cmdShort && !isNoisyBashCommand(fullCmd)) {
       const firstErrorLine = responseStr.split("\n").find(
         (l) => /(error|exception|failed|ENOENT|command not found|permission denied)/i.test(l)
       );
-      if (firstErrorLine) {
+      const detail = (firstErrorLine ?? responseStr.split("\n")[0] ?? "").trim().slice(0, 150);
+      if (detail) {
         candidates.push({
-          text: `[bug] command '${cmd}' failed: ${firstErrorLine.trim().slice(0, 150)}`,
+          text: `[bug] command '${cmdShort}' failed: ${detail}`,
           confidence: 0.55,
           explicit: false,
         });

--- a/packages/cli/src/core/finding.ts
+++ b/packages/cli/src/core/finding.ts
@@ -13,6 +13,20 @@ interface FindingResult {
   data?: unknown;
 }
 
+const FINDING_TAG_PREFIX_RE = /^\s*\[[^\]]+\]\s*/;
+
+/**
+ * Prepend `[findingType]` to a finding only when the text doesn't already
+ * start with a bracketed tag. Prevents accumulation like `[pattern] [pattern] X`
+ * when callers pass both `findingType` and a finding that's already tagged
+ * (a common shape — many MCP callers prefix manually for human readability).
+ */
+export function applyFindingTypePrefix(finding: string, findingType?: string): string {
+  if (!findingType) return finding;
+  if (FINDING_TAG_PREFIX_RE.test(finding)) return finding;
+  return `[${findingType}] ${finding}`;
+}
+
 /**
  * Validate and add a single finding. Shared validation logic used by
  * both CLI `phren add-finding` and MCP `add_finding` tool.
@@ -31,7 +45,7 @@ export function addFinding(
     return { ok: false, message: `Finding text exceeds ${MAX_FINDING_LENGTH} character limit.` };
   }
 
-  const taggedFinding = findingType ? `[${findingType}] ${finding}` : finding;
+  const taggedFinding = applyFindingTypePrefix(finding, findingType);
   const result = addFindingToFile(phrenPath, project, taggedFinding, citation);
   if (!result.ok) {
     return { ok: false, message: result.error };

--- a/packages/cli/src/data/tasks.ts
+++ b/packages/cli/src/data/tasks.ts
@@ -63,10 +63,16 @@ function normalizePriority(text: string): "high" | "medium" | "low" | undefined 
 }
 
 function stripPriorityTag(text: string): string {
-  return text
-    .replace(/\s*\[(high|medium|low)\](?=\s*(?:\[pinned\])?\s*$)/gi, "")
-    .replace(/\s{2,}/g, " ")
-    .trim();
+  // Strip ALL trailing priority tags (with optional [pinned] interleaved or at the end).
+  // Previous regex only stripped the last one and required [pinned] (if present) to be the
+  // final token — meaning accumulated `[high] [high] ... [pinned]` only lost one tag per
+  // call, so each updateTask grew the line by one tag (observed: 48× [high] on one task).
+  let prev: string;
+  do {
+    prev = text;
+    text = text.replace(/\s*\[(high|medium|low)\](?=\s*(?:\[pinned\])?\s*$)/gi, "");
+  } while (text !== prev);
+  return text.replace(/\s{2,}/g, " ").trim();
 }
 
 function detectPinned(text: string): boolean {
@@ -232,7 +238,10 @@ export function resolveTaskFilePath(phrenPath: string, project: string): string 
 }
 
 function normalizeTaskItemLine(item: TaskItem): string {
-  let text = stripPinnedTag(item.line.replace(/\s*\[(high|medium|low)\]\s*$/gi, "")).trim();
+  // Strip pinned first so the priority strip can clear ALL trailing priority tags
+  // (otherwise [pinned] sat between accumulated [high]s and the end-anchor, leaking
+  // one tag per render — see stripPriorityTag for the pre-fix shape).
+  let text = stripPinnedTag(item.line).replace(/(\s*\[(high|medium|low)\])+\s*$/gi, "").trim();
   if (item.priority) text = `${text} [${item.priority}]`;
   if (item.pinned) text = `${text} [pinned]`;
   const prefix = item.checked || item.section === "Done" ? "- [x] " : "- [ ] ";

--- a/packages/cli/src/link.test.ts
+++ b/packages/cli/src/link.test.ts
@@ -833,6 +833,89 @@ describe("link", () => {
       expect(fs.existsSync(path.join(phrenPath, ".runtime"))).toBe(true);
       expect(fs.existsSync(path.join(phrenPath, ".config"))).toBe(true);
     });
+
+    it("detects zombie blocked tasks and reports without --fix", async () => {
+      const profilesDir = path.join(phrenPath, "profiles");
+      fs.mkdirSync(profilesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(profilesDir, "test.yaml"),
+        yaml.dump({ name: "test", description: "T", projects: ["zproj"] })
+      );
+      fs.writeFileSync(path.join(phrenPath, "machines.yaml"), `${getMachineName()}: test\n`);
+      const projDir = path.join(phrenPath, "zproj");
+      fs.mkdirSync(projDir, { recursive: true });
+      fs.writeFileSync(path.join(projDir, "phren.project.yaml"), "ownership: detached\n");
+      fs.writeFileSync(path.join(projDir, "tasks.md"), [
+        "# zproj tasks",
+        "",
+        "## Active",
+        "",
+        "- [ ] Real task that should stay <!-- bid:aaaaaaaa rank:1 -->",
+        "  Context: Some real context",
+        "- [ ] Zombie one <!-- bid:bbbbbbbb rank:2 -->",
+        "  Context: Blocked: Command failed: git add -A",
+        "- [ ] Zombie two <!-- bid:cccccccc rank:3 -->",
+        "  Context: Blocked: Command failed: git commit",
+        "",
+        "## Queue",
+        "",
+        "## Done",
+        "",
+      ].join("\n"));
+
+      const result = await runDoctor(phrenPath, false);
+      const zombieCheck = result.checks.find((c) => c.name === "zombie-blocked-tasks");
+      expect(zombieCheck).toBeDefined();
+      expect(zombieCheck!.ok).toBe(false);
+      expect(zombieCheck!.detail).toContain("2 zombie");
+      // File untouched without --fix.
+      const after = fs.readFileSync(path.join(projDir, "tasks.md"), "utf8");
+      expect(after).toContain("Zombie one");
+      expect(after).toContain("Zombie two");
+    });
+
+    it("--fix archives zombie blocked tasks to Done", async () => {
+      const profilesDir = path.join(phrenPath, "profiles");
+      fs.mkdirSync(profilesDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(profilesDir, "test.yaml"),
+        yaml.dump({ name: "test", description: "T", projects: ["zproj"] })
+      );
+      fs.writeFileSync(path.join(phrenPath, "machines.yaml"), `${getMachineName()}: test\n`);
+      const projDir = path.join(phrenPath, "zproj");
+      fs.mkdirSync(projDir, { recursive: true });
+      fs.writeFileSync(path.join(projDir, "phren.project.yaml"), "ownership: detached\n");
+      fs.writeFileSync(path.join(projDir, "tasks.md"), [
+        "# zproj tasks",
+        "",
+        "## Active",
+        "",
+        "- [ ] Real task <!-- bid:aaaaaaaa rank:1 -->",
+        "  Context: Some real context",
+        "- [ ] Zombie <!-- bid:bbbbbbbb rank:2 -->",
+        "  Context: Blocked: Command failed: git add -A",
+        "",
+        "## Queue",
+        "",
+        "## Done",
+        "",
+      ].join("\n"));
+
+      const result = await runDoctor(phrenPath, true);
+      const zombieCheck = result.checks.find((c) => c.name === "zombie-blocked-tasks");
+      expect(zombieCheck).toBeDefined();
+      expect(zombieCheck!.ok).toBe(true);
+      expect(zombieCheck!.detail).toContain("archived 1");
+
+      const after = fs.readFileSync(path.join(projDir, "tasks.md"), "utf8");
+      // Active still has the real task.
+      expect(after).toMatch(/## Active[\s\S]*Real task/);
+      // Done has the archived zombie marked [x] with the phren-managed comment.
+      expect(after).toMatch(/## Done[\s\S]*- \[x\] Zombie[\s\S]*phren: archived zombie git-failure block/);
+      // Active no longer contains the zombie.
+      const activeSection = after.split("## Queue")[0];
+      expect(activeSection).not.toContain("Zombie");
+    });
   });
 
   describe("skill frontmatter validation (#294, #298)", () => {

--- a/packages/cli/src/link/doctor.ts
+++ b/packages/cli/src/link/doctor.ts
@@ -689,6 +689,109 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     }
   }
 
+  // Zombie blocked-task scan: pre-0.1.25 task lifecycle promoted tasks to Active
+  // and stamped them "Blocked: Command failed: git add -A" on transient git
+  // failures. Those tasks never resolve themselves. With --fix, archive them
+  // to Done with a phren-managed comment so they stop appearing in Active.
+  try {
+    const zombieResult = scanAndOptionallyFixZombieTasks(phrenPath, fix);
+    if (zombieResult.scanned > 0) {
+      const cleared = zombieResult.zombies === 0 || fix;
+      checks.push({
+        name: "zombie-blocked-tasks",
+        ok: cleared,
+        detail: zombieResult.zombies === 0
+          ? `0 zombie blocked tasks across ${zombieResult.scanned} project(s)`
+          : fix
+            ? `archived ${zombieResult.zombies} zombie task(s) across ${zombieResult.fixedProjects} project(s)`
+            : `${zombieResult.zombies} zombie blocked task(s) found across ${zombieResult.affectedProjects} project(s). Run \`phren doctor --fix\` to archive them.`,
+      });
+    }
+  } catch (err: unknown) {
+    debugLog(`doctor: zombie task scan failed: ${errorMessage(err)}`);
+  }
+
   const ok = checks.every((c) => c.ok);
   return { ok, machine, profile: profile || undefined, checks };
+}
+
+interface ZombieScanResult {
+  scanned: number;
+  affectedProjects: number;
+  fixedProjects: number;
+  zombies: number;
+}
+
+const ZOMBIE_BLOCKED_CONTEXT_RE = /^\s*Context:\s*Blocked:\s*Command failed:\s*git\s+(?:add|commit|push|stage|pull|fetch|stash)\b/i;
+
+function scanAndOptionallyFixZombieTasks(phrenPath: string, fix: boolean): ZombieScanResult {
+  const result: ZombieScanResult = { scanned: 0, affectedProjects: 0, fixedProjects: 0, zombies: 0 };
+  const projectDirs = getProjectDirs(phrenPath);
+  for (const project of projectDirs) {
+    const filePath = resolveTaskFilePath(phrenPath, project);
+    if (!filePath || !fs.existsSync(filePath)) continue;
+    result.scanned += 1;
+    const original = fs.readFileSync(filePath, "utf8");
+    const lines = original.split("\n");
+    // Walk in Active section; find task lines whose next line is a zombie Context.
+    let section: string | null = null;
+    const zombieIndices: number[] = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const heading = line.match(/^##\s+(\w+)/);
+      if (heading) {
+        section = heading[1];
+        continue;
+      }
+      if (section !== "Active") continue;
+      if (!/^- \[ \]/.test(line)) continue;
+      const next = lines[i + 1];
+      if (next && ZOMBIE_BLOCKED_CONTEXT_RE.test(next)) {
+        zombieIndices.push(i);
+      }
+    }
+    if (zombieIndices.length === 0) continue;
+    result.affectedProjects += 1;
+    result.zombies += zombieIndices.length;
+    if (!fix) continue;
+
+    // Build edited file: move zombie tasks (and their Context line) to ## Done.
+    // Mark them [x] and prepend "(phren: archived zombie git-failure block)".
+    const archived: string[] = [];
+    const keepLines: string[] = [];
+    section = null;
+    let insertDoneAfter: number | null = null;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const heading = line.match(/^##\s+(\w+)/);
+      if (heading) {
+        section = heading[1];
+        if (section === "Done") insertDoneAfter = keepLines.length;
+        keepLines.push(line);
+        continue;
+      }
+      if (section === "Active" && zombieIndices.includes(i)) {
+        const taskLine = line.replace(/^- \[ \]/, "- [x]");
+        archived.push(`${taskLine}  <!-- phren: archived zombie git-failure block -->`);
+        // Carry Context line if present.
+        const next = lines[i + 1];
+        if (next && ZOMBIE_BLOCKED_CONTEXT_RE.test(next)) {
+          archived.push(next);
+          i += 1;
+        }
+        continue;
+      }
+      keepLines.push(line);
+    }
+    if (archived.length > 0 && insertDoneAfter !== null) {
+      // Insert the archived block right after `## Done` heading (and the blank line).
+      const before = keepLines.slice(0, insertDoneAfter + 1);
+      const after = keepLines.slice(insertDoneAfter + 1);
+      const archivedBlock = ["", ...archived];
+      const next = [...before, ...archivedBlock, ...after].join("\n");
+      fs.writeFileSync(filePath, next, "utf8");
+      result.fixedProjects += 1;
+    }
+  }
+  return result;
 }

--- a/packages/cli/src/task-lifecycle.test.ts
+++ b/packages/cli/src/task-lifecycle.test.ts
@@ -175,6 +175,77 @@ describe("task lifecycle", () => {
     expect(result.noticeLines.join("\n")).toContain("Active task");
   });
 
+  it("auto mode does not poison the tracked task on transient git failure", () => {
+    // Regression for the zombie-blocked-task bug. The lifecycle used to promote
+    // the user's active task to Active and stamp it "Blocked: Command failed:
+    // git add -A" when the session-end git auto-stage failed — leaving a
+    // permanent task that re-blocked every subsequent session.
+    writeFile(path.join(tmp.path, ".config", "workflow-policy.json"), JSON.stringify({
+      schemaVersion: 1,
+
+      lowConfidenceThreshold: 0.7,
+      riskySections: ["Stale", "Conflicts"],
+      taskMode: "auto",
+    }, null, 2) + "\n");
+
+    handleTaskPromptLifecycle({
+      phrenPath: tmp.path,
+      prompt: "Fix narrow terminal task rendering",
+      project,
+      sessionId: "session-git-fail",
+      intent: "debug",
+    });
+
+    finalizeTaskSession({
+      phrenPath: tmp.path,
+      sessionId: "session-git-fail",
+      status: "error",
+      detail: "Command failed: git add -A",
+    });
+
+    const task = readTasks(tmp.path, project);
+    expect(task.ok).toBe(true);
+    if (!task.ok) return;
+    // Task remains as it was — not stamped with the git failure.
+    const allLines = [...task.data.items.Active, ...task.data.items.Queue].map((i) => i.line);
+    expect(allLines.some((l) => l.includes("narrow terminal task rendering"))).toBe(true);
+    const allContexts = [...task.data.items.Active, ...task.data.items.Queue]
+      .map((i) => i.context)
+      .filter(Boolean);
+    expect(allContexts.some((c) => /Blocked: Command failed: git/.test(c!))).toBe(false);
+  });
+
+  it("auto mode still blocks the task on a non-git error", () => {
+    writeFile(path.join(tmp.path, ".config", "workflow-policy.json"), JSON.stringify({
+      schemaVersion: 1,
+
+      lowConfidenceThreshold: 0.7,
+      riskySections: ["Stale", "Conflicts"],
+      taskMode: "auto",
+    }, null, 2) + "\n");
+
+    handleTaskPromptLifecycle({
+      phrenPath: tmp.path,
+      prompt: "Investigate the build pipeline failure",
+      project,
+      sessionId: "session-real-error",
+      intent: "debug",
+    });
+
+    finalizeTaskSession({
+      phrenPath: tmp.path,
+      sessionId: "session-real-error",
+      status: "error",
+      detail: "Disk full while writing logs",
+    });
+
+    const task = readTasks(tmp.path, project);
+    expect(task.ok).toBe(true);
+    if (!task.ok) return;
+    const blocked = task.data.items.Active.find((i) => /Disk full/.test(i.context ?? ""));
+    expect(blocked).toBeDefined();
+  });
+
   it("auto mode completes the tracked task after a successful stop", () => {
     writeFile(path.join(tmp.path, ".config", "workflow-policy.json"), JSON.stringify({
       schemaVersion: 1,

--- a/packages/cli/src/task/lifecycle.ts
+++ b/packages/cli/src/task/lifecycle.ts
@@ -390,6 +390,16 @@ export function finalizeTaskSession(args: {
   }
 
   if (args.status === "error") {
+    // Don't poison the task with transient git infrastructure failures. Common
+    // observed pattern: git add -A failing because of file locks / permissions
+    // on Windows mounts / sparse-checkout edge cases. The user's task is unrelated;
+    // promoting it to Active and marking it "Blocked: Command failed: git add -A"
+    // creates a permanent zombie that re-blocks every subsequent session.
+    if (isTransientGitFailure(args.detail)) {
+      debugLog(`task lifecycle ignored transient git failure for ${state.project}: ${args.detail}`);
+      // Keep session state intact — next clean session can complete normally.
+      return;
+    }
     const blocked = updateTask(args.phrenPath, state.project, match, {
       section: "active",
       context: `Blocked: ${args.detail}`,
@@ -406,6 +416,13 @@ export function finalizeTaskSession(args: {
     });
     return;
   }
+}
+
+const TRANSIENT_GIT_FAILURE_RE = /^Command failed:\s*git\s+(?:add|commit|push|stage|pull|fetch|stash)\b/i;
+
+export function isTransientGitFailure(detail: string): boolean {
+  if (!detail) return false;
+  return TRANSIENT_GIT_FAILURE_RE.test(detail.trim());
 }
 
 /**

--- a/packages/cli/src/task/lifecycle.ts
+++ b/packages/cli/src/task/lifecycle.ts
@@ -117,6 +117,24 @@ function getTaskMode(phrenPath: string): TaskMode {
   return getWorkflowPolicy(phrenPath).taskMode;
 }
 
+// Hard substance floor — applies before any intent-specific logic so that conversational
+// fragments slipping past the noise regex (e.g. "Here's the thing", "I just clicked on to
+// this page", "<") never become tasks even at proactivityTasks=high. A prompt clears the
+// floor only if it has enough words AND has at least one signal: an actionable verb, a
+// path-like fragment (./, /), a reference (#123 or a 4+ digit ticket number), a file
+// extension, or a URL.
+const MIN_TASK_PROMPT_WORDS = 4;
+const MIN_TASK_PROMPT_CHARS = 12;
+const TASK_SIGNAL_RE = /\b(?:fix|add|update|remove|delete|check|run|build|test|ship|implement|investigate|review|audit|create|change|refactor|rename|deploy|merge|migrate|wire|integrate|debug|explore|evaluate|compare|analy[sz]e|assess|consider|design|document|plan|prototype|prepare|configure|enable|disable|publish|release|rollback|verify|validate|profile|optimi[sz]e|harden|automate|backport|cleanup|cleanse|polish|tune|land)\b|[/\\][\w.\-]+|#\d+|\b\d{4,}\b|\.[a-z]{1,4}\b|https?:\/\//i;
+
+function hasMinimumTaskSubstance(prompt: string): boolean {
+  const trimmed = prompt.trim();
+  if (trimmed.length < MIN_TASK_PROMPT_CHARS) return false;
+  const words = trimmed.split(/\s+/).filter((w) => /\w/.test(w));
+  if (words.length < MIN_TASK_PROMPT_WORDS) return false;
+  return TASK_SIGNAL_RE.test(trimmed);
+}
+
 function isActionablePrompt(prompt: string, intent: string): boolean {
   const normalized = prompt.trim();
   if (!normalized) return false;
@@ -124,6 +142,9 @@ function isActionablePrompt(prompt: string, intent: string): boolean {
   // Always reject conversational noise and raw system/SQL fragments regardless of intent.
   if (CONVERSATIONAL_NOISE_RE.test(normalized)) return false;
   if (RAW_MESSAGE_SIGNALS_RE.test(normalized)) return false;
+  // Substance floor — independent of intent / proactivity. Short utterances without
+  // any actionable signal are conversational fragments, not tasks.
+  if (!hasMinimumTaskSubstance(normalized)) return false;
   if (intent === "general") return ACTIONABLE_RE.test(normalized);
   return true;
 }

--- a/packages/cli/src/tools/finding.ts
+++ b/packages/cli/src/tools/finding.ts
@@ -8,6 +8,7 @@ import { isValidProjectName, safeProjectPath, errorMessage } from "../utils.js";
 import {
   removeFinding as removeFindingCore,
   removeFindings as removeFindingsCore,
+  applyFindingTypePrefix,
 } from "../core/finding.js";
 import {
   debugLog,
@@ -166,7 +167,7 @@ async function handleAddFinding(
       const findings = Array.isArray(finding) ? finding : [finding];
       const added: string[] = [];
       for (const f of findings) {
-        const taggedFinding = findingType ? `[${findingType}] ${f}` : f;
+        const taggedFinding = applyFindingTypePrefix(f, findingType);
         const result = appendTeamJournal(phrenPath, project, taggedFinding, provenance.actor, provenance.machine);
         if (result.ok) added.push(taggedFinding);
       }
@@ -233,7 +234,7 @@ async function handleAddFinding(
   if (!normalizedScope) return mcpResponse({ ok: false, error: `Invalid scope: "${scope}". Use lowercase letters/numbers with '-' or '_' (max 64 chars), e.g. "researcher".` });
   return withWriteQueue(async () => {
     try {
-      const taggedFinding = findingType ? `[${findingType}] ${finding}` : finding;
+      const taggedFinding = applyFindingTypePrefix(finding, findingType);
       // Jaccard "maybe zone" scan — free, no LLM call. Return candidates so the agent decides.
       const potentialDuplicates = findJaccardCandidates(phrenPath, project, taggedFinding);
       const semanticConflicts = await checkSemanticConflicts(phrenPath, project, taggedFinding);


### PR DESCRIPTION
## Summary

Seven targeted bug fixes in the auto-extract pipeline that filled review queues and task lists with garbage at \`proactivity*=high\`. Surfaced by an audit of three real phren stores (one personal, two team) where the personal store had ~56 false-positive entries in one project's \`review.md\` and ~30 conversational-fragment tasks. Each fix has a regression test built from the observed bad data.

## Fixes

1. **\`extractToolFindings\` reads tool exit codes instead of grepping stdout for "error".** Was: any Bash response containing \`error\`/\`failed\`/\`ENOENT\` produced a \`[bug] command 'X' failed:\` row — \`ls\` listing a file named \`error.js\`, \`grep\` exit 1 (no match), \`curl\` printing \`failed\` in a JSON body. Now reads \`tool_response.is_error\`/\`exit_code\` and skips a noisy-command allowlist (\`grep\`/\`rg\`/\`find\`/\`test\`/\`[\`/\`pgrep\`/\`git diff --quiet\`/\`|| true\`/\`2>/dev/null\`).
2. **Removed the \`error handling added near \"...\"\` pitfall heuristic.** Adding a try/catch is normal code, not a pitfall. ~21 false positives per real one.
3. **\`EXPLICIT_TAG_PATTERN\` ignores markdown link patterns.** A README TOC \`[Architecture](#architecture)\` was producing \`[architecture] (#architecture)\` rows. Negative lookahead \`(?!\(|\[)\`.
4. **\`add_finding\` doesn't double-prepend a tag** when the finding already starts with one. New \`applyFindingTypePrefix\` helper across all three call sites.
5. **\`update_task\` priority tag is idempotent** — no more 48× \`[high]\`. Strip loops + reorders \`[pinned]\` strip first.
6. **Zombie \`Blocked: Command failed: git add -A\` Active tasks prevented.** \`finalizeTaskSession\` skips the task update on transient git infrastructure failures. Plus \`phren doctor [--fix]\` gained a \`zombie-blocked-tasks\` migration check that archives existing zombies to Done.
7. **Substance gate in \`isActionablePrompt\`** — \`Bro\`, \`<\`, \`OK\`, \`Need this fixed\`, \`I just clicked on to this page\` no longer become tasks even at \`proactivityTasks=high\`. Floor: 4+ words, 12+ chars, plus one signal (verb / path / \`#N\` / 4+ digit ticket / file extension / URL).

See \`CHANGELOG.md\` for the full \`## [0.1.25]\` entry.

## Out of scope

- Default \`proactivity\` level stays \`"high"\` — fixing the noise so \`high\` is usable is the right move; lowering the default is a different conversation.
- \`cli-hooks-prompt.ts\` is dead code (refactor leftover) — mirrored the fix into it for safety, deletion is a separate PR.

## Test plan

- [x] \`pnpm -w test\`: 2576 passed, 6 skipped, 0 failed
- [x] \`pnpm -w lint\`: 181 files clean
- [x] \`pnpm -w build\`: 2 tasks successful
- [x] After merge: tag \`v0.1.25\`, dispatch \`release.yml\`, smoke-test \`npx -y @phren/cli@0.1.25 doctor\` on a clean machine
- [x] Post-upgrade: deliberate failing \`grep\` does NOT add to \`review.md\`; single-word reply at \`proactivityTasks=high\` does NOT create a task; \`add_finding({finding:"[pattern] X", findingType:"pattern"})\` stores \`[pattern] X\`; 5× \`update_task(...priority="high")\` ends with one \`[high]\`; \`phren doctor --fix\` archives any pre-0.1.25 zombie blocked tasks