### PR TITLE
fix: resolve add_project team-store profile routing and dependency alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -35,8 +33,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -51,8 +47,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/cli/src/__tests__/mcp-ops.test.ts
+++ b/packages/cli/src/__tests__/mcp-ops.test.ts
@@ -383,6 +383,37 @@ describe("mcp-ops: add_project", () => {
     expect(fs.readFileSync(path.join(tmp.path, "repo-managed", "phren.project.yaml"), "utf8")).toContain("ownership: repo-managed");
   });
 
+  it("adds a repo to an explicit team store while updating the primary profile", async () => {
+    const teamStore = path.join(tmp.path, "team-store");
+    fs.mkdirSync(teamStore, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp.path, "stores.yaml"),
+      [
+        "version: 1",
+        "stores:",
+        "  - id: primary01",
+        "    name: primary",
+        `    path: ${tmp.path}`,
+        "    role: primary",
+        "    sync: managed-git",
+        "  - id: team0001",
+        "    name: team",
+        `    path: ${teamStore}`,
+        "    role: team",
+        "    sync: managed-git",
+        "",
+      ].join("\n")
+    );
+
+    const res = parseResult(await server.call("add_project", { path: repoDir, store: "team", ownership: "repo-managed" }));
+    expect(res.ok).toBe(true);
+    expect(res.data.files.summary).toBe(path.join(teamStore, "repo", "summary.md"));
+    expect(fs.existsSync(path.join(teamStore, "repo", "summary.md"))).toBe(true);
+    expect(fs.existsSync(path.join(tmp.path, "repo", "summary.md"))).toBe(false);
+    expect(fs.readFileSync(path.join(tmp.path, "profiles", "work.yaml"), "utf8")).toContain("- repo");
+    expect(fs.existsSync(path.join(teamStore, "profiles"))).toBe(false);
+  });
+
   it("requires an explicit path", async () => {
     const res = parseResult(await server.call("add_project", {}));
     expect(res.ok).toBe(false);

--- a/packages/cli/src/core-project.test.ts
+++ b/packages/cli/src/core-project.test.ts
@@ -62,4 +62,29 @@ describe("addProjectFromPath", () => {
       tmp.cleanup();
     }
   });
+
+  it("writes to a target store while updating the primary profile", () => {
+    const tmp = makeTempDir("core-project-write-store-");
+    try {
+      const phrenPath = path.join(tmp.path, ".phren");
+      const teamStorePath = path.join(tmp.path, "team-store");
+      const repoPath = path.join(tmp.path, "repo");
+      fs.mkdirSync(path.join(phrenPath, "profiles"), { recursive: true });
+      fs.writeFileSync(path.join(phrenPath, "profiles", "work.yaml"), "name: work\nprojects:\n  - global\n");
+      fs.mkdirSync(teamStorePath, { recursive: true });
+      fs.mkdirSync(path.join(repoPath, ".git"), { recursive: true });
+
+      const result = addProjectFromPath(phrenPath, repoPath, "work", "phren-managed", { writeToPath: teamStorePath });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.data.files.summary).toBe(path.join(teamStorePath, "repo", "summary.md"));
+      expect(fs.existsSync(path.join(teamStorePath, "repo", "summary.md"))).toBe(true);
+      expect(fs.existsSync(path.join(phrenPath, "repo", "summary.md"))).toBe(false);
+      expect(fs.readFileSync(path.join(phrenPath, "profiles", "work.yaml"), "utf8")).toContain("- repo");
+      expect(fs.existsSync(path.join(teamStorePath, "profiles"))).toBe(false);
+    } finally {
+      tmp.cleanup();
+    }
+  });
 });

--- a/packages/cli/src/core/project.ts
+++ b/packages/cli/src/core/project.ts
@@ -19,11 +19,16 @@ interface AddedProjectData {
   };
 }
 
+interface AddProjectFromPathOptions {
+  writeToPath?: string;
+}
+
 export function addProjectFromPath(
   phrenPath: string,
   targetPath: string | undefined,
   requestedProfile?: string,
   ownership?: ProjectOwnershipMode,
+  options: AddProjectFromPathOptions = {},
 ): PhrenResult<AddedProjectData> {
   if (!targetPath) {
     return phrenErr("Path is required. Pass the current project directory explicitly to avoid adding the wrong working directory.");
@@ -32,6 +37,7 @@ export function addProjectFromPath(
   const activeProfile = resolveActiveProfile(phrenPath, requestedProfile);
   if (!activeProfile.ok) return activeProfile;
 
+  const writePhrenPath = options.writeToPath ?? phrenPath;
   const manifest = readRootManifest(phrenPath);
   const resolvedPath = path.resolve(targetPath);
   if (manifest?.installMode === "project-local") {
@@ -42,7 +48,11 @@ export function addProjectFromPath(
     }
   }
   const selectedProfile = activeProfile.data;
-  const added = bootstrapFromExisting(phrenPath, resolvedPath, { profile: selectedProfile, ownership });
+  const added = bootstrapFromExisting(writePhrenPath, resolvedPath, {
+    profile: selectedProfile,
+    profilePhrenPath: phrenPath,
+    ownership,
+  });
 
   return phrenOk({
     project: added.project,
@@ -51,9 +61,9 @@ export function addProjectFromPath(
     ownership: added.ownership,
     files: {
       claude: added.claudePath,
-      summary: path.join(phrenPath, added.project, "summary.md"),
-      findings: path.join(phrenPath, added.project, FINDINGS_FILENAME),
-      task: path.join(phrenPath, added.project, TASKS_FILENAME),
+      summary: path.join(writePhrenPath, added.project, "summary.md"),
+      findings: path.join(writePhrenPath, added.project, FINDINGS_FILENAME),
+      task: path.join(writePhrenPath, added.project, TASKS_FILENAME),
     },
   });
 }

--- a/packages/cli/src/init/setup.ts
+++ b/packages/cli/src/init/setup.ts
@@ -50,6 +50,7 @@ export interface PostInitCheck {
 
 interface BootstrapProjectOptions {
   profile?: string;
+  profilePhrenPath?: string;
   ownership?: ProjectOwnershipMode;
 }
 
@@ -1189,6 +1190,7 @@ export function bootstrapFromExisting(
   opts: string | BootstrapProjectOptions = {}
 ): BootstrapProjectResult {
   const profile = typeof opts === "string" ? opts : opts.profile;
+  const profilePhrenPath = typeof opts === "string" ? phrenPath : (opts.profilePhrenPath ?? phrenPath);
   const resolvedPath = path.resolve(projectPath);
   if (!fs.existsSync(resolvedPath)) {
     throw new Error(`Path does not exist: ${resolvedPath}`);
@@ -1302,9 +1304,9 @@ export function bootstrapFromExisting(
     );
   }
 
-  const activeProfile = resolveActiveProfile(phrenPath, profile);
+  const activeProfile = resolveActiveProfile(profilePhrenPath, profile);
   if (activeProfile.ok && activeProfile.data) {
-    const addResult = addProjectToProfile(phrenPath, activeProfile.data, projectName);
+    const addResult = addProjectToProfile(profilePhrenPath, activeProfile.data, projectName);
     if (!addResult.ok) {
       throw new Error(addResult.error);
     }

--- a/packages/cli/src/tools/ops.ts
+++ b/packages/cli/src/tools/ops.ts
@@ -64,10 +64,11 @@ async function handleAddProject(
       }
 
       const added = addProjectFromPath(
-        targetPhrenPath,
+        phrenPath,
         targetPath,
         requestedProfile || profile || undefined,
-        parseProjectOwnershipMode(ownership) ?? undefined
+        parseProjectOwnershipMode(ownership) ?? undefined,
+        { writeToPath: targetPhrenPath }
       );
       if (!added.ok) {
         return mcpResponse({


### PR DESCRIPTION
## Summary
- Fixes `add_project` when targeting an explicit team store by keeping profile resolution/update on the primary phren store.
- Adds a separate write-store path so project scaffold files are still created in the requested team store.
- Adds core and MCP regression tests for issue #46.
- Forces patched transitive dependency versions for the Dependabot alerts in `fast-uri`, `hono`, and `ip-address`, then regenerates `pnpm-lock.yaml`.
- Removes redundant pnpm Action version inputs so workflows use the repo packageManager pin.

Fixes #46

## Dependabot alerts addressed
- `fast-uri` host confusion: `3.1.1` -> `3.1.2`
- `hono` cache/CSS/JWT advisories: `4.12.16` -> `4.12.18`
- `ip-address` XSS advisory: `10.1.0` -> `10.2.0`

## Validation
- `pnpm audit`
- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm lint`
- `pnpm build`