### PR TITLE
fix(cli): reliability hardening and faster incremental indexing

### DIFF
--- a/packages/cli/src/__tests__/index-invalidation.test.ts
+++ b/packages/cli/src/__tests__/index-invalidation.test.ts
@@ -70,6 +70,35 @@ describe("index invalidation: file changes trigger rebuild", () => {
     expect(afterOld.length).toBe(0);
   });
 
+  it("stores mtime/size meta alongside file hashes after a build", async () => {
+    db = await buildIndex(tmp.path);
+
+    const hashFile = path.join(tmp.path, ".runtime", "index-hashes.json");
+    const data = JSON.parse(fs.readFileSync(hashFile, "utf8"));
+    const findingsPath = path.join(tmp.path, "myapp", "FINDINGS.md");
+
+    expect(data.hashes[findingsPath]).toBeTruthy();
+    expect(data.meta).toBeTruthy();
+    const stat = fs.statSync(findingsPath);
+    expect(data.meta[findingsPath]).toEqual({ mtimeMs: stat.mtimeMs, size: stat.size });
+  });
+
+  it("rewriting a file with identical content (mtime bump) keeps the doc indexed", async () => {
+    db = await buildIndex(tmp.path);
+    db.close();
+
+    const findingsPath = path.join(tmp.path, "myapp", "FINDINGS.md");
+    const content = fs.readFileSync(findingsPath, "utf8");
+    // Bump mtime without changing content: stat check misses, hash check confirms no change
+    fs.utimesSync(findingsPath, new Date(), new Date(Date.now() + 5000));
+    fs.writeFileSync(findingsPath, content);
+
+    db = await buildIndex(tmp.path);
+
+    const results = db.exec("SELECT content FROM docs WHERE content LIKE '%Zymurgical%'");
+    expect(results.length).toBeGreaterThan(0);
+  });
+
   it("project file using @import gets global content indexed", async () => {
     // Write a project file that @imports the global conventions
     writeFile(

--- a/packages/cli/src/__tests__/mcp-graph.test.ts
+++ b/packages/cli/src/__tests__/mcp-graph.test.ts
@@ -56,6 +56,32 @@ describe("manual-links.json persistence", () => {
     ]);
   });
 
+  it("merges valid links across projects and prunes stale ones in one pass", async () => {
+    seedFindings(tmp.path, "alpha", "# alpha\n\n- Alpha finding about caching\n");
+    seedFindings(tmp.path, "beta", "# beta\n\n- Beta finding about routing\n");
+    const manualLinksPath = runtimeFile(tmp.path, "manual-links.json");
+    fs.mkdirSync(path.dirname(manualLinksPath), { recursive: true });
+    fs.writeFileSync(manualLinksPath, JSON.stringify([
+      { entity: "cache-layer", entityType: "library", sourceDoc: "alpha/FINDINGS.md", relType: "mentions" },
+      { entity: "edge-router", entityType: "library", sourceDoc: "beta/FINDINGS.md", relType: "mentions" },
+      { entity: "ghost-lib", entityType: "library", sourceDoc: "deleted-proj/FINDINGS.md", relType: "mentions" },
+    ]));
+
+    const db = await buildIndex(tmp.path);
+
+    const entityNames = db.exec("SELECT name FROM entities WHERE name IN ('cache-layer', 'edge-router', 'ghost-lib')");
+    const found = (entityNames[0]?.values ?? []).map((row) => row[0]);
+    expect(found).toContain("cache-layer");
+    expect(found).toContain("edge-router");
+    expect(found).not.toContain("ghost-lib");
+
+    // Stale link pruned from disk; valid links survive
+    expect(JSON.parse(fs.readFileSync(manualLinksPath, "utf8"))).toEqual([
+      { entity: "cache-layer", entityType: "library", sourceDoc: "alpha/FINDINGS.md", relType: "mentions" },
+      { entity: "edge-router", entityType: "library", sourceDoc: "beta/FINDINGS.md", relType: "mentions" },
+    ]);
+  });
+
   it("handles missing manual-links.json gracefully", async () => {
     seedFindings(tmp.path, "proj", "# proj\n\n- A finding\n");
     await expect(buildIndex(tmp.path)).resolves.toBeDefined();

--- a/packages/cli/src/__tests__/tool-registration.test.ts
+++ b/packages/cli/src/__tests__/tool-registration.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { register as registerSearch } from "../tools/search.js";
+import { register as registerTask } from "../tools/tasks.js";
+import { register as registerFinding } from "../tools/finding.js";
+import { register as registerMemory } from "../tools/memory.js";
+import { register as registerData } from "../tools/data.js";
+import { register as registerGraph } from "../tools/graph.js";
+import { register as registerSession } from "../tools/session.js";
+import { register as registerOps } from "../tools/ops.js";
+import { register as registerSkills } from "../tools/skills.js";
+import { register as registerHooks } from "../tools/hooks.js";
+import { register as registerExtract } from "../tools/extract.js";
+import { register as registerConfig } from "../tools/config.js";
+import type { McpContext } from "../tools/types.js";
+
+const ALL_REGISTER_FNS = [
+  registerSearch,
+  registerTask,
+  registerFinding,
+  registerMemory,
+  registerData,
+  registerGraph,
+  registerSession,
+  registerOps,
+  registerSkills,
+  registerHooks,
+  registerExtract,
+  registerConfig,
+];
+
+function makeRecordingServer() {
+  const names: string[] = [];
+  return {
+    names,
+    registerTool(name: string, _meta: unknown, _handler: unknown) {
+      names.push(name);
+    },
+  };
+}
+
+describe("MCP tool registration", () => {
+  it("registers no duplicate tool names across all modules", () => {
+    const server = makeRecordingServer();
+    const ctx: McpContext = {
+      phrenPath: "/nonexistent",
+      profile: "test",
+      db: () => { throw new Error("not needed at registration time"); },
+      rebuildIndex: async () => {},
+      updateFileInIndex: () => {},
+      withWriteQueue: async <T>(fn: () => Promise<T>) => fn(),
+    };
+
+    for (const register of ALL_REGISTER_FNS) {
+      register(server as any, ctx);
+    }
+
+    const duplicates = server.names.filter((name, i) => server.names.indexOf(name) !== i);
+    expect(duplicates).toEqual([]);
+    expect(server.names.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/src/cli-config-proactivity.test.ts
+++ b/packages/cli/src/cli-config-proactivity.test.ts
@@ -136,15 +136,17 @@ describe("handleConfig proactivity", () => {
   it("rejects invalid proactivity values", async () => {
     const { handleConfig } = await importCliConfig();
     const output = captureConsole();
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
+    const previousExitCode = process.exitCode;
 
-    await expect(handleConfig(["proactivity.findings", "urgent"])).rejects.toThrow("process.exit");
+    try {
+      await handleConfig(["proactivity.findings", "urgent"]);
 
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(output.errors).toContain("Usage: phren config proactivity.findings [high|medium|low]");
-    expect(fs.existsSync(governancePrefsPath())).toBe(false);
+      expect(process.exitCode).toBe(1);
+      expect(output.errors).toContain("Usage: phren config proactivity.findings [high|medium|low]");
+      expect(fs.existsSync(governancePrefsPath())).toBe(false);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 });
 

--- a/packages/cli/src/cli/config-proactivity.ts
+++ b/packages/cli/src/cli/config-proactivity.ts
@@ -62,7 +62,8 @@ export function handleConfigProactivity(subcommand: "proactivity" | "proactivity
     if (projectArg) {
       if (!isValidProjectName(projectArg)) {
         console.error(`Invalid project name: "${projectArg}"`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
       const resolved = mergeConfig(phrenPath, projectArg);
       console.log(JSON.stringify({
@@ -79,19 +80,22 @@ export function handleConfigProactivity(subcommand: "proactivity" | "proactivity
 
   if (filteredArgs.length !== 1) {
     printProactivityUsage(subcommand);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const level = normalizeProactivityLevel(value);
   if (!level) {
     printProactivityUsage(subcommand);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (projectArg) {
     if (!isValidProjectName(projectArg)) {
       console.error(`Invalid project name: "${projectArg}"`);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     warnIfUnregistered(phrenPath, projectArg);
     const key = subcommand === "proactivity" ? "proactivity"
@@ -147,13 +151,15 @@ export function handleConfigProjectOwnership(args: string[]) {
 
   if (args.length !== 1) {
     console.error(`Usage: phren config project-ownership [${PROJECT_OWNERSHIP_MODES.join("|")}]`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const ownership = parseProjectOwnershipMode(value);
   if (!ownership) {
     console.error(`Usage: phren config project-ownership [${PROJECT_OWNERSHIP_MODES.join("|")}]`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   writeInstallPreferences(phrenPath, { projectOwnershipDefault: ownership });

--- a/packages/cli/src/cli/config-synonyms.ts
+++ b/packages/cli/src/cli/config-synonyms.ts
@@ -34,7 +34,8 @@ export function handleConfigSynonyms(args: string[]) {
 
   if (!project || !isValidProjectName(project)) {
     printSynonymsUsage();
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (action === "list") {
@@ -51,7 +52,8 @@ export function handleConfigSynonyms(args: string[]) {
     const synonyms = parseSynonymItems(args[3]);
     if (!term || synonyms.length === 0) {
       printSynonymsUsage();
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     const updated = learnSynonym(phrenPath, project, term, synonyms);
     console.log(JSON.stringify({ project, term, synonyms: updated[term.toLowerCase()] ?? [], updated }, null, 2));
@@ -62,7 +64,8 @@ export function handleConfigSynonyms(args: string[]) {
     const term = args[2];
     if (!term) {
       printSynonymsUsage();
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     const updated = removeLearnedSynonym(phrenPath, project, term, parseSynonymItems(args[3]));
     console.log(JSON.stringify({ project, term: term.toLowerCase(), updated }, null, 2));
@@ -70,5 +73,5 @@ export function handleConfigSynonyms(args: string[]) {
   }
 
   printSynonymsUsage();
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/packages/cli/src/cli/team.ts
+++ b/packages/cli/src/cli/team.ts
@@ -41,18 +41,21 @@ async function handleTeamInit(args: string[]): Promise<void> {
 
   if (!name) {
     console.error("Usage: phren team init <name> [--remote <url>] [--description <text>]");
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   if (!isValidProjectName(name)) {
     console.error(`Invalid store name: "${name}". Use lowercase letters, numbers, hyphens.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Check if store already exists
   const existing = findStoreByName(phrenPath, name);
   if (existing) {
     console.error(`Store "${name}" already exists at ${existing.path}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const storesDir = path.join(path.dirname(phrenPath), ".phren-stores");
@@ -60,7 +63,8 @@ async function handleTeamInit(args: string[]): Promise<void> {
 
   if (fs.existsSync(storePath)) {
     console.error(`Directory already exists: ${storePath}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Create the team store directory
@@ -173,7 +177,8 @@ async function handleTeamJoin(args: string[]): Promise<void> {
 
   if (!remote) {
     console.error("Usage: phren team join <git-url> [--name <name>]");
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const storesDir = path.join(path.dirname(phrenPath), ".phren-stores");
@@ -182,19 +187,22 @@ async function handleTeamJoin(args: string[]): Promise<void> {
 
   if (!isValidProjectName(inferredName)) {
     console.error(`Invalid store name: "${inferredName}". Use --name to specify a valid name.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const existing = findStoreByName(phrenPath, inferredName);
   if (existing) {
     console.error(`Store "${inferredName}" already exists at ${existing.path}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const storePath = path.join(storesDir, inferredName);
   if (fs.existsSync(storePath)) {
     console.error(`Directory already exists: ${storePath}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Clone the remote
@@ -239,22 +247,26 @@ async function handleTeamAddProject(args: string[]): Promise<void> {
 
   if (!storeName || !projectName) {
     console.error("Usage: phren team add-project <store-name> <project-name>");
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   if (!isValidProjectName(projectName)) {
     console.error(`Invalid project name: "${projectName}"`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   const store = findStoreByName(phrenPath, storeName);
   if (!store) {
     console.error(`Store "${storeName}" not found. Run 'phren store list' to see available stores.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   if (store.role === "readonly") {
     console.error(`Store "${storeName}" is read-only. Cannot add projects.`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Create project directory in the store
@@ -347,7 +359,8 @@ export async function handleTeamNamespace(args: string[]): Promise<void> {
 `);
       if (subcommand) {
         console.error(`Unknown subcommand: ${subcommand}`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
       }
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { log as structuredLog, logger } from "./logger.js";
 import {
   buildIndex,
+  flushEmbeddingQueue,
   updateFileInIndex as updateFileInIndexFn,
 } from "./shared/index.js";
 import { runCustomHooks } from "./hooks.js";
@@ -91,6 +92,7 @@ async function main() {
   cleanStaleLocks(phrenPath);
   let db: Awaited<ReturnType<typeof buildIndex>> | null = null;
   let indexReady = false;
+  let shuttingDown = false;
   try {
     db = await buildIndex(phrenPath, profile);
     indexReady = true;
@@ -192,8 +194,16 @@ async function main() {
     "get_tasks",
   ]);
 
+  const registeredToolNames = new Set<string>();
+
   server.registerTool = function (name: RegisterToolName, config: RegisterToolConfig, handler: RegisterToolHandler) {
     const registeredName = name;
+    // Registration runs before server.connect, so throwing here fails fast at
+    // startup instead of letting a later module silently shadow an earlier tool.
+    if (registeredToolNames.has(registeredName as string)) {
+      throw new Error(`Duplicate MCP tool registration: "${String(registeredName)}"`);
+    }
+    registeredToolNames.add(registeredName as string);
     let finalConfig = config;
     if (ALWAYS_LOAD_TOOLS.has(registeredName as string)) {
       const cfgObj = config as Record<string, unknown>;
@@ -201,6 +211,17 @@ async function main() {
       finalConfig = { ...cfgObj, _meta: { ...existingMeta, "anthropic/alwaysLoad": true } } as RegisterToolConfig;
     }
     const wrapped = async (...args: unknown[]) => {
+      if (shuttingDown) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: false,
+              error: "phren-mcp server is shutting down; retry in a new session",
+            }, null, 2),
+          }],
+        };
+      }
       if (!indexReady || !db) {
         return {
           content: [{
@@ -255,11 +276,22 @@ async function main() {
 
   // Graceful shutdown: drain write queue and close DB before exit
   async function shutdown(signal: string): Promise<void> {
+    shuttingDown = true;
     structuredLog("info", "shutdown", `Received ${signal}, draining write queue...`);
     try {
       await writeQueue;
     } catch {
       // Write queue errors already logged
+    }
+    // Persist any pending embeddings; bounded so a slow/unreachable Ollama
+    // can't stall shutdown.
+    try {
+      await Promise.race([
+        flushEmbeddingQueue(),
+        new Promise<void>((resolve) => setTimeout(resolve, 3000)),
+      ]);
+    } catch (err: unknown) {
+      logger.warn("shutdown", `embFlush: ${errorMessage(err)}`);
     }
     try { db?.close(); } catch (err: unknown) {
       logger.warn("shutdown", `dbClose: ${errorMessage(err)}`);

--- a/packages/cli/src/shared/index.ts
+++ b/packages/cli/src/shared/index.ts
@@ -86,8 +86,10 @@ import { bootstrapSqlJs } from "./sqljs.js";
 import { getProjectOwnershipMode, getProjectSourcePath, readProjectConfig } from "../project-config.js";
 import {
   buildSourceDocKey,
-  queryDocBySourceKey,
+  decodeStringRow,
+  getDocSourceKey,
   queryDocRows,
+  queryRows,
   type SqlJsDatabase,
 } from "../index-query.js";
 import {
@@ -138,8 +140,19 @@ function scheduleEmbedding(phrenPath: string, docPath: string, content: string):
   _embQueue.set(docPath, { phrenPath, content });
   if (_embTimer) clearTimeout(_embTimer);
   _embTimer = setTimeout(() => { _embTimer = null; void _drainEmbQueue(); }, 500);
-  // Unref so the timer doesn't keep short-lived CLI processes alive
+  // Unref so the timer doesn't keep short-lived CLI processes alive. Pending
+  // embeddings are lost if such a process exits first (acceptable: they're
+  // regenerated on demand); the MCP server calls flushEmbeddingQueue on shutdown.
   _embTimer.unref();
+}
+
+/** Drain pending embeddings immediately (used by the MCP server's graceful shutdown). */
+export async function flushEmbeddingQueue(): Promise<void> {
+  if (_embTimer) {
+    clearTimeout(_embTimer);
+    _embTimer = null;
+  }
+  await _drainEmbQueue();
 }
 
 async function _drainEmbQueue(): Promise<void> {
@@ -420,13 +433,27 @@ function computePhrenHash(phrenPath: string, profile?: string, preGlobbed?: stri
 
 const INDEX_HASHES_FILENAME = "index-hashes.json";
 const INDEX_SCHEMA_VERSION = 3; // bump when FTS schema changes to force full rebuild
+// Deletion share above which an incremental update falls back to a full rebuild.
+const MAX_INCREMENTAL_DELETE_RATIO = 0.5;
 
 function hashFileContent(filePath: string): string {
   const content = fs.readFileSync(filePath, "utf-8");
   return crypto.createHash("sha256").update(content).digest("hex");
 }
 
-function loadHashMap(phrenPath: string): { version?: number; hashes: Record<string, string> } {
+/** Errors expected from idempotent schema migrations run against older cached DBs. */
+function isExpectedMigrationError(err: unknown): boolean {
+  const msg = errorMessage(err).toLowerCase();
+  return msg.includes("duplicate column name") || msg.includes("no such table");
+}
+
+/** Stat snapshot stored alongside each file hash so unchanged files can skip re-hashing. */
+interface FileStatMeta {
+  mtimeMs: number;
+  size: number;
+}
+
+function loadHashMap(phrenPath: string): { version?: number; hashes: Record<string, string>; meta?: Record<string, FileStatMeta> } {
   const runtimeDir = path.join(phrenPath, ".runtime");
   const hashFile = path.join(runtimeDir, INDEX_HASHES_FILENAME);
   try {
@@ -439,7 +466,7 @@ function loadHashMap(phrenPath: string): { version?: number; hashes: Record<stri
   return { hashes: {} };
 }
 
-function saveHashMap(phrenPath: string, hashes: Record<string, string>, knownPaths?: Set<string>): void {
+function saveHashMap(phrenPath: string, hashes: Record<string, string>, knownPaths?: Set<string>, meta?: Record<string, FileStatMeta>): void {
   const runtimeDir = path.join(phrenPath, ".runtime");
   try {
     fs.mkdirSync(runtimeDir, { recursive: true });
@@ -449,24 +476,32 @@ function saveHashMap(phrenPath: string, hashes: Record<string, string>, knownPat
       // Prune entries for files that no longer exist to prevent ghost paths from causing
       // repeated full rebuilds when deleted files are found in the hash map.
       let existing: Record<string, string> = {};
+      let existingMeta: Record<string, FileStatMeta> = {};
       try {
         const data = JSON.parse(fs.readFileSync(hashFile, "utf-8"));
         if (data.hashes && typeof data.hashes === "object") existing = data.hashes;
+        if (data.meta && typeof data.meta === "object") existingMeta = data.meta;
       } catch (err: unknown) {
         logger.debug("saveHashMap readExisting", errorMessage(err));
       }
       const merged = { ...existing, ...hashes };
+      const mergedMeta = { ...existingMeta, ...meta };
       // Remove entries for paths that no longer exist. When knownPaths is provided
       // (build passes supply the full file list), use set membership instead of
       // hitting the filesystem — avoids N sync stat calls inside the lock.
       for (const filePath of Object.keys(merged)) {
         if (knownPaths ? !knownPaths.has(filePath) : !fs.existsSync(filePath)) {
           delete merged[filePath];
+          delete mergedMeta[filePath];
         }
+      }
+      // Drop meta for paths without a hash entry (meta is only an optimization).
+      for (const filePath of Object.keys(mergedMeta)) {
+        if (!(filePath in merged)) delete mergedMeta[filePath];
       }
       fs.writeFileSync(
         hashFile,
-        JSON.stringify({ version: INDEX_SCHEMA_VERSION, hashes: merged }, null, 2)
+        JSON.stringify({ version: INDEX_SCHEMA_VERSION, hashes: merged, meta: mergedMeta }, null, 2)
       );
     });
   } catch (err: unknown) {
@@ -745,7 +780,8 @@ export function updateFileInIndex(db: SqlJsDatabase, filePath: string, phrenPath
     try {
       const hashData = loadHashMap(phrenPath);
       hashData.hashes[resolvedPath] = hashFileContent(resolvedPath);
-      saveHashMap(phrenPath, hashData.hashes);
+      const stat = fs.statSync(resolvedPath);
+      saveHashMap(phrenPath, hashData.hashes, undefined, { [resolvedPath]: { mtimeMs: stat.mtimeMs, size: stat.size } });
     } catch (err: unknown) {
       logger.debug("updateFileInIndex hashMap", errorMessage(err));
     }
@@ -899,13 +935,35 @@ function mergeManualLinks(db: SqlJsDatabase, phrenPath: string): void {
   try {
     const manualLinks: Array<{ entity: string; entityType: string; sourceDoc: string; relType: string }> =
       JSON.parse(fs.readFileSync(manualLinksPath, 'utf8'));
+
+    // Resolve all sourceDoc keys in one query instead of one lookup per link.
+    // Mirrors queryDocBySourceKey semantics: match project + basename(filename),
+    // then compare the full source-doc key.
+    const projects = [...new Set(
+      manualLinks.map((l) => l.sourceDoc.match(/^([^/]+)\//)?.[1]).filter((p): p is string => !!p)
+    )];
+    const filenames = [...new Set(
+      manualLinks
+        .map((l) => l.sourceDoc.match(/^[^/]+\/(.+)$/)?.[1])
+        .filter((rest): rest is string => !!rest)
+        .map((rest) => path.basename(rest))
+    )];
+    const validSourceKeys = new Set<string>();
+    if (projects.length && filenames.length) {
+      const sql = `SELECT project, filename, path FROM docs WHERE project IN (${projects.map(() => "?").join(",")}) AND filename IN (${filenames.map(() => "?").join(",")})`;
+      const rows = queryRows(db, sql, [...projects, ...filenames]) ?? [];
+      for (const row of rows) {
+        const [project, filename, docPath] = decodeStringRow(row, 3, "mergeManualLinks");
+        validSourceKeys.add(getDocSourceKey({ project, filename, path: docPath }, phrenPath));
+      }
+    }
+
     let pruned = false;
     const validLinks: typeof manualLinks = [];
     for (const link of manualLinks) {
       try {
         // Validate: skip manual links whose sourceDoc no longer exists in the index
-        const docCheck = queryDocBySourceKey(db, phrenPath, link.sourceDoc);
-        if (!docCheck) {
+        if (!validSourceKeys.has(link.sourceDoc)) {
           logger.debug("manualLinks", `pruning stale link to "${link.sourceDoc}"`);
           pruned = true;
           continue;
@@ -1015,7 +1073,10 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
         const docCountResult = db.exec("SELECT COUNT(*) FROM docs");
         const docCount = docCountResult?.[0]?.values?.[0]?.[0] as number ?? 0;
         if (docCount > 0) {
-          try { db.run("ALTER TABLE entities ADD COLUMN first_seen_at TEXT"); } catch { /* column already exists */ }
+          try { db.run("ALTER TABLE entities ADD COLUMN first_seen_at TEXT"); } catch (err: unknown) {
+            // Usually "duplicate column name" — column already exists
+            if (!isExpectedMigrationError(err)) logger.warn("buildIndex migration", errorMessage(err));
+          }
           debugLog(`Loaded FTS index from cache (${hash.slice(0, 8)}) in ${Date.now() - t0}ms [sentinel-hit]`);
           appendIndexEvent(phrenPath, {
             event: "build_index",
@@ -1053,18 +1114,32 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
         }
 
         // Schema migration: add first_seen_at column if missing
-        try { db.run("ALTER TABLE entities ADD COLUMN first_seen_at TEXT"); } catch { /* column already exists — expected */ }
+        try { db.run("ALTER TABLE entities ADD COLUMN first_seen_at TEXT"); } catch (err: unknown) {
+          // Usually "duplicate column name" — column already exists
+          if (!isExpectedMigrationError(err)) logger.warn("buildIndex migration", errorMessage(err));
+        }
 
-        // Compute current file hashes and determine what changed
+        // Compute current file hashes and determine what changed.
+        // Files whose mtime+size match the stored snapshot reuse the stored hash,
+        // skipping a read+SHA256 per file; the content hash stays the source of
+        // truth whenever the stat changed.
         const allFiles = globResult.entries;
+        const savedMeta = savedHashData.meta ?? {};
         const currentHashes: Record<string, string> = {};
+        const currentMeta: Record<string, FileStatMeta> = {};
         const changedFiles: FileEntry[] = [];
         const newFiles: FileEntry[] = [];
 
         for (const entry of allFiles) {
           try {
-            const fileHash = hashFileContent(entry.fullPath);
+            const stat = fs.statSync(entry.fullPath);
+            const prevHash = savedHashes[entry.fullPath];
+            const prevMeta = savedMeta[entry.fullPath];
+            const statUnchanged = prevHash !== undefined && prevMeta !== undefined
+              && prevMeta.mtimeMs === stat.mtimeMs && prevMeta.size === stat.size;
+            const fileHash = statUnchanged ? prevHash : hashFileContent(entry.fullPath);
             currentHashes[entry.fullPath] = fileHash;
+            currentMeta[entry.fullPath] = { mtimeMs: stat.mtimeMs, size: stat.size };
             if (!(entry.fullPath in savedHashes)) {
               newFiles.push(entry);
             } else if (savedHashes[entry.fullPath] !== fileHash) {
@@ -1079,10 +1154,13 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
         const currentPaths = new Set(Object.keys(currentHashes));
         const missingFromIndex = Object.keys(savedHashes).filter(p => !currentPaths.has(p));
 
-        // Force full rebuild if >20% of saved files are missing
+        // Force a full rebuild when a large share of saved files vanished at once —
+        // guards against pathological glob results (e.g. a temporarily unmounted
+        // store dir) and bounds FTS bloat from mass tombstones. Smaller deletions
+        // are removed incrementally.
         const totalSaved = Object.keys(savedHashes).length;
-        if (totalSaved > 0 && missingFromIndex.length / totalSaved > 0.2) {
-          debugLog(`>20% files missing (${missingFromIndex.length}/${totalSaved}), forcing full rebuild`);
+        if (totalSaved > 0 && missingFromIndex.length / totalSaved > MAX_INCREMENTAL_DELETE_RATIO) {
+          debugLog(`>${MAX_INCREMENTAL_DELETE_RATIO * 100}% files missing (${missingFromIndex.length}/${totalSaved}), forcing full rebuild`);
           // Fall through to full rebuild below
         } else if (changedFiles.length === 0 && newFiles.length === 0 && missingFromIndex.length === 0) {
           // Nothing changed, pure cache hit
@@ -1125,7 +1203,10 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
                 const sourceDocKey = getEntrySourceDocKey(entry, phrenPath);
                 db.run("DELETE FROM entity_links WHERE source_doc = ?", [sourceDocKey]);
                 // Q19: keep global_entities in sync with entity_links on updates
-                try { db.run("DELETE FROM global_entities WHERE doc_key = ?", [sourceDocKey]); } catch { /* table may not exist in older cached DBs */ }
+                try { db.run("DELETE FROM global_entities WHERE doc_key = ?", [sourceDocKey]); } catch (err: unknown) {
+                  // Usually "no such table" — table may not exist in older cached DBs
+                  if (!isExpectedMigrationError(err)) logger.warn("buildIndex migration", errorMessage(err));
+                }
                 db.run("DELETE FROM docs WHERE path = ?", [entry.fullPath]);
               }
 
@@ -1148,7 +1229,7 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
             }
           }
 
-          saveHashMap(phrenPath, currentHashes, new Set(Object.keys(currentHashes)));
+          saveHashMap(phrenPath, currentHashes, new Set(Object.keys(currentHashes)), currentMeta);
           touchSentinel(phrenPath);
           invalidateDfCache();
 
@@ -1207,6 +1288,7 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
 
   const allFiles = globResult.entries;
   const newHashes: Record<string, string> = {};
+  const newMeta: Record<string, FileStatMeta> = {};
   let fileCount = 0;
 
   // Try loading cached fragment graph
@@ -1216,6 +1298,8 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
   for (const entry of allFiles) {
     try {
       newHashes[entry.fullPath] = hashFileContent(entry.fullPath);
+      const stat = fs.statSync(entry.fullPath);
+      newMeta[entry.fullPath] = { mtimeMs: stat.mtimeMs, size: stat.size };
     } catch (err: unknown) {
         logger.debug("computePhrenHash skip", errorMessage(err));
       }
@@ -1249,7 +1333,7 @@ async function buildIndexImpl(phrenPath: string, profile?: string): Promise<SqlJ
   mergeManualLinks(db, phrenPath);
 
   // ── Finalize: persist hashes, save cache, log ─────────────────────────────
-  saveHashMap(phrenPath, newHashes, new Set(Object.keys(newHashes)));
+  saveHashMap(phrenPath, newHashes, new Set(Object.keys(newHashes)), newMeta);
   touchSentinel(phrenPath);
   invalidateDfCache();
 

--- a/packages/cli/src/telemetry.test.ts
+++ b/packages/cli/src/telemetry.test.ts
@@ -48,6 +48,24 @@ describe("telemetry", () => {
     expect(fs.existsSync(oldPath)).toBe(false);
   });
 
+  it.skipIf(process.platform === "win32")("writes telemetry file with owner-only permissions", () => {
+    setTelemetryEnabled(tmpDir, true);
+    const file = path.join(tmpDir, ".runtime", "telemetry.json");
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it.skipIf(process.platform === "win32")("tightens permissions on pre-existing telemetry files", () => {
+    const runtimeDir = path.join(tmpDir, ".runtime");
+    fs.mkdirSync(runtimeDir, { recursive: true });
+    const file = path.join(runtimeDir, "telemetry.json");
+    fs.writeFileSync(file, JSON.stringify({ config: { enabled: true }, stats: {} }), { mode: 0o644 });
+
+    trackToolCall(tmpDir, "search_knowledge");
+    flushTelemetry();
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
   it("records enabledAt timestamp on first enable", () => {
     setTelemetryEnabled(tmpDir, true);
     const data = JSON.parse(

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -75,7 +75,10 @@ function flushTelemetryForPath(phrenPath: string): void {
   const file = telemetryPath(phrenPath);
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\n");
+    // Usage stats are private to the user: owner-only perms, including files
+    // created by older versions (mode only applies on create).
+    fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
+    fs.chmodSync(file, 0o600);
   } catch (err: unknown) {
     logger.debug("telemetry flush", errorMessage(err));
   }


### PR DESCRIPTION
Reliability:
- Log unexpected schema-migration errors instead of swallowing them
  (expected duplicate-column / missing-table errors stay silent)
- Detect duplicate MCP tool registrations and fail fast at startup
- Return a clear "server is shutting down" error from tools during
  graceful shutdown instead of "Index unavailable"
- Write telemetry.json with owner-only (0600) permissions
- Use process.exitCode + return instead of process.exit(1) in
  config-synonyms, config-proactivity, and team handlers so output
  flushes and locks release before exit

Index performance:
- Store mtime/size alongside per-file hashes in index-hashes.json and
  skip re-hashing files whose stat snapshot is unchanged (content hash
  remains the source of truth when the stat differs)
- Validate manual fragment links with one batched query instead of one
  query per link
- Name the incremental-delete full-rebuild threshold and raise it from
  20% to 50%
- Flush the pending embedding queue (bounded to 3s) during MCP server
  shutdown so scheduled embeddings aren't lost

https://claude.ai/code/session_01NzrPQA2MVGLyi1WytDaZeJ