### PR TITLE
fix(mcp): mark core tools alwaysLoad — bump @phren/cli to 0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.30] - 2026-05-13
+
+### Fixed
+
+- MCP core tools (`add_finding`, `add_task`, `complete_task`, `search_knowledge`, `get_findings`, `get_tasks`, `session_start`, `session_end`) are now marked `anthropic/alwaysLoad` via the `_meta` field so Claude Code keeps their schemas resident instead of deferring them behind `ToolSearch`. Without this flag, the first call to a deferred tool in a fresh session fails with `InputValidationError` because parameters are stripped before the schema is loaded — which surfaced as repeated silent `add_finding` failures with "project/finding both undefined." Other phren tools remain deferred since the deferral exists to keep MCP tool definitions under ~10% of the context window.
+
 ## [0.1.29] - 2026-05-10
 
 ### Security

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -852,7 +852,7 @@
             <p>Run init to configure hooks and MCP for your agents:</p>
             <pre><code>phren init</code></pre>
             <p>Expected output:</p>
-            <pre><code>phren init v0.1.29
+            <pre><code>phren init v0.1.30
   Detected agents: Claude Code, Copilot
   Created ~/.phren/
   Registered MCP server in ~/.claude/settings.json

--- a/docs/index.html
+++ b/docs/index.html
@@ -1244,7 +1244,7 @@
       <span class="dot-sep">&#9829;</span>
       <span>made with love by <a href="https://github.com/alaarab" style="color:var(--text-muted);text-decoration:none;">@alaarab</a> &amp; claude</span>
       <span class="dot-sep">•</span>
-      <span style="opacity:0.5;font-size:11px">v0.1.29</span>
+      <span style="opacity:0.5;font-size:11px">v0.1.30</span>
     </div>
     <div class="footer-right">
       <a href="https://github.com/alaarab/phren" target="_blank" rel="noopener">GitHub</a>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -176,8 +176,30 @@ async function main() {
   type RegisterToolName = RegisterToolArgs[0];
   type RegisterToolConfig = RegisterToolArgs[1];
   type RegisterToolHandler = (...args: unknown[]) => unknown;
+
+  // Tools Claude reaches for during normal work. Marked with anthropic/alwaysLoad
+  // so Claude Code keeps their schemas resident instead of deferring them behind
+  // ToolSearch — otherwise the first call in a fresh session fails with
+  // InputValidationError until the schema is fetched.
+  const ALWAYS_LOAD_TOOLS = new Set([
+    "add_finding",
+    "add_task",
+    "complete_task",
+    "search_knowledge",
+    "session_start",
+    "session_end",
+    "get_findings",
+    "get_tasks",
+  ]);
+
   server.registerTool = function (name: RegisterToolName, config: RegisterToolConfig, handler: RegisterToolHandler) {
     const registeredName = name;
+    let finalConfig = config;
+    if (ALWAYS_LOAD_TOOLS.has(registeredName as string)) {
+      const cfgObj = config as Record<string, unknown>;
+      const existingMeta = (cfgObj?._meta as Record<string, unknown> | undefined) ?? {};
+      finalConfig = { ...cfgObj, _meta: { ...existingMeta, "anthropic/alwaysLoad": true } } as RegisterToolConfig;
+    }
     const wrapped = async (...args: unknown[]) => {
       if (!indexReady || !db) {
         return {
@@ -195,7 +217,7 @@ async function main() {
       }
       return handler(...args);
     };
-    return origRegisterTool(registeredName, config, wrapped as RegisterToolArgs[2]);
+    return origRegisterTool(registeredName, finalConfig, wrapped as RegisterToolArgs[2]);
   } as typeof server.registerTool;
 
   // Register all tool handlers from domain modules


### PR DESCRIPTION
## Summary

- Claude Code 2.1.97+ defers MCP tool schemas when they would exceed ~10% of the context window. Deferred tools must be loaded via `ToolSearch` before the first invocation; calling them blind fails with `InputValidationError` and the args get dropped (e.g. `project/finding both undefined`).
- In practice this silently breaks `add_finding` / `add_task` for any Claude session that hasn't pre-loaded the schema. The session falls back to writing the data into AI Notes or the journal, losing the entry from the searchable memory store.
- This PR marks the 8 tools Claude reaches for during normal work with `_meta: { "anthropic/alwaysLoad": true }` so their schemas stay resident: `add_finding`, `add_task`, `complete_task`, `search_knowledge`, `get_findings`, `get_tasks`, `session_start`, `session_end`. The other ~46 phren tools remain deferred — that's the whole point of deferral.
- Bumps `@phren/cli` to **0.1.30**, updates docs site footer + `phren init` example output, adds CHANGELOG entry.

## Reference

- [Claude Code MCP docs — `anthropic/alwaysLoad`](https://code.claude.com/docs/en/mcp.md)
- Shipped in Claude Code 2.1.97; per-server `alwaysLoad` config flag in 2.1.121.

## Test plan

- [ ] `pnpm --filter @phren/cli build` — green (verified locally; `dist/index.js` contains two `anthropic/alwaysLoad` references)
- [ ] Restart a Claude Code session, confirm `mcp__phren__add_finding` is NOT in the deferred-tools system-reminder and can be called without a prior `ToolSearch`
- [ ] Confirm other phren tools (e.g. `mcp__phren__pin_memory`) ARE still in the deferred list — we don't want to opt the whole server out
- [ ] `npm publish` once approved