### PR TITLE
feat(config): surface configuration across CLI, Web UI, and VS Code (v0.1.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.31] - 2026-05-17
+
+### Added
+
+- **Config is now first-class and surfaced across every interface.** A single shared
+  config schema (`packages/cli/src/config/schema.ts`) describes all eight config
+  domains — proactivity, taskMode, findingSensitivity, retention, workflow, index,
+  topic, access — with labels, plain-English help, options, defaults, and ranges.
+  The CLI, Web UI, and VS Code extension all render from it, so config copy can no
+  longer drift between surfaces.
+- **Uniform config provenance.** A new resolver (`config/resolve.ts`,
+  `buildConfigView`) resolves every field through the 3-level precedence chain and
+  reports `{ value, source, inheritedValue, sourcePath }`. A global file that merely
+  mirrors the defaults is correctly reported as `default`, not a customisation.
+  `get_config` now returns a `fields` map (resolved provenance) and `schema`
+  alongside its existing keys.
+- **`phren config show`** is rewritten: grouped by domain with a source column
+  (`default` / `global` / `project`) and the file each value came from. New
+  `--diff` flag shows only customised values; `--json` emits the machine-readable view.
+- **`phren config access`** — view and set role-based access lists
+  (`admins` / `contributors` / `readers`) at global or per-project scope.
+- **Web UI** — the settings tab gains an Index Policy section (include/exclude
+  globs, hidden-file toggle); `/api/config`, `/api/settings`, and a new
+  `/api/config/view` endpoint expose the resolved view + schema.
+- **VS Code** — a new Settings Dashboard webview (`phren.openSettings`, gear icon
+  in the Phren view) covers every domain with source chips and inline help,
+  replacing the four-setting QuickPick as the primary config surface.
+
 ## [0.1.30] - 2026-05-13
 
 ### Fixed

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -852,7 +852,7 @@
             <p>Run init to configure hooks and MCP for your agents:</p>
             <pre><code>phren init</code></pre>
             <p>Expected output:</p>
-            <pre><code>phren init v0.1.30
+            <pre><code>phren init v0.1.31
   Detected agents: Claude Code, Copilot
   Created ~/.phren/
   Registered MCP server in ~/.claude/settings.json

--- a/docs/index.html
+++ b/docs/index.html
@@ -1244,7 +1244,7 @@
       <span class="dot-sep">&#9829;</span>
       <span>made with love by <a href="https://github.com/alaarab" style="color:var(--text-muted);text-decoration:none;">@alaarab</a> &amp; claude</span>
       <span class="dot-sep">•</span>
-      <span style="opacity:0.5;font-size:11px">v0.1.30</span>
+      <span style="opacity:0.5;font-size:11px">v0.1.31</span>
     </div>
     <div class="footer-right">
       <a href="https://github.com/alaarab/phren" target="_blank" rel="noopener">GitHub</a>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/cli-config.test.ts
+++ b/packages/cli/src/cli-config.test.ts
@@ -322,3 +322,127 @@ describe("CLI config: synonyms", () => {
     expect(removeAll.exitCode).toBe(0);
   });
 });
+
+describe("CLI config: show", () => {
+  let phrenDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ phrenDir, cleanup } = setupPhrenDir());
+    fs.mkdirSync(path.join(phrenDir, "demo"), { recursive: true });
+  });
+  afterEach(() => cleanup());
+
+  it("renders config grouped by domain with a source column", () => {
+    const { stdout, exitCode } = runCli(
+      ["config", "show"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("phren config — global");
+    expect(stdout).toContain("Retention");
+    expect(stdout).toContain("TTL (days)");
+    expect(stdout).toContain("default");
+  });
+
+  it("emits a machine-readable view with --json", () => {
+    const { stdout, exitCode } = runCli(
+      ["config", "show", "--json"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(exitCode).toBe(0);
+    const view = JSON.parse(stdout);
+    expect(view.scope).toBe("global");
+    expect(view.fields["retention.ttlDays"].value).toBe(120);
+    expect(view.fields["retention.ttlDays"].source).toBe("default");
+  });
+
+  it("shows the source as global after a value is set, and surfaces it in --diff", () => {
+    runCli(
+      ["config", "task-mode", "set", "suggest"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    const json = runCli(
+      ["config", "show", "--json"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    const view = JSON.parse(json.stdout);
+    expect(view.fields.taskMode.value).toBe("suggest");
+    expect(view.fields.taskMode.source).toBe("global");
+
+    const diff = runCli(
+      ["config", "show", "--diff"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(diff.stdout).toContain("suggest");
+    expect(diff.stdout).toContain("global");
+  });
+
+  it("reports everything as default in --diff before any change", () => {
+    const { stdout } = runCli(
+      ["config", "show", "--diff"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(stdout).toContain("Everything is at its default value");
+  });
+
+  it("renders a project-scoped view", () => {
+    const { stdout, exitCode } = runCli(
+      ["config", "show", "--project", "demo"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("project: demo");
+  });
+});
+
+describe("CLI config: access", () => {
+  let phrenDir: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ phrenDir, cleanup } = setupPhrenDir());
+    fs.mkdirSync(path.join(phrenDir, "demo"), { recursive: true });
+  });
+  afterEach(() => cleanup());
+
+  it("reports empty role lists by default", () => {
+    const { stdout, exitCode } = runCli(
+      ["config", "access", "get"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(exitCode).toBe(0);
+    const payload = JSON.parse(stdout);
+    expect(payload.admins).toEqual([]);
+    expect(payload.contributors).toEqual([]);
+    expect(payload.readers).toEqual([]);
+  });
+
+  it("sets a global admin and reads it back", () => {
+    const set = runCli(
+      ["config", "access", "set", "--admins=alice,bob"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    expect(set.exitCode).toBe(0);
+    const payload = JSON.parse(set.stdout);
+    expect(payload.admins).toEqual(["alice", "bob"]);
+  });
+
+  it("unions global and per-project role lists", () => {
+    runCli(
+      ["config", "access", "set", "--admins=alice"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    runCli(
+      ["config", "access", "--project", "demo", "set", "--contributors=carol"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    const { stdout } = runCli(
+      ["config", "access", "--project", "demo", "get"],
+      { PHREN_PATH: phrenDir, PHREN_ACTOR: "config-test" }
+    );
+    const payload = JSON.parse(stdout);
+    expect(payload.admins).toEqual(["alice"]);
+    expect(payload.contributors).toEqual(["carol"]);
+  });
+});

--- a/packages/cli/src/cli/config.ts
+++ b/packages/cli/src/cli/config.ts
@@ -33,7 +33,14 @@ import {
   getProjectOwnershipDefault,
   parseProjectOwnershipMode,
   updateProjectConfigOverrides,
+  readProjectConfig,
+  writeProjectConfig,
+  type ProjectAccessControl,
 } from "../project-config.js";
+import * as fs from "fs";
+import * as path from "path";
+import { buildConfigView, type ConfigView } from "../config/resolve.js";
+import { CONFIG_DOMAINS } from "../config/schema.js";
 import {
   isValidProjectName,
   learnedSynonymsPath,
@@ -87,94 +94,84 @@ export function buildProactivitySnapshot(phrenPath: string) {
 
 // ── Config show ───────────────────────────────────────────────────────────────
 
-function formatConfigAsTable(label: string, rows: [string, string][]): void {
-  const maxKey = Math.max(...rows.map(([k]) => k.length));
-  console.log(`\n${label}`);
-  for (const [k, v] of rows) {
-    console.log(`  ${k.padEnd(maxKey)}  ${v}`);
+function formatConfigValue(value: unknown): string {
+  if (value === undefined || value === null) return "(unset)";
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "(none)";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+/**
+ * Render a resolved {@link ConfigView} grouped by domain, with a source column
+ * that names where each value came from (default / global / project) and the
+ * file that set it.
+ */
+function renderConfigView(view: ConfigView, opts: { diff: boolean }): void {
+  const heading = view.scope === "project"
+    ? `phren config — project: ${view.project}`
+    : "phren config — global (applies to all projects unless overridden)";
+  console.log(`\n${heading}`);
+  if (opts.diff) console.log("(showing only values customised away from defaults)");
+
+  let shownAny = false;
+  for (const domain of CONFIG_DOMAINS) {
+    const rows: Array<{ label: string; value: string; source: string }> = [];
+    for (const field of domain.fields) {
+      const resolved = view.fields[field.key];
+      if (!resolved) continue; // topic fields are resolved separately
+      if (opts.diff && resolved.source === "default") continue;
+      const file = resolved.sourcePath ? path.basename(resolved.sourcePath) : "";
+      rows.push({
+        label: field.label,
+        value: formatConfigValue(resolved.value),
+        source: resolved.source === "default"
+          ? "default"
+          : `${resolved.source}${file ? ` (${file})` : ""}`,
+      });
+    }
+    if (!rows.length) continue;
+    shownAny = true;
+    console.log(`\n${domain.label}  —  ${domain.summary}`);
+    const labelW = Math.max(...rows.map((r) => r.label.length));
+    const valueW = Math.max(...rows.map((r) => r.value.length), 6);
+    for (const r of rows) {
+      console.log(`  ${r.label.padEnd(labelW)}  ${r.value.padEnd(valueW)}  ${r.source}`);
+    }
   }
+  if (!shownAny) {
+    console.log(opts.diff ? "\nEverything is at its default value." : "\n(no config)");
+  }
+  console.log("");
 }
 
 function handleConfigShow(args: string[]): void {
   const phrenPath = getPhrenPath();
-  const { project: projectArg } = parseProjectArg(args);
+  const { project: projectArg, rest } = parseProjectArg(args);
+  const asJson = rest.includes("--json");
+  const diff = rest.includes("--diff");
 
-  if (projectArg) {
-    if (!isValidProjectName(projectArg)) {
-      console.error(`Invalid project name: "${projectArg}"`);
-      process.exit(1);
-    }
-    const resolved = mergeConfig(phrenPath, projectArg);
-    const inProfile = checkProjectInProfile(phrenPath, projectArg);
+  if (projectArg && !isValidProjectName(projectArg)) {
+    console.error(`Invalid project name: "${projectArg}"`);
+    process.exit(1);
+  }
 
-    console.log(`\nConfig for project: ${projectArg}${inProfile ? "" : "  (not in active profile)"}`);
+  const view = buildConfigView(phrenPath, projectArg);
 
-    formatConfigAsTable("Finding capture", [
-      ["sensitivity", resolved.findingSensitivity],
-      ["proactivity", resolved.proactivity.base ?? "(global)"],
-      ["proactivity.findings", resolved.proactivity.findings ?? "(global)"],
-      ["proactivity.tasks", resolved.proactivity.tasks ?? "(global)"],
-    ]);
-
-    formatConfigAsTable("Task automation", [
-      ["taskMode", resolved.taskMode],
-    ]);
-
-    formatConfigAsTable("Retention policy", [
-      ["ttlDays", String(resolved.retentionPolicy.ttlDays)],
-      ["retentionDays", String(resolved.retentionPolicy.retentionDays)],
-      ["autoAcceptThreshold", String(resolved.retentionPolicy.autoAcceptThreshold)],
-      ["minInjectConfidence", String(resolved.retentionPolicy.minInjectConfidence)],
-      ["decay.d30", String(resolved.retentionPolicy.decay.d30)],
-      ["decay.d60", String(resolved.retentionPolicy.decay.d60)],
-      ["decay.d90", String(resolved.retentionPolicy.decay.d90)],
-      ["decay.d120", String(resolved.retentionPolicy.decay.d120)],
-    ]);
-
-    formatConfigAsTable("Workflow policy", [
-      ["lowConfidenceThreshold", String(resolved.workflowPolicy.lowConfidenceThreshold)],
-      ["riskySections", resolved.workflowPolicy.riskySections.join(", ")],
-    ]);
-
-    if (!inProfile) {
-      console.error(`\nRun 'phren add /path/to/${projectArg}' to register this project.`);
-    }
-    console.log("");
+  if (asJson) {
+    console.log(JSON.stringify(view, null, 2));
     return;
   }
 
-  // Global config — no project
-  const retention = getRetentionPolicy(phrenPath);
-  const workflow = getWorkflowPolicy(phrenPath);
+  renderConfigView(view, { diff });
 
-  console.log("\nGlobal config (applies to all projects unless overridden)");
-
-  formatConfigAsTable("Finding capture", [
-    ["findingSensitivity", workflow.findingSensitivity],
-  ]);
-
-  formatConfigAsTable("Task automation", [
-    ["taskMode", workflow.taskMode],
-  ]);
-
-  formatConfigAsTable("Retention policy", [
-    ["ttlDays", String(retention.ttlDays)],
-    ["retentionDays", String(retention.retentionDays)],
-    ["autoAcceptThreshold", String(retention.autoAcceptThreshold)],
-    ["minInjectConfidence", String(retention.minInjectConfidence)],
-    ["decay.d30", String(retention.decay.d30)],
-    ["decay.d60", String(retention.decay.d60)],
-    ["decay.d90", String(retention.decay.d90)],
-    ["decay.d120", String(retention.decay.d120)],
-  ]);
-
-  formatConfigAsTable("Workflow policy", [
-    ["lowConfidenceThreshold", String(workflow.lowConfidenceThreshold)],
-    ["riskySections", workflow.riskySections.join(", ")],
-  ]);
-
-  console.log(`\nUse '--project <name>' to see merged config for a specific project.`);
-  console.log("");
+  if (projectArg) {
+    const notRegistered = checkProjectInProfile(phrenPath, projectArg);
+    if (notRegistered) {
+      console.error(`Run 'phren add /path/to/${projectArg}' to register this project.\n`);
+    }
+  } else {
+    console.log("Tips: '--project <name>' for a project's merged config, '--diff' for only customised values, '--json' for machine-readable output.\n");
+  }
 }
 
 // ── Config router ────────────────────────────────────────────────────────────
@@ -207,6 +204,8 @@ export async function handleConfig(args: string[]) {
       return handleConfigTaskMode(rest);
     case "finding-sensitivity":
       return handleConfigFindingSensitivity(rest);
+    case "access":
+      return handleConfigAccess(rest);
     case "llm":
       return handleConfigLlm(rest);
     case "synonyms":
@@ -215,7 +214,9 @@ export async function handleConfig(args: string[]) {
       console.log(`phren config - manage settings and policies
 
 Subcommands:
-  phren config show [--project <name>]  Full merged config summary (what's actually active)
+  phren config show [--project <name>] [--diff] [--json]
+                                        Full merged config grouped by domain, with the
+                                        source (default/global/project) of every value
   phren config policy [get|set ...]     Memory retention, TTL, confidence, decay
   phren config workflow [get|set ...]   Risky-memory thresholds, task automation mode
   phren config index [get|set ...]      Indexer include/exclude globs
@@ -228,6 +229,8 @@ Subcommands:
                                         Task automation mode (off|manual|suggest|auto)
   phren config finding-sensitivity [get|set <level>]
                                         Finding capture level (minimal|conservative|balanced|aggressive)
+  phren config access [--project <name>] [get|set --admins=...]
+                                        Role-based access lists (admins|contributors|readers)
   phren config project-ownership [mode]
                                         Default ownership for future project enrollments
   phren config llm [get|set model|endpoint|key]
@@ -830,6 +833,91 @@ export async function handleWorkflowPolicy(args: string[]) {
     return;
   }
   console.error("Usage: phren config workflow [--project <name>] [get|set --lowConfidenceThreshold=0.7 --riskySections=Stale,Conflicts --taskMode=manual]");
+  process.exit(1);
+}
+
+// ── Access control ───────────────────────────────────────────────────────────
+
+const ACCESS_ROLES = ["admins", "contributors", "readers"] as const;
+
+function globalAccessFile(phrenPath: string): string {
+  return path.join(phrenPath, ".config", "access-control.json");
+}
+
+function readGlobalAccess(phrenPath: string): ProjectAccessControl {
+  const file = globalAccessFile(phrenPath);
+  if (!fs.existsSync(file)) return {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseRoleList(raw: string): string[] {
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function printAccessSnapshot(phrenPath: string, projectArg: string | undefined): void {
+  const view = buildConfigView(phrenPath, projectArg);
+  console.log(JSON.stringify({
+    _project: projectArg ?? null,
+    _note: "Effective lists are the union of global and per-project roles. All lists empty everywhere = open mode.",
+    admins: view.fields["access.admins"].value,
+    contributors: view.fields["access.contributors"].value,
+    readers: view.fields["access.readers"].value,
+  }, null, 2));
+}
+
+export function handleConfigAccess(args: string[]) {
+  const phrenPath = getPhrenPath();
+  const { project: projectArg, rest } = parseProjectArg(args);
+  const action = rest[0];
+
+  if (projectArg && !isValidProjectName(projectArg)) {
+    console.error(`Invalid project name: "${projectArg}"`);
+    process.exit(1);
+  }
+
+  if (!action || action === "get") {
+    printAccessSnapshot(phrenPath, projectArg);
+    return;
+  }
+
+  if (action === "set") {
+    const patch: ProjectAccessControl = {};
+    let touched = false;
+    for (const arg of rest.slice(1)) {
+      if (!arg.startsWith("--")) continue;
+      const [k, v] = arg.slice(2).split("=");
+      if (!k || v === undefined) continue;
+      if ((ACCESS_ROLES as readonly string[]).includes(k)) {
+        patch[k as keyof ProjectAccessControl] = parseRoleList(v);
+        touched = true;
+      }
+    }
+    if (!touched) {
+      console.error("Usage: phren config access [--project <name>] set --admins=a,b --contributors=c --readers=d");
+      process.exit(1);
+    }
+    if (projectArg) {
+      warnIfUnregistered(phrenPath, projectArg);
+      const current = readProjectConfig(phrenPath, projectArg);
+      writeProjectConfig(phrenPath, projectArg, {
+        access: { ...(current.access ?? {}), ...patch },
+      });
+    } else {
+      const next = { ...readGlobalAccess(phrenPath), ...patch };
+      const file = globalAccessFile(phrenPath);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, JSON.stringify(next, null, 2) + "\n");
+    }
+    printAccessSnapshot(phrenPath, projectArg);
+    return;
+  }
+
+  console.error("Usage: phren config access [--project <name>] [get|set --admins=a,b --contributors=c --readers=d]");
   process.exit(1);
 }
 

--- a/packages/cli/src/config/resolve.test.ts
+++ b/packages/cli/src/config/resolve.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { makeTempDir, initTestPhrenRoot } from "../test-helpers.js";
+import { writeProjectConfig } from "../project-config.js";
+import { writeGovernanceInstallPreferences } from "../init/preferences.js";
+import { buildConfigView, resolveConfigField } from "./resolve.js";
+import { allConfigFields } from "./schema.js";
+
+function writeGlobal(phrenPath: string, file: string, data: Record<string, unknown>): void {
+  const dir = path.join(phrenPath, ".config");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, file), JSON.stringify(data, null, 2) + "\n");
+}
+
+describe("resolveConfigField", () => {
+  it("returns the default when nothing is set", () => {
+    const r = resolveConfigField("x", 120, []);
+    expect(r).toEqual({ key: "x", value: 120, source: "default", inheritedValue: 120 });
+  });
+
+  it("reports global as the source when only a global level is set", () => {
+    const r = resolveConfigField("x", 120, [{ tier: "global", value: 90, path: "/g.json" }]);
+    expect(r.value).toBe(90);
+    expect(r.source).toBe("global");
+    expect(r.inheritedValue).toBe(120);
+    expect(r.sourcePath).toBe("/g.json");
+  });
+
+  it("reports project as the source and global as the inherited value", () => {
+    const r = resolveConfigField("x", 120, [
+      { tier: "project", value: 30, path: "/p.yaml" },
+      { tier: "global", value: 90 },
+    ]);
+    expect(r.value).toBe(30);
+    expect(r.source).toBe("project");
+    expect(r.inheritedValue).toBe(90);
+  });
+});
+
+describe("buildConfigView", () => {
+  let tmp: { path: string; cleanup: () => void };
+  let phrenPath: string;
+
+  beforeEach(() => {
+    tmp = makeTempDir("config-view-");
+    phrenPath = tmp.path;
+    initTestPhrenRoot(phrenPath);
+    fs.mkdirSync(path.join(phrenPath, "proj"), { recursive: true });
+  });
+
+  afterEach(() => tmp.cleanup());
+
+  it("resolves every field to its default when nothing is configured", () => {
+    const view = buildConfigView(phrenPath);
+    expect(view.scope).toBe("global");
+    expect(view.fields["retention.ttlDays"].value).toBe(120);
+    expect(view.fields["retention.ttlDays"].source).toBe("default");
+    expect(view.fields.taskMode.value).toBe("auto");
+    expect(view.fields.taskMode.source).toBe("default");
+    expect(view.fields["proactivity.base"].value).toBe("high");
+    expect(view.fields["proactivity.base"].source).toBe("default");
+  });
+
+  it("marks fields set in a global policy file as global-sourced", () => {
+    writeGlobal(phrenPath, "workflow-policy.json", { taskMode: "suggest", findingSensitivity: "minimal" });
+    const view = buildConfigView(phrenPath);
+    expect(view.fields.taskMode.value).toBe("suggest");
+    expect(view.fields.taskMode.source).toBe("global");
+    expect(view.fields.taskMode.sourcePath).toContain("workflow-policy.json");
+    expect(view.fields.findingSensitivity.value).toBe("minimal");
+    expect(view.fields.findingSensitivity.source).toBe("global");
+  });
+
+  it("marks project overrides as project-sourced with the global inherited value", () => {
+    writeGlobal(phrenPath, "workflow-policy.json", { taskMode: "suggest" });
+    writeProjectConfig(phrenPath, "proj", { config: { taskMode: "off" } });
+    const view = buildConfigView(phrenPath, "proj");
+    expect(view.scope).toBe("project");
+    expect(view.project).toBe("proj");
+    expect(view.fields.taskMode.value).toBe("off");
+    expect(view.fields.taskMode.source).toBe("project");
+    expect(view.fields.taskMode.inheritedValue).toBe("suggest");
+    expect(view.fields.taskMode.sourcePath).toContain("phren.project.yaml");
+  });
+
+  it("inherits proactivity findings/tasks from the resolved base", () => {
+    writeGovernanceInstallPreferences(phrenPath, { proactivity: "low" });
+    const view = buildConfigView(phrenPath);
+    expect(view.fields["proactivity.base"].value).toBe("low");
+    expect(view.fields["proactivity.base"].source).toBe("global");
+    // findings has no own override — inherits base
+    expect(view.fields["proactivity.findings"].value).toBe("low");
+    expect(view.fields["proactivity.findings"].source).toBe("global");
+  });
+
+  it("lets a project override proactivity findings independently of base", () => {
+    writeGovernanceInstallPreferences(phrenPath, { proactivity: "low" });
+    writeProjectConfig(phrenPath, "proj", { config: { proactivityFindings: "high" } });
+    const view = buildConfigView(phrenPath, "proj");
+    expect(view.fields["proactivity.findings"].value).toBe("high");
+    expect(view.fields["proactivity.findings"].source).toBe("project");
+    expect(view.fields["proactivity.base"].value).toBe("low");
+  });
+
+  it("resolves decay milestones individually with partial project overrides", () => {
+    // d60 is customised away from its default (0.85); d30 stays at the default.
+    writeGlobal(phrenPath, "retention-policy.json", {
+      decay: { d30: 1.0, d60: 0.8, d90: 0.65, d120: 0.45 },
+    });
+    writeProjectConfig(phrenPath, "proj", {
+      config: { retentionPolicy: { decay: { d30: 0.5 } } },
+    });
+    const view = buildConfigView(phrenPath, "proj");
+    expect(view.fields["retention.decay.d30"].value).toBe(0.5);
+    expect(view.fields["retention.decay.d30"].source).toBe("project");
+    expect(view.fields["retention.decay.d60"].value).toBe(0.8);
+    expect(view.fields["retention.decay.d60"].source).toBe("global");
+  });
+
+  it("treats a global file that merely mirrors defaults as still default", () => {
+    // repairPreexistingInstall writes policy files containing the defaults —
+    // those must not masquerade as a deliberate global customisation.
+    writeGlobal(phrenPath, "retention-policy.json", {
+      ttlDays: 120,
+      decay: { d30: 1.0, d60: 0.85, d90: 0.65, d120: 0.45 },
+    });
+    const view = buildConfigView(phrenPath);
+    expect(view.fields["retention.ttlDays"].source).toBe("default");
+    expect(view.fields["retention.decay.d60"].source).toBe("default");
+  });
+
+  it("resolves a field for every non-topic schema field", () => {
+    // Anti-drift: a new schema field must also be wired into buildConfigView.
+    const view = buildConfigView(phrenPath);
+    for (const field of allConfigFields()) {
+      if (field.domain === "topic") continue; // topic is stored separately
+      expect(view.fields[field.key], `missing resolved field: ${field.key}`).toBeTruthy();
+    }
+  });
+
+  it("unions access role lists across global and project scope", () => {
+    writeGlobal(phrenPath, "access-control.json", { admins: ["alice"] });
+    writeProjectConfig(phrenPath, "proj", { access: { admins: ["bob"] } });
+    const view = buildConfigView(phrenPath, "proj");
+    expect(view.fields["access.admins"].value).toEqual(["alice", "bob"]);
+    expect(view.fields["access.admins"].source).toBe("project");
+  });
+});

--- a/packages/cli/src/config/resolve.ts
+++ b/packages/cli/src/config/resolve.ts
@@ -1,0 +1,300 @@
+/**
+ * Config resolver — turns the 3-level precedence chain (default → global/profile
+ * → project) into a uniform, per-field view that every surface renders the same.
+ *
+ * `buildConfigView` is consumed by the `get_config` MCP tool, `phren config show`,
+ * the Web UI settings tab, and the VS Code settings webview, so the "where did
+ * this value come from" answer is computed in exactly one place.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { getIndexPolicy } from "../governance/policy.js";
+import { getProjectConfigOverrides } from "../governance/policy.js";
+import { getActiveProfileDefaults } from "../profile-store.js";
+import { readGovernanceInstallPreferences } from "../init/preferences.js";
+import { readProjectConfig } from "../project-config.js";
+import { isRecord } from "../shared.js";
+import { allConfigFields, getConfigField } from "./schema.js";
+import type { ConfigDomainId } from "./schema.js";
+
+/** One field, resolved across the precedence chain. */
+export interface ResolvedField {
+  key: string;
+  value: unknown;
+  /** Where the winning value came from. `global` covers both global files and profile defaults. */
+  source: "default" | "global" | "project";
+  /** The value this field would resolve to if the winning override were removed. */
+  inheritedValue: unknown;
+  /** File that supplied the winning value, when not a default. */
+  sourcePath?: string;
+}
+
+/** The resolved view of every field at a given scope. */
+export interface ConfigView {
+  scope: "global" | "project";
+  project?: string;
+  /** Resolved fields keyed by dotted field key. */
+  fields: Record<string, ResolvedField>;
+}
+
+type Tier = "project" | "profile" | "global" | "default";
+
+interface Level {
+  tier: Tier;
+  value: unknown;
+  path?: string;
+}
+
+/** Structural equality good enough for config values (scalars + flat arrays). */
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  }
+  return false;
+}
+
+/**
+ * Resolve one field from a precedence-ordered list of levels that actually set
+ * it. `levels` must be ordered highest-precedence first and must NOT include the
+ * default tier — the default is appended here.
+ *
+ * Redundant levels are collapsed: a level whose value equals the value of the
+ * level below it is a no-op (e.g. a global policy file that merely mirrors the
+ * defaults), so the source reflects the first level that genuinely changes the
+ * value — never a level that just restates what it would already be.
+ */
+export function resolveConfigField(key: string, def: unknown, levels: Level[]): ResolvedField {
+  const chain: Level[] = [...levels, { tier: "default", value: def }];
+  const value = chain[0].value;
+
+  // The source is the highest level whose value differs from the level below it.
+  let sourceIdx = chain.length - 1; // default, unless something overrides it
+  for (let i = 0; i < chain.length - 1; i++) {
+    if (!valuesEqual(chain[i].value, chain[i + 1].value)) {
+      sourceIdx = i;
+      break;
+    }
+  }
+  const winner = chain[sourceIdx];
+  const inherited = chain[sourceIdx + 1] ?? { tier: "default", value: def };
+  const source: ResolvedField["source"] =
+    winner.tier === "project" ? "project" : winner.tier === "default" ? "default" : "global";
+
+  return {
+    key,
+    value,
+    source,
+    inheritedValue: inherited.value,
+    ...(winner.path ? { sourcePath: winner.path } : {}),
+  };
+}
+
+function readRawJson(file: string): Record<string, unknown> {
+  try {
+    if (!fs.existsSync(file)) return {};
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** A nested-path getter that returns `undefined` for any missing segment. */
+function dig(obj: unknown, ...segments: string[]): unknown {
+  let cur: unknown = obj;
+  for (const seg of segments) {
+    if (!isRecord(cur)) return undefined;
+    cur = cur[seg];
+  }
+  return cur;
+}
+
+/** Push a level only when the value is actually set (not undefined/null). */
+function pushIfSet(levels: Level[], tier: Tier, value: unknown, path?: string): void {
+  if (value !== undefined && value !== null) levels.push({ tier, value, path });
+}
+
+/**
+ * Build the full resolved config view for a scope. When `project` is given, the
+ * view reflects that project's merged config with override provenance; otherwise
+ * it reflects the global defaults.
+ *
+ * Note: the `topic` domain is project-specific and stored separately — it is not
+ * included here; use the `get_config` topic branch for that.
+ */
+export function buildConfigView(phrenPath: string, project?: string): ConfigView {
+  const configDir = path.join(phrenPath, ".config");
+  const retentionPath = path.join(configDir, "retention-policy.json");
+  const workflowPath = path.join(configDir, "workflow-policy.json");
+  const indexPath = path.join(configDir, "index-policy.json");
+  const accessPath = path.join(configDir, "access-control.json");
+  const proactivityPath = path.join(configDir, "install-preferences.json");
+
+  const rawRetention = readRawJson(retentionPath);
+  const rawWorkflow = readRawJson(workflowPath);
+  const rawAccess = readRawJson(accessPath);
+  const govPrefs = readGovernanceInstallPreferences(phrenPath);
+  const indexPolicy = getIndexPolicy(phrenPath);
+
+  let profileDefaults: ReturnType<typeof getActiveProfileDefaults>;
+  try {
+    profileDefaults = getActiveProfileDefaults(phrenPath);
+  } catch {
+    profileDefaults = undefined;
+  }
+
+  const overrides = project ? getProjectConfigOverrides(phrenPath, project) : null;
+  const projectAccess = project ? readProjectConfig(phrenPath, project).access : undefined;
+  const projectConfigPath = project
+    ? path.join(phrenPath, project, "phren.project.yaml")
+    : undefined;
+
+  const fields: Record<string, ResolvedField> = {};
+
+  // ── proactivity ────────────────────────────────────────────────────────────
+  const proactivityKeyMap: Record<string, "proactivity" | "proactivityFindings" | "proactivityTask"> = {
+    "proactivity.base": "proactivity",
+    "proactivity.findings": "proactivityFindings",
+    "proactivity.tasks": "proactivityTask",
+  };
+  const baseLevels: Level[] = [];
+  pushIfSet(baseLevels, "project", overrides?.proactivity, projectConfigPath);
+  pushIfSet(baseLevels, "profile", profileDefaults?.proactivity);
+  pushIfSet(baseLevels, "global", govPrefs.proactivity, proactivityPath);
+  const baseResolved = resolveConfigField("proactivity.base", "high", baseLevels);
+  fields["proactivity.base"] = baseResolved;
+
+  for (const key of ["proactivity.findings", "proactivity.tasks"]) {
+    const ovKey = proactivityKeyMap[key];
+    const levels: Level[] = [];
+    pushIfSet(levels, "project", overrides?.[ovKey], projectConfigPath);
+    pushIfSet(levels, "profile", profileDefaults?.[ovKey]);
+    pushIfSet(levels, "global", govPrefs[ovKey], proactivityPath);
+    if (levels.length === 0) {
+      // No own override at any level: inherit the resolved base verbatim.
+      fields[key] = {
+        key,
+        value: baseResolved.value,
+        source: baseResolved.source,
+        inheritedValue: baseResolved.value,
+        ...(baseResolved.sourcePath ? { sourcePath: baseResolved.sourcePath } : {}),
+      };
+    } else {
+      // Resolve against the base value, so a findings/tasks override only counts
+      // as a source when it genuinely diverges from the inherited base level.
+      fields[key] = resolveConfigField(key, baseResolved.value, levels);
+    }
+  }
+
+  // ── findingSensitivity & taskMode (live in workflow-policy.json) ────────────
+  const fsLevels: Level[] = [];
+  pushIfSet(fsLevels, "project", overrides?.findingSensitivity, projectConfigPath);
+  pushIfSet(fsLevels, "profile", profileDefaults?.findingSensitivity);
+  pushIfSet(fsLevels, "global", rawWorkflow.findingSensitivity, workflowPath);
+  fields.findingSensitivity = resolveConfigField(
+    "findingSensitivity",
+    getConfigField("findingSensitivity")?.default,
+    fsLevels,
+  );
+
+  const tmLevels: Level[] = [];
+  pushIfSet(tmLevels, "project", overrides?.taskMode, projectConfigPath);
+  pushIfSet(tmLevels, "profile", profileDefaults?.taskMode);
+  pushIfSet(tmLevels, "global", rawWorkflow.taskMode, workflowPath);
+  fields.taskMode = resolveConfigField("taskMode", getConfigField("taskMode")?.default, tmLevels);
+
+  // ── retention ──────────────────────────────────────────────────────────────
+  const retentionScalars: Array<[string, string]> = [
+    ["retention.ttlDays", "ttlDays"],
+    ["retention.retentionDays", "retentionDays"],
+    ["retention.autoAcceptThreshold", "autoAcceptThreshold"],
+    ["retention.minInjectConfidence", "minInjectConfidence"],
+  ];
+  for (const [fieldKey, prop] of retentionScalars) {
+    const levels: Level[] = [];
+    pushIfSet(levels, "project", dig(overrides?.retentionPolicy, prop), projectConfigPath);
+    pushIfSet(levels, "profile", dig(profileDefaults?.retentionPolicy, prop));
+    pushIfSet(levels, "global", rawRetention[prop], retentionPath);
+    fields[fieldKey] = resolveConfigField(fieldKey, getConfigField(fieldKey)?.default, levels);
+  }
+  for (const milestone of ["d30", "d60", "d90", "d120"]) {
+    const fieldKey = `retention.decay.${milestone}`;
+    const levels: Level[] = [];
+    pushIfSet(levels, "project", dig(overrides?.retentionPolicy, "decay", milestone), projectConfigPath);
+    pushIfSet(levels, "profile", dig(profileDefaults?.retentionPolicy, "decay", milestone));
+    pushIfSet(levels, "global", dig(rawRetention, "decay", milestone), retentionPath);
+    fields[fieldKey] = resolveConfigField(fieldKey, getConfigField(fieldKey)?.default, levels);
+  }
+
+  // ── workflow ───────────────────────────────────────────────────────────────
+  const lctLevels: Level[] = [];
+  pushIfSet(lctLevels, "project", dig(overrides?.workflowPolicy, "lowConfidenceThreshold"), projectConfigPath);
+  pushIfSet(lctLevels, "profile", dig(profileDefaults?.workflowPolicy, "lowConfidenceThreshold"));
+  pushIfSet(lctLevels, "global", rawWorkflow.lowConfidenceThreshold, workflowPath);
+  fields["workflow.lowConfidenceThreshold"] = resolveConfigField(
+    "workflow.lowConfidenceThreshold",
+    getConfigField("workflow.lowConfidenceThreshold")?.default,
+    lctLevels,
+  );
+
+  const rsLevels: Level[] = [];
+  const projectRisky = dig(overrides?.workflowPolicy, "riskySections");
+  pushIfSet(rsLevels, "project", Array.isArray(projectRisky) && projectRisky.length ? projectRisky : undefined, projectConfigPath);
+  const profileRisky = dig(profileDefaults?.workflowPolicy, "riskySections");
+  pushIfSet(rsLevels, "profile", Array.isArray(profileRisky) && profileRisky.length ? profileRisky : undefined);
+  const globalRisky = rawWorkflow.riskySections;
+  pushIfSet(rsLevels, "global", Array.isArray(globalRisky) && globalRisky.length ? globalRisky : undefined, workflowPath);
+  fields["workflow.riskySections"] = resolveConfigField(
+    "workflow.riskySections",
+    getConfigField("workflow.riskySections")?.default,
+    rsLevels,
+  );
+
+  // ── index (global-only) ────────────────────────────────────────────────────
+  const rawIndex = readRawJson(indexPath);
+  for (const [fieldKey, prop] of [
+    ["index.includeGlobs", "includeGlobs"],
+    ["index.excludeGlobs", "excludeGlobs"],
+    ["index.includeHidden", "includeHidden"],
+  ] as const) {
+    const levels: Level[] = [];
+    pushIfSet(levels, "global", rawIndex[prop], indexPath);
+    const resolved = resolveConfigField(fieldKey, getConfigField(fieldKey)?.default, levels);
+    // Always report the normalized effective value for index.
+    fields[fieldKey] = { ...resolved, value: (indexPolicy as unknown as Record<string, unknown>)[prop] };
+  }
+
+  // ── access ─────────────────────────────────────────────────────────────────
+  for (const [fieldKey, role] of [
+    ["access.admins", "admins"],
+    ["access.contributors", "contributors"],
+    ["access.readers", "readers"],
+  ] as const) {
+    const globalList = Array.isArray(rawAccess[role]) ? (rawAccess[role] as string[]) : undefined;
+    const projectList = Array.isArray(dig(projectAccess, role))
+      ? (dig(projectAccess, role) as string[])
+      : undefined;
+    const levels: Level[] = [];
+    pushIfSet(levels, "project", projectList && projectList.length ? projectList : undefined, projectConfigPath);
+    pushIfSet(levels, "global", globalList && globalList.length ? globalList : undefined, accessPath);
+    // Effective value is the union of every level that contributes.
+    const union = [...new Set([...(globalList ?? []), ...(projectList ?? [])])];
+    const resolved = resolveConfigField(fieldKey, [], levels);
+    fields[fieldKey] = { ...resolved, value: union };
+  }
+
+  return {
+    scope: project ? "project" : "global",
+    ...(project ? { project } : {}),
+    fields,
+  };
+}
+
+/** Field keys belonging to a domain, in schema order. Excludes `topic`. */
+export function fieldKeysForDomain(domain: ConfigDomainId): string[] {
+  return allConfigFields()
+    .filter((f) => f.domain === domain && f.domain !== "topic")
+    .map((f) => f.key);
+}

--- a/packages/cli/src/config/schema.test.ts
+++ b/packages/cli/src/config/schema.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  CONFIG_DOMAINS,
+  allConfigFields,
+  getConfigDomain,
+  getConfigField,
+  resolveConfigDomainAlias,
+} from "./schema.js";
+import { FINDING_SENSITIVITY_CONFIG } from "../cli/config.js";
+import {
+  DEFAULT_POLICY,
+  DEFAULT_WORKFLOW_POLICY,
+  DEFAULT_INDEX_POLICY,
+} from "../governance/policy.js";
+
+describe("config schema", () => {
+  it("defines all eight domains", () => {
+    expect(CONFIG_DOMAINS.map((d) => d.id).sort()).toEqual(
+      ["access", "findingSensitivity", "index", "proactivity", "retention", "taskMode", "topic", "workflow"],
+    );
+  });
+
+  it("has unique field keys", () => {
+    const keys = allConfigFields().map((f) => f.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("keeps every field's domain consistent with its containing domain", () => {
+    for (const domain of CONFIG_DOMAINS) {
+      for (const field of domain.fields) {
+        expect(field.domain).toBe(domain.id);
+      }
+    }
+  });
+
+  it("gives enum fields options and number fields a range", () => {
+    for (const field of allConfigFields()) {
+      if (field.control === "enum") {
+        expect(field.options, `${field.key} should have options`).toBeTruthy();
+        expect(field.options!.length).toBeGreaterThan(1);
+      }
+      if (field.control === "number") {
+        expect(field.range, `${field.key} should have a range`).toBeTruthy();
+        expect(field.range!.min).toBeLessThan(field.range!.max);
+      }
+    }
+  });
+
+  it("marks exactly one recommended option per enum field that has one", () => {
+    for (const field of allConfigFields()) {
+      if (field.control !== "enum" || !field.options) continue;
+      const recommended = field.options.filter((o) => o.recommended);
+      expect(recommended.length, `${field.key} recommended count`).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("derives defaults from the canonical policy constants", () => {
+    expect(getConfigField("retention.ttlDays")?.default).toBe(DEFAULT_POLICY.ttlDays);
+    expect(getConfigField("retention.decay.d90")?.default).toBe(DEFAULT_POLICY.decay.d90);
+    expect(getConfigField("taskMode")?.default).toBe(DEFAULT_WORKFLOW_POLICY.taskMode);
+    expect(getConfigField("findingSensitivity")?.default).toBe(DEFAULT_WORKFLOW_POLICY.findingSensitivity);
+    expect(getConfigField("workflow.lowConfidenceThreshold")?.default)
+      .toBe(DEFAULT_WORKFLOW_POLICY.lowConfidenceThreshold);
+    expect(getConfigField("index.includeHidden")?.default).toBe(DEFAULT_INDEX_POLICY.includeHidden);
+  });
+
+  it("keeps findingSensitivity option blurbs in sync with FINDING_SENSITIVITY_CONFIG", () => {
+    const field = getConfigField("findingSensitivity")!;
+    for (const option of field.options!) {
+      const runtime = FINDING_SENSITIVITY_CONFIG[option.value as keyof typeof FINDING_SENSITIVITY_CONFIG];
+      expect(runtime, `runtime config for ${option.value}`).toBeTruthy();
+      expect(option.blurb).toBe(runtime.agentInstruction);
+    }
+  });
+
+  it("resolves historical CLI subcommand aliases to canonical domains", () => {
+    expect(resolveConfigDomainAlias("task-mode")).toBe("taskMode");
+    expect(resolveConfigDomainAlias("finding-sensitivity")).toBe("findingSensitivity");
+    expect(resolveConfigDomainAlias("policy")).toBe("retention");
+    expect(resolveConfigDomainAlias("PROACTIVITY")).toBe("proactivity");
+    expect(resolveConfigDomainAlias("nonsense")).toBeUndefined();
+  });
+
+  it("looks up domains and fields by id/key", () => {
+    expect(getConfigDomain("retention")?.label).toBe("Retention");
+    expect(getConfigField("retention.ttlDays")?.label).toBe("TTL (days)");
+    expect(getConfigField("missing.key")).toBeUndefined();
+  });
+});

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,0 +1,598 @@
+/**
+ * Shared config schema — the single source of truth every surface renders from.
+ *
+ * The CLI (`phren config`), the Web UI settings tab, and the VS Code settings
+ * webview all import these descriptors so their labels, help text, option lists,
+ * defaults, and ranges can never drift apart.
+ *
+ * Each field is a {@link ConfigFieldDescriptor}; fields are grouped into the
+ * eight {@link CONFIG_DOMAINS}. Nothing here renders UI — descriptors are pure
+ * data so every surface can present them in its own idiom.
+ */
+
+import {
+  DEFAULT_POLICY,
+  DEFAULT_WORKFLOW_POLICY,
+  DEFAULT_INDEX_POLICY,
+} from "../governance/policy.js";
+
+/** The eight configurable domains, named to match the `get_config`/`set_config` MCP tools. */
+export type ConfigDomainId =
+  | "proactivity"
+  | "taskMode"
+  | "findingSensitivity"
+  | "retention"
+  | "workflow"
+  | "index"
+  | "topic"
+  | "access";
+
+/** How a field's value is entered. Surfaces pick a widget from this. */
+export type ConfigControl = "enum" | "number" | "boolean" | "string-list" | "object";
+
+/** Where a field may be set. `global+project` fields support per-project overrides. */
+export type ConfigScope = "global+project" | "global-only" | "project-only";
+
+/** One choice for an `enum` field, with plain-English copy. */
+export interface ConfigOption {
+  value: string;
+  label: string;
+  /** One sentence explaining what choosing this does. */
+  blurb: string;
+  /** True for the safe default most users should keep. */
+  recommended?: boolean;
+}
+
+/** A single configurable setting. */
+export interface ConfigFieldDescriptor {
+  /** Dotted, stable identifier — e.g. `retention.ttlDays`, `proactivity.base`. */
+  key: string;
+  domain: ConfigDomainId;
+  /** Short human label. */
+  label: string;
+  /** One line shown inline next to the control. */
+  summary: string;
+  /** A paragraph shown on a help disclosure. */
+  help: string;
+  control: ConfigControl;
+  /** Present for `enum` and `string-list` (constrained) fields. */
+  options?: ConfigOption[];
+  /** Present for `number` fields. */
+  range?: { min: number; max: number; step: number };
+  /** The value used when nothing is configured at any level. */
+  default: unknown;
+  scope: ConfigScope;
+  /** Plain-English description of what changing this affects. */
+  impact: string;
+  /** `caution` fields trigger a confirm step before applying. */
+  risk: "safe" | "caution";
+}
+
+/** A group of related fields. */
+export interface ConfigDomainDescriptor {
+  id: ConfigDomainId;
+  label: string;
+  /** A codicon-style icon name (used by VS Code; ignored elsewhere). */
+  icon: string;
+  summary: string;
+  scope: ConfigScope;
+  fields: ConfigFieldDescriptor[];
+}
+
+// ── Reusable option lists ─────────────────────────────────────────────────────
+
+const PROACTIVITY_OPTIONS: ConfigOption[] = [
+  {
+    value: "high",
+    label: "High",
+    blurb: "The agent auto-captures eagerly without waiting for an explicit ask.",
+    recommended: true,
+  },
+  {
+    value: "medium",
+    label: "Medium",
+    blurb: "The agent only auto-captures when your message has an explicit signal (e.g. \"remember this\").",
+  },
+  {
+    value: "low",
+    label: "Low",
+    blurb: "The agent never auto-captures — you drive every save yourself.",
+  },
+];
+
+// ── Domain definitions ────────────────────────────────────────────────────────
+
+export const CONFIG_DOMAINS: ConfigDomainDescriptor[] = [
+  {
+    id: "proactivity",
+    label: "Proactivity",
+    icon: "pulse",
+    summary: "How eagerly the agent acts on its own to capture memory.",
+    scope: "global+project",
+    fields: [
+      {
+        key: "proactivity.base",
+        domain: "proactivity",
+        label: "Base proactivity",
+        summary: "Master auto-capture level for both findings and tasks.",
+        help:
+          "Sets the default eagerness for everything the agent captures without being asked. "
+          + "Findings and tasks each inherit this unless you override them below.",
+        control: "enum",
+        options: PROACTIVITY_OPTIONS,
+        default: "high",
+        scope: "global+project",
+        impact: "Higher = more memories saved automatically; lower = you stay fully in control.",
+        risk: "safe",
+      },
+      {
+        key: "proactivity.findings",
+        domain: "proactivity",
+        label: "Findings proactivity",
+        summary: "Auto-capture level for findings specifically.",
+        help:
+          "Overrides the base level just for findings (insights, decisions, pitfalls). "
+          + "Leave unset to inherit the base level.",
+        control: "enum",
+        options: PROACTIVITY_OPTIONS,
+        default: "high",
+        scope: "global+project",
+        impact: "Controls how often the agent writes to FINDINGS.md on its own.",
+        risk: "safe",
+      },
+      {
+        key: "proactivity.tasks",
+        domain: "proactivity",
+        label: "Tasks proactivity",
+        summary: "Auto-capture level for tasks specifically.",
+        help:
+          "Overrides the base level just for tasks. Leave unset to inherit the base level.",
+        control: "enum",
+        options: PROACTIVITY_OPTIONS,
+        default: "high",
+        scope: "global+project",
+        impact: "Controls how often the agent adds items to tasks.md on its own.",
+        risk: "safe",
+      },
+    ],
+  },
+  {
+    id: "taskMode",
+    label: "Task mode",
+    icon: "checklist",
+    summary: "How much authority the agent has over your task list.",
+    scope: "global+project",
+    fields: [
+      {
+        key: "taskMode",
+        domain: "taskMode",
+        label: "Task mode",
+        summary: "What the agent is allowed to do with tasks.",
+        help:
+          "Governs whether the agent may create, complete, and reorder tasks for you, "
+          + "or whether task management stays entirely in your hands.",
+        control: "enum",
+        options: [
+          {
+            value: "auto",
+            label: "Auto",
+            blurb: "The agent freely creates, updates, and completes tasks as work progresses.",
+            recommended: true,
+          },
+          {
+            value: "suggest",
+            label: "Suggest",
+            blurb: "The agent proposes task changes but waits for you to confirm.",
+          },
+          {
+            value: "manual",
+            label: "Manual",
+            blurb: "Only you create and change tasks; the agent never touches them.",
+          },
+          {
+            value: "off",
+            label: "Off",
+            blurb: "Task tracking is disabled entirely.",
+          },
+        ],
+        default: DEFAULT_WORKFLOW_POLICY.taskMode,
+        scope: "global+project",
+        impact: "`off` hides the task system completely; `auto` lets the agent run it.",
+        risk: "caution",
+      },
+    ],
+  },
+  {
+    id: "findingSensitivity",
+    label: "Finding sensitivity",
+    icon: "lightbulb",
+    summary: "How selective the agent is about what counts as worth remembering.",
+    scope: "global+project",
+    fields: [
+      {
+        key: "findingSensitivity",
+        domain: "findingSensitivity",
+        label: "Finding sensitivity",
+        summary: "The bar for what the agent saves as a finding.",
+        help:
+          "Sets both the per-session cap on auto-captured findings and the instruction the "
+          + "agent follows about what is worth keeping.",
+        control: "enum",
+        options: [
+          {
+            value: "minimal",
+            label: "Minimal",
+            blurb: "Only save findings when the user explicitly asks you to remember something.",
+          },
+          {
+            value: "conservative",
+            label: "Conservative",
+            blurb: "Save decisions and pitfalls only — skip patterns and observations.",
+          },
+          {
+            value: "balanced",
+            label: "Balanced",
+            blurb: "Save non-obvious patterns, decisions, pitfalls, and bugs worth remembering next session.",
+            recommended: true,
+          },
+          {
+            value: "aggressive",
+            label: "Aggressive",
+            blurb: "Save everything worth remembering — err on the side of capturing.",
+          },
+        ],
+        default: DEFAULT_WORKFLOW_POLICY.findingSensitivity,
+        scope: "global+project",
+        impact: "Higher = more findings per session (cap 0/3/10/20), larger context injection, more noise.",
+        risk: "safe",
+      },
+    ],
+  },
+  {
+    id: "retention",
+    label: "Retention",
+    icon: "archive",
+    summary: "How long memory lives and how its confidence decays over time.",
+    scope: "global+project",
+    fields: [
+      {
+        key: "retention.ttlDays",
+        domain: "retention",
+        label: "TTL (days)",
+        summary: "Age at which a memory becomes eligible for pruning review.",
+        help:
+          "Findings older than this are considered for cleanup during consolidation. "
+          + "It does not delete anything by itself.",
+        control: "number",
+        range: { min: 7, max: 3650, step: 1 },
+        default: DEFAULT_POLICY.ttlDays,
+        scope: "global+project",
+        impact: "Lower = memory turns over faster; higher = old findings linger longer.",
+        risk: "safe",
+      },
+      {
+        key: "retention.retentionDays",
+        domain: "retention",
+        label: "Retention (days)",
+        summary: "Hard age cutoff — findings past this are pruned.",
+        help:
+          "The maximum age a finding can reach before `phren maintain prune` removes it. "
+          + "Shrinking this can permanently drop old memory.",
+        control: "number",
+        range: { min: 30, max: 3650, step: 1 },
+        default: DEFAULT_POLICY.retentionDays,
+        scope: "global+project",
+        impact: "Lowering this deletes findings older than the new cutoff on the next prune.",
+        risk: "caution",
+      },
+      {
+        key: "retention.autoAcceptThreshold",
+        domain: "retention",
+        label: "Auto-accept threshold",
+        summary: "Confidence score above which a finding skips the review queue.",
+        help:
+          "Findings scoring at or above this go straight in; lower-scoring ones land in the "
+          + "review queue for you to approve.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_POLICY.autoAcceptThreshold,
+        scope: "global+project",
+        impact: "Higher = more findings routed to manual review; lower = more auto-accepted.",
+        risk: "safe",
+      },
+      {
+        key: "retention.minInjectConfidence",
+        domain: "retention",
+        label: "Min inject confidence",
+        summary: "Lowest confidence a finding may have to be injected into context.",
+        help:
+          "Findings scoring below this are kept on disk but not surfaced into the agent's "
+          + "context automatically.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_POLICY.minInjectConfidence,
+        scope: "global+project",
+        impact: "Higher = only strong memories get injected; lower = weaker ones surface too.",
+        risk: "safe",
+      },
+      {
+        key: "retention.decay.d30",
+        domain: "retention",
+        label: "Decay @ 30 days",
+        summary: "Confidence multiplier applied to a finding 30 days old.",
+        help: "Part of the decay curve — how much a 30-day-old finding's confidence is scaled.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_POLICY.decay.d30,
+        scope: "global+project",
+        impact: "Lower values make recent memory fade faster.",
+        risk: "safe",
+      },
+      {
+        key: "retention.decay.d60",
+        domain: "retention",
+        label: "Decay @ 60 days",
+        summary: "Confidence multiplier applied to a finding 60 days old.",
+        help: "Part of the decay curve — how much a 60-day-old finding's confidence is scaled.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_POLICY.decay.d60,
+        scope: "global+project",
+        impact: "Lower values make mid-age memory fade faster.",
+        risk: "safe",
+      },
+      {
+        key: "retention.decay.d90",
+        domain: "retention",
+        label: "Decay @ 90 days",
+        summary: "Confidence multiplier applied to a finding 90 days old.",
+        help: "Part of the decay curve — how much a 90-day-old finding's confidence is scaled.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_POLICY.decay.d90,
+        scope: "global+project",
+        impact: "Lower values make older memory fade faster.",
+        risk: "safe",
+      },
+      {
+        key: "retention.decay.d120",
+        domain: "retention",
+        label: "Decay @ 120 days",
+        summary: "Confidence multiplier applied to a finding 120 days old.",
+        help: "Part of the decay curve — how much a 120-day-old finding's confidence is scaled.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_POLICY.decay.d120,
+        scope: "global+project",
+        impact: "Lower values make stale memory fade faster.",
+        risk: "safe",
+      },
+    ],
+  },
+  {
+    id: "workflow",
+    label: "Workflow",
+    icon: "settings-gear",
+    summary: "Review gating and which memory sections are treated as risky.",
+    scope: "global+project",
+    fields: [
+      {
+        key: "workflow.lowConfidenceThreshold",
+        domain: "workflow",
+        label: "Low-confidence threshold",
+        summary: "Score below which a finding is flagged as low-confidence.",
+        help:
+          "Findings scoring under this are treated as low-confidence and may be routed to the "
+          + "review queue rather than accepted silently.",
+        control: "number",
+        range: { min: 0, max: 1, step: 0.05 },
+        default: DEFAULT_WORKFLOW_POLICY.lowConfidenceThreshold,
+        scope: "global+project",
+        impact: "Higher = more findings flagged for review; lower = fewer flagged.",
+        risk: "safe",
+      },
+      {
+        key: "workflow.riskySections",
+        domain: "workflow",
+        label: "Risky sections",
+        summary: "Review-queue sections that require explicit attention.",
+        help:
+          "Findings landing in these sections are surfaced for review instead of being "
+          + "treated as settled. Choose any of Review, Stale, Conflicts.",
+        control: "string-list",
+        options: [
+          { value: "Review", label: "Review", blurb: "Items explicitly queued for your review." },
+          { value: "Stale", label: "Stale", blurb: "Findings that have aged past their TTL." },
+          { value: "Conflicts", label: "Conflicts", blurb: "Findings that contradict another finding." },
+        ],
+        default: DEFAULT_WORKFLOW_POLICY.riskySections,
+        scope: "global+project",
+        impact: "More sections = more findings held back for explicit attention.",
+        risk: "safe",
+      },
+    ],
+  },
+  {
+    id: "index",
+    label: "Index",
+    icon: "search",
+    summary: "Which files the search indexer reads.",
+    scope: "global-only",
+    fields: [
+      {
+        key: "index.includeGlobs",
+        domain: "index",
+        label: "Include globs",
+        summary: "Glob patterns the indexer reads.",
+        help:
+          "Files matching any of these globs are indexed for search. Removing a pattern hides "
+          + "those files from search until the next reindex.",
+        control: "string-list",
+        default: DEFAULT_INDEX_POLICY.includeGlobs,
+        scope: "global-only",
+        impact: "Narrowing this shrinks what search and context injection can find.",
+        risk: "caution",
+      },
+      {
+        key: "index.excludeGlobs",
+        domain: "index",
+        label: "Exclude globs",
+        summary: "Glob patterns the indexer skips.",
+        help:
+          "Files matching any of these globs are never indexed, even if they match an include "
+          + "pattern. Excludes win over includes.",
+        control: "string-list",
+        default: DEFAULT_INDEX_POLICY.excludeGlobs,
+        scope: "global-only",
+        impact: "Adding a pattern removes those files from search on the next reindex.",
+        risk: "caution",
+      },
+      {
+        key: "index.includeHidden",
+        domain: "index",
+        label: "Index hidden files",
+        summary: "Whether dotfiles and dot-directories are indexed.",
+        help: "When on, files and folders beginning with `.` are eligible for indexing.",
+        control: "boolean",
+        default: DEFAULT_INDEX_POLICY.includeHidden,
+        scope: "global-only",
+        impact: "Turning this on can pull in `.config` and similar files.",
+        risk: "caution",
+      },
+    ],
+  },
+  {
+    id: "topic",
+    label: "Topics",
+    icon: "symbol-namespace",
+    summary: "Per-project topic classification for routing findings.",
+    scope: "project-only",
+    fields: [
+      {
+        key: "topic.domain",
+        domain: "topic",
+        label: "Project domain",
+        summary: "The high-level domain this project belongs to.",
+        help:
+          "A coarse classification (e.g. backend, frontend, data) used to tune how findings "
+          + "are organised for this project.",
+        control: "string-list",
+        default: null,
+        scope: "project-only",
+        impact: "Affects how new findings are routed into topic files.",
+        risk: "safe",
+      },
+      {
+        key: "topic.topics",
+        domain: "topic",
+        label: "Topics",
+        summary: "Named topics findings are bucketed into for this project.",
+        help:
+          "Each topic has a slug, a label, an optional description, and keywords used to "
+          + "match findings to it.",
+        control: "object",
+        default: [],
+        scope: "project-only",
+        impact: "Editing topics changes how this project's findings are grouped.",
+        risk: "safe",
+      },
+    ],
+  },
+  {
+    id: "access",
+    label: "Access control",
+    icon: "shield",
+    summary: "Role-based permissions over who can read and write memory.",
+    scope: "global+project",
+    fields: [
+      {
+        key: "access.admins",
+        domain: "access",
+        label: "Admins",
+        summary: "Actors allowed every action, including config changes.",
+        help:
+          "Actor names (matched against PHREN_ACTOR) with full permissions. "
+          + "When all three role lists are empty, phren runs in open mode.",
+        control: "string-list",
+        default: [],
+        scope: "global+project",
+        impact: "Admins can change config and manage findings, tasks, and access itself.",
+        risk: "caution",
+      },
+      {
+        key: "access.contributors",
+        domain: "access",
+        label: "Contributors",
+        summary: "Actors allowed to add and edit findings and tasks.",
+        help: "Actor names with read-write access to findings and tasks but not config.",
+        control: "string-list",
+        default: [],
+        scope: "global+project",
+        impact: "Contributors can write memory but cannot change configuration.",
+        risk: "caution",
+      },
+      {
+        key: "access.readers",
+        domain: "access",
+        label: "Readers",
+        summary: "Actors allowed read-only access.",
+        help: "Actor names that may search and read but never mutate memory.",
+        control: "string-list",
+        default: [],
+        scope: "global+project",
+        impact: "Readers can search and view but cannot add or edit anything.",
+        risk: "caution",
+      },
+    ],
+  },
+];
+
+// ── Lookups ───────────────────────────────────────────────────────────────────
+
+const DOMAIN_BY_ID = new Map<ConfigDomainId, ConfigDomainDescriptor>(
+  CONFIG_DOMAINS.map((d) => [d.id, d]),
+);
+
+const FIELD_BY_KEY = new Map<string, ConfigFieldDescriptor>(
+  CONFIG_DOMAINS.flatMap((d) => d.fields.map((f) => [f.key, f] as const)),
+);
+
+/** Look up a domain descriptor by id. */
+export function getConfigDomain(id: ConfigDomainId): ConfigDomainDescriptor | undefined {
+  return DOMAIN_BY_ID.get(id);
+}
+
+/** Look up a field descriptor by its dotted key. */
+export function getConfigField(key: string): ConfigFieldDescriptor | undefined {
+  return FIELD_BY_KEY.get(key);
+}
+
+/** Every field across every domain, in domain order. */
+export function allConfigFields(): ConfigFieldDescriptor[] {
+  return CONFIG_DOMAINS.flatMap((d) => d.fields);
+}
+
+/**
+ * Aliases mapping the historical hyphenated `phren config` subcommands to the
+ * canonical domain ids. Help text and routing are generated from this so the
+ * CLI surface can never drift from the schema.
+ */
+export const CONFIG_DOMAIN_ALIASES: Record<string, ConfigDomainId> = {
+  proactivity: "proactivity",
+  "task-mode": "taskMode",
+  taskmode: "taskMode",
+  "finding-sensitivity": "findingSensitivity",
+  findingsensitivity: "findingSensitivity",
+  policy: "retention",
+  retention: "retention",
+  workflow: "workflow",
+  index: "index",
+  topic: "topic",
+  topics: "topic",
+  access: "access",
+};
+
+/** Resolve a user-supplied domain/subcommand token to a canonical domain id. */
+export function resolveConfigDomainAlias(token: string): ConfigDomainId | undefined {
+  return CONFIG_DOMAIN_ALIASES[token.trim().toLowerCase()];
+}

--- a/packages/cli/src/governance/policy.ts
+++ b/packages/cli/src/governance/policy.ts
@@ -106,7 +106,8 @@ export type RetentionPolicyPatch = Partial<Omit<RetentionPolicy, "decay">> & {
 
 export const GOVERNANCE_SCHEMA_VERSION = 1;
 
-const DEFAULT_POLICY: RetentionPolicy = {
+/** Default retention policy. Exported so {@link config/schema} can render one source of truth. */
+export const DEFAULT_POLICY: RetentionPolicy = {
   schemaVersion: GOVERNANCE_SCHEMA_VERSION,
   ttlDays: 120,
   retentionDays: 365,
@@ -120,7 +121,8 @@ const DEFAULT_POLICY: RetentionPolicy = {
   },
 };
 
-const DEFAULT_WORKFLOW_POLICY: WorkflowPolicy = {
+/** Default workflow policy. Exported so {@link config/schema} can render one source of truth. */
+export const DEFAULT_WORKFLOW_POLICY: WorkflowPolicy = {
   schemaVersion: GOVERNANCE_SCHEMA_VERSION,
   lowConfidenceThreshold: 0.7,
   riskySections: ["Stale", "Conflicts"],
@@ -128,7 +130,8 @@ const DEFAULT_WORKFLOW_POLICY: WorkflowPolicy = {
   findingSensitivity: "balanced",
 };
 
-const DEFAULT_INDEX_POLICY: IndexPolicy = {
+/** Default index policy. Exported so {@link config/schema} can render one source of truth. */
+export const DEFAULT_INDEX_POLICY: IndexPolicy = {
   schemaVersion: GOVERNANCE_SCHEMA_VERSION,
   includeGlobs: ["**/*.md", "**/skills/**/*.md", ".claude/skills/**/*.md"],
   excludeGlobs: ["**/.git/**", "**/node_modules/**", "**/dist/**", "**/build/**"],

--- a/packages/cli/src/memory-ui.test.ts
+++ b/packages/cli/src/memory-ui.test.ts
@@ -160,6 +160,51 @@ describe.sequential("web-ui server", () => {
     expect(res.body).toBe("Not found");
   });
 
+  it("serves a resolved config view with schema via /api/config/view", async () => {
+    const body = await new Promise<string>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/api/config/view`, (res) => {
+        let out = "";
+        res.on("data", (chunk) => { out += String(chunk); });
+        res.on("end", () => resolve(out));
+      }).on("error", reject);
+    });
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.view.scope).toBe("global");
+    expect(parsed.view.fields["retention.ttlDays"].value).toBe(120);
+    expect(parsed.view.fields["retention.ttlDays"].source).toBe("default");
+    expect(Array.isArray(parsed.schema)).toBe(true);
+    expect(parsed.schema.length).toBe(8);
+  });
+
+  it("includes the resolved view and index policy in /api/settings", async () => {
+    const body = await new Promise<string>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/api/settings`, (res) => {
+        let out = "";
+        res.on("data", (chunk) => { out += String(chunk); });
+        res.on("end", () => resolve(out));
+      }).on("error", reject);
+    });
+    const parsed = JSON.parse(body);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.view).toBeTruthy();
+    expect(parsed.view.fields.taskMode).toBeTruthy();
+    expect(parsed.indexPolicy).toBeTruthy();
+    expect(Array.isArray(parsed.indexPolicy.includeGlobs)).toBe(true);
+  });
+
+  it("updates the index policy via POST /api/settings/index-policy", async () => {
+    const res = await postForm(port, "/api/settings/index-policy", {
+      includeGlobs: "**/*.md, docs/**/*.md",
+      includeHidden: "true",
+    });
+    expect(res.status).toBe(200);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.indexPolicy.includeGlobs).toContain("docs/**/*.md");
+    expect(parsed.indexPolicy.includeHidden).toBe(true);
+  });
+
   it("change token updates when project content changes", async () => {
     const readToken = async (): Promise<string> => {
       return await new Promise((resolve, reject) => {

--- a/packages/cli/src/tools/config.ts
+++ b/packages/cli/src/tools/config.ts
@@ -34,6 +34,8 @@ import {
   writeProjectTopics,
   type ProjectTopic,
 } from "../project-topics.js";
+import { buildConfigView } from "../config/resolve.js";
+import { getConfigField, CONFIG_DOMAINS } from "../config/schema.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -96,6 +98,28 @@ function getTopicConfigData(phrenPath: string, project: string) {
       pinnedTopics: raw?.pinnedTopics ?? [],
     },
   };
+}
+
+/**
+ * Resolved per-field provenance for the requested domain(s), keyed by dotted
+ * field key. Every field carries the uniform `{ value, source, inheritedValue,
+ * sourcePath }` shape so all surfaces render the same 3-level source chip.
+ */
+function resolvedFields(phrenPath: string, domain: string, project?: string) {
+  const view = buildConfigView(phrenPath, project);
+  if (domain === "all") return view.fields;
+  return Object.fromEntries(
+    Object.entries(view.fields).filter(([key]) => getConfigField(key)?.domain === domain),
+  );
+}
+
+/**
+ * The shared schema descriptors for the requested domain(s). Surfaces that can't
+ * import `@phren/cli` directly (e.g. the VS Code extension) render entirely from
+ * this, so they never re-hardcode labels, options, or defaults.
+ */
+function configSchema(domain: string) {
+  return domain === "all" ? CONFIG_DOMAINS : CONFIG_DOMAINS.filter((d) => d.id === domain);
 }
 
 // ── Handlers ─────────────────────────────────────────────────────────────────
@@ -201,6 +225,9 @@ async function handleGetConfig(
       result.index = getIndexPolicy(phrenPath);
     }
 
+    result.fields = resolvedFields(phrenPath, d, project);
+    result.schema = configSchema(d);
+
     return mcpResponse({
       ok: true,
       message: `Config for ${d === "all" ? "all domains" : d} (project: ${project}).`,
@@ -232,6 +259,9 @@ async function handleGetConfig(
   if (d === "all" || d === "index") {
     result.index = getIndexPolicy(phrenPath);
   }
+
+  result.fields = resolvedFields(phrenPath, d);
+  result.schema = configSchema(d);
 
   return mcpResponse({
     ok: true,

--- a/packages/cli/src/ui/page.ts
+++ b/packages/cli/src/ui/page.ts
@@ -334,6 +334,12 @@ ${PHREN_DEEP_VOID_STYLES}
           <div id="settings-workflow" style="color:var(--muted)">Loading...</div>
         </div>
       </section>
+      <section class="settings-section" style="border-top:3px solid color-mix(in srgb, var(--cyan) 45%, var(--border))">
+        <div class="settings-section-header">Index Policy</div>
+        <div class="settings-section-body">
+          <div id="settings-index" style="color:var(--muted)">Loading...</div>
+        </div>
+      </section>
       <section class="settings-section settings-section-integrations">
         <div class="settings-section-header">Integrations</div>
         <div class="settings-section-body">

--- a/packages/cli/src/ui/scripts.ts
+++ b/packages/cli/src/ui/scripts.ts
@@ -1201,6 +1201,30 @@ export function renderTasksAndSettingsScript(authToken: string): string {
           workflowEl.innerHTML = wfHtml;
         }
 
+        var indexEl = document.getElementById('settings-index');
+        if (indexEl && !isProject) {
+          var idx = data.indexPolicy || {};
+          var idxHtml = '';
+          function idxGlobRow(label, field, note) {
+            var val = Array.isArray(idx[field]) ? idx[field].join(', ') : '';
+            idxHtml += '<div class="settings-control">';
+            idxHtml += '<div class="settings-control-header"><span class="settings-control-label">' + esc(label) + '</span></div>';
+            idxHtml += '<div class="settings-control-note">' + esc(note) + '</div>';
+            idxHtml += '<div style="display:flex;gap:8px;align-items:center;margin-top:8px">' +
+              '<input type="text" id="idx-input-' + esc(field) + '" value="' + esc(val) + '" style="flex:1;min-width:0;border:1px solid var(--border);border-radius:var(--radius-sm);padding:4px 8px;font-size:var(--text-sm);background:var(--surface);color:var(--ink)">' +
+              '<button data-ts-action="setGlobalIndex" data-field="' + esc(field) + '" class="settings-chip active" style="font-size:11px">Set</button>' +
+              '</div></div>';
+          }
+          idxGlobRow('Include globs', 'includeGlobs', 'Comma-separated glob patterns the indexer reads.');
+          idxGlobRow('Exclude globs', 'excludeGlobs', 'Comma-separated glob patterns the indexer skips. Excludes win over includes.');
+          idxHtml += '<div class="settings-control"><div class="settings-control-header"><span class="settings-control-label">Index hidden files</span>';
+          idxHtml += '<button data-ts-action="toggleIndexHidden" data-enabled="' + (idx.includeHidden ? 'true' : 'false') + '" class="settings-chip' + (idx.includeHidden ? ' active' : '') + '" style="margin-left:auto">' + (idx.includeHidden ? 'On' : 'Off') + '</button></div>';
+          idxHtml += '<div class="settings-control-note">When on, dotfiles and dot-directories are eligible for indexing.</div></div>';
+          indexEl.innerHTML = idxHtml;
+        } else if (indexEl && isProject) {
+          indexEl.innerHTML = '<div style="color:var(--muted);font-size:var(--text-sm)">Index policy is global — switch to Global scope to edit it.</div>';
+        }
+
         var integrationsEl = document.getElementById('settings-integrations');
         if (integrationsEl && !isProject) {
           var tools = Array.isArray(data.hookTools) ? data.hookTools : [];
@@ -1388,6 +1412,17 @@ export function renderTasksAndSettingsScript(authToken: string): string {
         var inputEl = document.getElementById('wf-input-' + field);
         var val = inputEl ? inputEl.value : '';
         postProjectOverride(proj, field, val, false);
+      }
+      else if (action === 'setGlobalIndex') {
+        var field = actionEl.getAttribute('data-field') || '';
+        var inputEl = document.getElementById('idx-input-' + field);
+        var payload = {};
+        payload[field] = inputEl ? inputEl.value : '';
+        postSettings('/api/settings/index-policy', payload, 'Index policy updated.');
+      }
+      else if (action === 'toggleIndexHidden') {
+        var nextHidden = actionEl.getAttribute('data-enabled') !== 'true';
+        postSettings('/api/settings/index-policy', { includeHidden: String(nextHidden) }, 'Index policy updated.');
       }
     });
 

--- a/packages/cli/src/ui/server.ts
+++ b/packages/cli/src/ui/server.ts
@@ -47,8 +47,10 @@ import {
   unpinProjectTopicSuggestion,
   writeProjectTopics,
 } from "../project-topics.js";
-import { getWorkflowPolicy, updateWorkflowPolicy, mergeConfig, getRetentionPolicy, getProjectConfigOverrides, VALID_TASK_MODES } from "../governance/policy.js";
+import { getWorkflowPolicy, updateWorkflowPolicy, mergeConfig, getRetentionPolicy, getProjectConfigOverrides, getIndexPolicy, updateIndexPolicy, VALID_TASK_MODES } from "../governance/policy.js";
 import { readProjectConfig, updateProjectConfigOverrides } from "../project-config.js";
+import { buildConfigView } from "../config/resolve.js";
+import { CONFIG_DOMAINS } from "../config/schema.js";
 import { findSkill } from "../skill/registry.js";
 import { setSkillEnabledAndSync } from "../skill/files.js";
 import { repairPreexistingInstall } from "../init/setup.js";
@@ -611,13 +613,18 @@ function handleGetSettings(res: Res, url: string, ctx: RouteCtx): void {
         hasClaudeMd: fs.existsSync(path.join(projectDir, "CLAUDE.md")), findingCount, taskCount,
       };
     }
+    const indexPolicy = getIndexPolicy(ctx.phrenPath);
+    const view = buildConfigView(
+      ctx.phrenPath,
+      settingsProject && isValidProjectName(settingsProject) ? settingsProject : undefined,
+    );
     jsonOk(res, {
       ok: true, proactivity: prefs.proactivity || "high", proactivityFindings,
       proactivityTask: prefs.proactivityTask || prefs.proactivity || "high", taskMode: workflowPolicy.taskMode,
       findingSensitivity: workflowPolicy.findingSensitivity || "balanced", autoCaptureEnabled: proactivityFindings !== "low",
       consolidationEntryThreshold: CONSOLIDATION_ENTRY_THRESHOLD, hooksEnabled: hooksData.globalEnabled,
       mcpEnabled: prefs.mcpEnabled !== false, hookTools: hooksData.tools,
-      retentionPolicy, workflowPolicy, merged, overrides, projectInfo,
+      retentionPolicy, workflowPolicy, indexPolicy, merged, overrides, projectInfo, view,
     });
   } catch (err: unknown) {
     jsonErr(res, errorMessage(err));
@@ -630,7 +637,23 @@ function handleGetConfig(res: Res, url: string, ctx: RouteCtx): void {
   try {
     const config = mergeConfig(ctx.phrenPath, project || undefined);
     const projects = getProjectDirs(ctx.phrenPath, ctx.profile).map((d) => path.basename(d)).filter((p) => p !== "global");
-    jsonOk(res, { ok: true, config, projects });
+    const view = buildConfigView(ctx.phrenPath, project || undefined);
+    jsonOk(res, { ok: true, config, projects, view });
+  } catch (err: unknown) {
+    jsonErr(res, errorMessage(err));
+  }
+}
+
+/**
+ * Resolved config view plus the shared schema — everything the settings UI
+ * needs to render every domain with a consistent source chip, in one call.
+ */
+function handleGetConfigView(res: Res, url: string, ctx: RouteCtx): void {
+  const project = String(parseQs(url).project || "");
+  if (project && !isValidProjectName(project)) return jsonErr(res, "Invalid project name", 400);
+  try {
+    const view = buildConfigView(ctx.phrenPath, project || undefined);
+    jsonOk(res, { ok: true, view, schema: CONFIG_DOMAINS });
   } catch (err: unknown) {
     jsonErr(res, errorMessage(err));
   }
@@ -892,6 +915,23 @@ function handlePostSettingsAutoCapture(req: Req, res: Res, url: string, ctx: Rou
   });
 }
 
+function handlePostSettingsIndexPolicy(req: Req, res: Res, url: string, ctx: RouteCtx): void {
+  withPostBody(req, res, url, ctx, (parsed) => {
+    const patch: { includeGlobs?: string[]; excludeGlobs?: string[]; includeHidden?: boolean } = {};
+    const toGlobList = (v: unknown): string[] =>
+      (Array.isArray(v) ? v : String(v ?? "").split(","))
+        .map((s) => String(s).trim())
+        .filter(Boolean);
+    if (Object.prototype.hasOwnProperty.call(parsed, "includeGlobs")) patch.includeGlobs = toGlobList(parsed.includeGlobs);
+    if (Object.prototype.hasOwnProperty.call(parsed, "excludeGlobs")) patch.excludeGlobs = toGlobList(parsed.excludeGlobs);
+    if (Object.prototype.hasOwnProperty.call(parsed, "includeHidden")) {
+      patch.includeHidden = String(parsed.includeHidden).toLowerCase() === "true";
+    }
+    const result = updateIndexPolicy(ctx.phrenPath, patch);
+    jsonOk(res, result.ok ? { ok: true, indexPolicy: result.data } : { ok: false, error: result.error });
+  });
+}
+
 function handlePostSettingsMcpEnabled(req: Req, res: Res, url: string, ctx: RouteCtx): void {
   withPostBody(req, res, url, ctx, (parsed) => {
     const enabled = String(parsed.enabled || "").toLowerCase() === "true";
@@ -1124,6 +1164,7 @@ export function createWebUiHttpServer(
         case "/api/tasks": return handleGetTasks(res, ctx);
         case "/api/settings": return handleGetSettings(res, url, ctx);
         case "/api/config": return handleGetConfig(res, url, ctx);
+        case "/api/config/view": return handleGetConfigView(res, url, ctx);
         case "/api/csrf-token": return handleGetCsrfToken(res, ctx);
         case "/api/profiles": return handleGetProfiles(res, ctx);
         case "/api/search": return await handleGetSearch(res, url, ctx);
@@ -1161,6 +1202,7 @@ export function createWebUiHttpServer(
         case "/api/settings/proactivity": return handlePostSettingsProactivity(req, res, url, ctx);
         case "/api/settings/auto-capture": return handlePostSettingsAutoCapture(req, res, url, ctx);
         case "/api/settings/mcp-enabled": return handlePostSettingsMcpEnabled(req, res, url, ctx);
+        case "/api/settings/index-policy": return handlePostSettingsIndexPolicy(req, res, url, ctx);
         case "/api/settings/project-overrides": return handlePostSettingsProjectOverrides(req, res, url, ctx);
       }
       // Prefix-matched write routes

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -182,8 +182,13 @@
       },
       {
         "command": "phren.projectConfig",
-        "title": "Phren: Project Config",
+        "title": "Phren: Project Config (Quick Edit)",
         "icon": "$(settings-gear)"
+      },
+      {
+        "command": "phren.openSettings",
+        "title": "Phren: Open Settings Dashboard",
+        "icon": "$(gear)"
       },
       {
         "command": "phren.toggleProject",
@@ -421,6 +426,11 @@
       "view/title": [
         {
           "command": "phren.addProject",
+          "when": "view == phren.explorer",
+          "group": "navigation"
+        },
+        {
+          "command": "phren.openSettings",
           "when": "view == phren.explorer",
           "group": "navigation"
         },

--- a/packages/vscode/src/commands/project-commands.ts
+++ b/packages/vscode/src/commands/project-commands.ts
@@ -7,6 +7,7 @@ import { showGraphWebview } from "../graphWebview";
 import { showProjectFile } from "../projectFileViewer";
 import { showSkillEditor } from "../skillEditor";
 import { showProjectConfigPanel } from "../configPanel";
+import { showSettingsWebview } from "../settingsWebview";
 import { showSetupWizard } from "../setupWizard";
 
 export function registerProjectCommands(ctx: ExtensionContext): vscode.Disposable[] {
@@ -418,7 +419,17 @@ export function registerProjectCommands(ctx: ExtensionContext): vscode.Disposabl
     }
   });
 
+  const openSettings = vscode.commands.registerCommand("phren.openSettings", async (projectName?: unknown) => {
+    try {
+      const initial = typeof projectName === "string" ? projectName : statusBar.getActiveProjectName() ?? undefined;
+      await showSettingsWebview(phrenClient, ctx.context, initial);
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to open Phren settings: ${toErrorMessage(error)}`);
+    }
+  });
+
   return [
+    openSettings,
     setActiveProject,
     search,
     showGraph,

--- a/packages/vscode/src/settingsWebview.ts
+++ b/packages/vscode/src/settingsWebview.ts
@@ -1,0 +1,430 @@
+/**
+ * Phren settings webview — a full configuration dashboard for the VS Code
+ * extension.
+ *
+ * It renders every config domain from the shared schema that `get_config`
+ * returns (so labels, options, help, and defaults never drift from the CLI or
+ * Web UI), shows each field's resolved value with a 3-level source chip
+ * (default / global / project), and writes changes back through `set_config`.
+ */
+
+import * as vscode from "vscode";
+import * as crypto from "crypto";
+import { PhrenClient } from "./phrenClient";
+
+// ── Shapes mirrored from the MCP get_config response ──────────────────────────
+
+interface SchemaOption {
+  value: string;
+  label: string;
+  blurb: string;
+  recommended?: boolean;
+}
+
+interface SchemaField {
+  key: string;
+  domain: string;
+  label: string;
+  summary: string;
+  help: string;
+  control: "enum" | "number" | "boolean" | "string-list" | "object";
+  options?: SchemaOption[];
+  range?: { min: number; max: number; step: number };
+  default: unknown;
+  scope: "global+project" | "global-only" | "project-only";
+  impact: string;
+  risk: "safe" | "caution";
+}
+
+interface SchemaDomain {
+  id: string;
+  label: string;
+  icon: string;
+  summary: string;
+  scope: string;
+  fields: SchemaField[];
+}
+
+interface ResolvedField {
+  key: string;
+  value: unknown;
+  source: "default" | "global" | "project";
+  inheritedValue: unknown;
+  sourcePath?: string;
+}
+
+interface ConfigSnapshot {
+  schema: SchemaDomain[];
+  fields: Record<string, ResolvedField>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function esc(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined || value === null) return "unset";
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "none";
+  if (typeof value === "boolean") return value ? "on" : "off";
+  return String(value);
+}
+
+/** Map a dotted field key + new value to a `set_config` domain + settings payload. */
+function toSetConfig(key: string, value: unknown): { domain: string; settings: Record<string, unknown> } | null {
+  if (key === "proactivity.base") return { domain: "proactivity", settings: { level: value, scope: "base" } };
+  if (key === "proactivity.findings") return { domain: "proactivity", settings: { level: value, scope: "findings" } };
+  if (key === "proactivity.tasks") return { domain: "proactivity", settings: { level: value, scope: "tasks" } };
+  if (key === "taskMode") return { domain: "taskMode", settings: { mode: value } };
+  if (key === "findingSensitivity") return { domain: "findingSensitivity", settings: { level: value } };
+  if (key.startsWith("retention.decay.")) {
+    return { domain: "retention", settings: { decay: { [key.slice("retention.decay.".length)]: value } } };
+  }
+  if (key.startsWith("retention.")) {
+    return { domain: "retention", settings: { [key.slice("retention.".length)]: value } };
+  }
+  if (key === "workflow.lowConfidenceThreshold") return { domain: "workflow", settings: { lowConfidenceThreshold: value } };
+  if (key === "workflow.riskySections") return { domain: "workflow", settings: { riskySections: value } };
+  if (key.startsWith("index.")) return { domain: "index", settings: { [key.slice("index.".length)]: value } };
+  return null; // access / topic — not writable through set_config
+}
+
+/** Whether a field can be edited at the current scope. */
+function isEditable(field: SchemaField, isProject: boolean): boolean {
+  if (field.domain === "access" || field.domain === "topic") return false;
+  if (field.scope === "global-only") return !isProject;
+  if (field.scope === "project-only") return isProject;
+  return true;
+}
+
+// ── Data loading ──────────────────────────────────────────────────────────────
+
+async function loadSnapshot(client: PhrenClient, project?: string): Promise<ConfigSnapshot> {
+  const raw = await client.getConfig("all", project);
+  const data = asRecord(asRecord(raw)?.data);
+  const schema = asArray(data?.schema) as SchemaDomain[];
+  const fields = (asRecord(data?.fields) as Record<string, ResolvedField>) ?? {};
+  return { schema, fields };
+}
+
+async function loadProjectNames(client: PhrenClient): Promise<string[]> {
+  try {
+    const raw = await client.listProjects();
+    const data = asRecord(asRecord(raw)?.data);
+    const names: string[] = [];
+    for (const entry of asArray(data?.projects)) {
+      const name = asRecord(entry)?.name;
+      if (typeof name === "string") names.push(name);
+    }
+    return names.sort();
+  } catch {
+    return [];
+  }
+}
+
+// ── HTML rendering ────────────────────────────────────────────────────────────
+
+function sourceChip(field: SchemaField, resolved: ResolvedField | undefined): string {
+  const source = resolved?.source ?? "default";
+  const titleParts: string[] = [];
+  if (source === "default") titleParts.push("Using the built-in default.");
+  else if (source === "global") titleParts.push("Set in global config (~/.phren/.config).");
+  else titleParts.push("Overridden for this project (phren.project.yaml).");
+  if (source !== "default" && resolved) {
+    titleParts.push(`Without this: ${formatValue(resolved.inheritedValue)}.`);
+  }
+  if (resolved?.sourcePath) titleParts.push(resolved.sourcePath);
+  return `<span class="chip chip-${esc(source)}" title="${esc(titleParts.join(" "))}">${esc(source)}</span>`;
+}
+
+function renderControl(field: SchemaField, resolved: ResolvedField | undefined, editable: boolean): string {
+  const value = resolved ? resolved.value : field.default;
+  if (!editable) {
+    return `<div class="value readonly">${esc(formatValue(value))}</div>`;
+  }
+  const dataKey = `data-key="${esc(field.key)}"`;
+
+  if (field.control === "enum" && field.options) {
+    const buttons = field.options.map((opt) => {
+      const active = String(value) === opt.value ? " active" : "";
+      const star = opt.recommended ? " ★" : "";
+      return `<button class="opt${active}" ${dataKey} data-value="${esc(opt.value)}" `
+        + `title="${esc(opt.blurb)}">${esc(opt.label)}${star}</button>`;
+    }).join("");
+    return `<div class="opts">${buttons}</div>`;
+  }
+
+  if (field.control === "boolean") {
+    const on = value === true;
+    return `<button class="toggle${on ? " active" : ""}" ${dataKey} data-value="${on ? "false" : "true"}">`
+      + `${on ? "On" : "Off"}</button>`;
+  }
+
+  if (field.control === "number") {
+    const r = field.range;
+    const attrs = r ? `min="${r.min}" max="${r.max}" step="${r.step}"` : "";
+    return `<div class="numrow">`
+      + `<input type="number" id="in-${esc(field.key)}" value="${esc(String(value ?? ""))}" ${attrs} />`
+      + `<button class="set" ${dataKey} data-kind="number">Set</button></div>`;
+  }
+
+  // string-list — comma separated
+  const listValue = Array.isArray(value) ? value.join(", ") : "";
+  return `<div class="numrow">`
+    + `<input type="text" id="in-${esc(field.key)}" value="${esc(listValue)}" placeholder="comma,separated" />`
+    + `<button class="set" ${dataKey} data-kind="list">Set</button></div>`;
+}
+
+function renderField(field: SchemaField, resolved: ResolvedField | undefined, isProject: boolean): string {
+  const editable = isEditable(field, isProject);
+  const cautionBadge = field.risk === "caution" ? `<span class="caution" title="Changing this has notable side effects.">caution</span>` : "";
+  const scopeNote = !editable && field.domain !== "access" && field.domain !== "topic"
+    ? `<div class="note">${field.scope === "global-only"
+      ? "Global-only — switch to Global scope to edit."
+      : "Project-only — select a project to edit."}</div>`
+    : "";
+  const accessNote = field.domain === "access"
+    ? `<div class="note">Edit access roles with <code>phren config access</code>.</div>`
+    : "";
+  return `<div class="field">
+    <div class="field-head">
+      <span class="field-label">${esc(field.label)}</span>
+      ${cautionBadge}
+      ${sourceChip(field, resolved)}
+    </div>
+    <div class="field-summary">${esc(field.summary)}</div>
+    ${renderControl(field, resolved, editable)}
+    ${scopeNote}${accessNote}
+    <details class="help"><summary>What this does</summary>
+      <div class="help-body">${esc(field.help)}</div>
+      <div class="help-impact"><strong>Impact:</strong> ${esc(field.impact)}</div>
+    </details>
+  </div>`;
+}
+
+function renderDomain(domain: SchemaDomain, fields: Record<string, ResolvedField>, isProject: boolean): string {
+  const rows = domain.fields.map((f) => renderField(f, fields[f.key], isProject)).join("");
+  return `<section class="domain">
+    <div class="domain-head">
+      <span class="domain-label">${esc(domain.label)}</span>
+      <span class="domain-summary">${esc(domain.summary)}</span>
+    </div>
+    ${rows}
+  </section>`;
+}
+
+function renderHtml(
+  snapshot: ConfigSnapshot,
+  scope: string | undefined,
+  projects: string[],
+  nonce: string,
+): string {
+  const isProject = Boolean(scope);
+  const scopeOptions = [
+    `<option value=""${scope ? "" : " selected"}>Global (all projects)</option>`,
+    ...projects.map((p) => `<option value="${esc(p)}"${p === scope ? " selected" : ""}>${esc(p)}</option>`),
+  ].join("");
+
+  const domainsHtml = snapshot.schema.length
+    ? snapshot.schema.map((d) => renderDomain(d, snapshot.fields, isProject)).join("")
+    : `<p class="empty">Could not load the config schema. Is the Phren MCP server running?</p>`;
+
+  const scopeLine = isProject
+    ? `Editing <strong>${esc(scope)}</strong> — changes write to <code>phren.project.yaml</code>.`
+    : `Editing <strong>global</strong> config — applies to every project unless overridden.`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+<style>
+  body { font-family: var(--vscode-font-family); color: var(--vscode-foreground);
+    background: var(--vscode-editor-background); padding: 0 20px 40px; }
+  h1 { font-size: 1.3em; margin: 18px 0 4px; }
+  .scope-bar { display: flex; align-items: center; gap: 10px; margin: 14px 0 6px;
+    flex-wrap: wrap; }
+  .scope-bar select { background: var(--vscode-dropdown-background);
+    color: var(--vscode-dropdown-foreground); border: 1px solid var(--vscode-dropdown-border);
+    padding: 4px 8px; border-radius: 4px; }
+  .scope-note { color: var(--vscode-descriptionForeground); font-size: 0.9em; }
+  .domain { border: 1px solid var(--vscode-panel-border); border-radius: 6px;
+    margin: 16px 0; overflow: hidden; }
+  .domain-head { padding: 10px 14px; background: var(--vscode-sideBar-background);
+    border-bottom: 1px solid var(--vscode-panel-border); }
+  .domain-label { font-weight: 600; }
+  .domain-summary { color: var(--vscode-descriptionForeground); margin-left: 8px; font-size: 0.9em; }
+  .field { padding: 12px 14px; border-bottom: 1px solid var(--vscode-panel-border); }
+  .field:last-child { border-bottom: none; }
+  .field-head { display: flex; align-items: center; gap: 8px; }
+  .field-label { font-weight: 600; }
+  .field-summary { color: var(--vscode-descriptionForeground); font-size: 0.9em;
+    margin: 2px 0 8px; }
+  .chip { font-size: 0.72em; padding: 1px 7px; border-radius: 9px; text-transform: uppercase;
+    letter-spacing: 0.04em; }
+  .chip-default { background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); }
+  .chip-global { background: var(--vscode-statusBarItem-prominentBackground, #3a3d8a);
+    color: var(--vscode-statusBar-foreground, #fff); }
+  .chip-project { background: var(--vscode-statusBarItem-warningBackground, #8a5a1a);
+    color: var(--vscode-statusBar-foreground, #fff); }
+  .caution { font-size: 0.72em; padding: 1px 7px; border-radius: 9px;
+    background: var(--vscode-inputValidation-warningBackground, #6b4a00);
+    color: var(--vscode-foreground); }
+  .opts { display: flex; flex-wrap: wrap; gap: 6px; }
+  .opt, .toggle, .set { background: var(--vscode-button-secondaryBackground);
+    color: var(--vscode-button-secondaryForeground); border: 1px solid var(--vscode-panel-border);
+    padding: 4px 10px; border-radius: 4px; cursor: pointer; font-size: 0.9em; }
+  .opt.active, .toggle.active { background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground); border-color: var(--vscode-button-background); }
+  .opt:hover, .toggle:hover, .set:hover { filter: brightness(1.15); }
+  .numrow { display: flex; gap: 6px; align-items: center; }
+  .numrow input { background: var(--vscode-input-background); color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+    padding: 4px 8px; border-radius: 4px; min-width: 120px; }
+  .value.readonly { color: var(--vscode-descriptionForeground); font-family: var(--vscode-editor-font-family); }
+  .note { color: var(--vscode-descriptionForeground); font-size: 0.85em; margin-top: 6px; font-style: italic; }
+  .help { margin-top: 8px; }
+  .help summary { cursor: pointer; color: var(--vscode-textLink-foreground); font-size: 0.85em; }
+  .help-body, .help-impact { color: var(--vscode-descriptionForeground); font-size: 0.85em;
+    margin-top: 6px; }
+  code { background: var(--vscode-textCodeBlock-background); padding: 1px 4px; border-radius: 3px; }
+  .empty { color: var(--vscode-descriptionForeground); }
+</style>
+</head>
+<body>
+  <h1>Phren Settings</h1>
+  <div class="scope-bar">
+    <label for="scope">Scope:</label>
+    <select id="scope">${scopeOptions}</select>
+    <button class="set" id="refresh">Refresh</button>
+  </div>
+  <div class="scope-note">${scopeLine}</div>
+  ${domainsHtml}
+  <script nonce="${nonce}">
+    const vscodeApi = acquireVsCodeApi();
+    document.getElementById('scope').addEventListener('change', function (e) {
+      vscodeApi.postMessage({ command: 'changeScope', scope: e.target.value });
+    });
+    document.getElementById('refresh').addEventListener('click', function () {
+      vscodeApi.postMessage({ command: 'refresh' });
+    });
+    document.body.addEventListener('click', function (e) {
+      const el = e.target.closest('[data-key]');
+      if (!el) return;
+      const key = el.getAttribute('data-key');
+      if (el.classList.contains('opt') || el.classList.contains('toggle')) {
+        let value = el.getAttribute('data-value');
+        if (value === 'true') value = true;
+        else if (value === 'false') value = false;
+        vscodeApi.postMessage({ command: 'setField', key: key, value: value });
+        return;
+      }
+      if (el.classList.contains('set')) {
+        const input = document.getElementById('in-' + key);
+        if (!input) return;
+        const kind = el.getAttribute('data-kind');
+        let value;
+        if (kind === 'number') {
+          value = Number(input.value);
+          if (!isFinite(value)) return;
+        } else if (kind === 'list') {
+          value = input.value.split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+        } else {
+          value = input.value;
+        }
+        vscodeApi.postMessage({ command: 'setField', key: key, value: value });
+      }
+    });
+  </script>
+</body>
+</html>`;
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+/**
+ * Open the Phren settings dashboard. `initialProject`, when given, opens the
+ * panel scoped to that project.
+ */
+export async function showSettingsWebview(
+  client: PhrenClient,
+  context: vscode.ExtensionContext,
+  initialProject?: string,
+): Promise<void> {
+  const panel = vscode.window.createWebviewPanel(
+    "phren.settings",
+    "Phren Settings",
+    vscode.ViewColumn.One,
+    { enableScripts: true, retainContextWhenHidden: true },
+  );
+
+  let scope: string | undefined = initialProject;
+
+  async function render(): Promise<void> {
+    const nonce = crypto.randomBytes(16).toString("base64");
+    try {
+      const [snapshot, projects] = await Promise.all([
+        loadSnapshot(client, scope),
+        loadProjectNames(client),
+      ]);
+      if (scope && !projects.includes(scope)) scope = undefined;
+      panel.webview.html = renderHtml(snapshot, scope, projects, nonce);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      panel.webview.html = `<!DOCTYPE html><html><body style="font-family:sans-serif;padding:20px">`
+        + `<h2>Phren Settings</h2><p>Failed to load configuration:</p>`
+        + `<pre>${esc(message)}</pre></body></html>`;
+    }
+  }
+
+  await render();
+
+  panel.webview.onDidReceiveMessage(async (raw: unknown) => {
+    const msg = asRecord(raw);
+    if (!msg) return;
+    const command = msg.command;
+
+    if (command === "changeScope") {
+      scope = typeof msg.scope === "string" && msg.scope ? msg.scope : undefined;
+      await render();
+      return;
+    }
+
+    if (command === "refresh") {
+      await render();
+      return;
+    }
+
+    if (command === "setField" && typeof msg.key === "string") {
+      const mapped = toSetConfig(msg.key, msg.value);
+      if (!mapped) {
+        await vscode.window.showWarningMessage(`Phren: "${msg.key}" cannot be edited here.`);
+        return;
+      }
+      try {
+        const result = await client.setConfig(mapped.domain, mapped.settings, scope);
+        const data = asRecord(asRecord(result)?.data);
+        const warning = typeof data?.warning === "string" ? data.warning : undefined;
+        if (warning) void vscode.window.showWarningMessage(`Phren: ${warning}`);
+        await render();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        await vscode.window.showErrorMessage(`Phren: failed to update ${msg.key}: ${message}`);
+      }
+    }
+  }, undefined, context.subscriptions);
+}


### PR DESCRIPTION
## Summary

Makes configuration a first-class, discoverable part of every surface, driven by **one shared schema** so copy and defaults can no longer drift between the CLI, Web UI, and VS Code extension.

## Changes

- **`config/schema.ts`** — single source of truth for all 8 config domains (labels, plain-English help, options, defaults, ranges, impact, risk).
- **`config/resolve.ts`** — `buildConfigView` resolves every field through the 3-level precedence chain to `{value, source, inheritedValue, sourcePath}`. A global file that merely mirrors the defaults is correctly reported as `default`.
- **`get_config`** now returns uniform `fields` + `schema` alongside existing keys (backward compatible).
- **CLI** — `phren config show` rewritten: grouped by domain, source column (`default`/`global`/`project`), `--diff` and `--json` flags. New `phren config access` subcommand.
- **Web UI** — Index Policy settings section; new `/api/config/view` endpoint; resolved `view` added to `/api/config` and `/api/settings`.
- **VS Code** — new Settings Dashboard webview (`phren.openSettings`, gear icon) covering every domain with source chips and inline help.

## Release

Bumps `@phren/cli` to **0.1.31**. CHANGELOG updated; doc version strings bumped.

## Testing

- 22 new tests (schema, resolver, CLI config show/access, Web UI endpoints).
- Full suite green (2649 passed); build, lint, and `validate-docs` pass.
- Web UI endpoints live-smoke-tested. VS Code webview is compile-verified only — recommend a manual smoke before the separate `phren-vscode` release.

## Notes

- Web UI got the Index section + backend `view` foundation; source chips on the other domains aren't rendered yet (data is exposed for follow-up).
- The interactive `phren config` TUI from the original plan was descoped in favour of the much richer `config show` + the two webviews.