### PR TITLE
Add query-relevance floor to context injection; stop uninstall tests from deleting the global install

### DIFF
--- a/packages/cli/src/__tests__/cli-hooks-retrieval.test.ts
+++ b/packages/cli/src/__tests__/cli-hooks-retrieval.test.ts
@@ -8,7 +8,7 @@ import { makeTempDir, grantAdmin } from "../test-helpers.js";
 const tmpPhren = fs.mkdtempSync(path.join(os.tmpdir(), "phren-retrieval-test-"));
 process.env.PHREN_PATH = tmpPhren;
 
-import { rankResults, searchDocuments } from "../cli/hooks.js";
+import { rankResults, searchDocuments, applyRelevanceFloor, DEFAULT_MIN_QUERY_RELEVANCE } from "../cli/hooks.js";
 import type { DocRow } from "../shared/index.js";
 import { buildRobustFtsQuery } from "../utils.js";
 
@@ -171,5 +171,68 @@ describe("searchDocuments", () => {
     expect(result?.[0]?.path).toBe("/tmpphren/FINDINGS.md");
     expect(seenQueries).toHaveLength(2);
     expect(seenQueries[1]).toContain(" OR ");
+  });
+});
+
+describe("applyRelevanceFloor", () => {
+  function makeDocRow(project: string, filename: string, type: string, content: string): DocRow {
+    return { project, filename, type, content, path: `/tmp/${project}/${filename}` };
+  }
+
+  const KEYWORDS = "webhook discord alerts monitor";
+
+  it("drops a doc with zero query overlap (priors-only ranking noise)", () => {
+    const rows = [makeDocRow("zeta", "notes.md", "findings", "The quick brown fox jumps over the lazy dog")];
+    const kept = applyRelevanceFloor(rows, KEYWORDS, null, null);
+    expect(kept).toHaveLength(0); // inject nothing rather than noise
+  });
+
+  it("keeps a doc whose text actually matches the prompt", () => {
+    const rows = [
+      makeDocRow("zeta", "notes.md", "findings", "Route alerts to an external webhook instead of discord for monitors"),
+    ];
+    const kept = applyRelevanceFloor(rows, KEYWORDS, null, null);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("keeps a structurally-relevant doc (changed file) even with no textual overlap", () => {
+    const rows = [makeDocRow("myapp", "auth-config.md", "findings", "nothing lexically relevant here at all")];
+    const gitCtx = { branch: "main", changedFiles: new Set(["auth-config.md"]) };
+    const kept = applyRelevanceFloor(rows, KEYWORDS, gitCtx, "myapp");
+    expect(kept).toHaveLength(1);
+  });
+
+  it("keeps a canonical doc for the detected project even with no overlap", () => {
+    const rows = [makeDocRow("myapp", "CLAUDE.md", "canonical", "unrelated project overview text")];
+    const kept = applyRelevanceFloor(rows, KEYWORDS, null, "myapp");
+    expect(kept).toHaveLength(1);
+  });
+
+  it("holds cross-project docs to a higher bar than local docs", () => {
+    // 5-token query → denom 5; one shared token ("latency") scores 0.2:
+    // clears the local floor (0.12) but not the cross-project floor (0.25).
+    const fiveTokenQuery = "webhook discord alerts monitor latency";
+    const local = makeDocRow("myapp", "perf.md", "findings", "improving latency on the dashboard");
+    const cross = makeDocRow("other", "perf.md", "findings", "latency tuning notes");
+    const kept = applyRelevanceFloor([local, cross], fiveTokenQuery, null, "myapp");
+    expect(kept.some((r) => r.project === "myapp")).toBe(true);
+    expect(kept.some((r) => r.project === "other")).toBe(false);
+  });
+
+  it("is a no-op when the floor is 0 (disabled)", () => {
+    const rows = [makeDocRow("zeta", "notes.md", "findings", "totally unrelated content")];
+    const kept = applyRelevanceFloor(rows, KEYWORDS, null, null, 0);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("is a no-op when there is no usable query signal", () => {
+    const rows = [makeDocRow("zeta", "notes.md", "findings", "totally unrelated content")];
+    const kept = applyRelevanceFloor(rows, "", null, null);
+    expect(kept).toHaveLength(1);
+  });
+
+  it("exposes a sane default floor in (0, 1)", () => {
+    expect(DEFAULT_MIN_QUERY_RELEVANCE).toBeGreaterThan(0);
+    expect(DEFAULT_MIN_QUERY_RELEVANCE).toBeLessThan(1);
   });
 });

--- a/packages/cli/src/cli/hooks.ts
+++ b/packages/cli/src/cli/hooks.ts
@@ -27,6 +27,7 @@ import {
   extractKeywordEntries,
   isFeatureEnabled,
   clampInt,
+  clampFloat,
   errorMessage,
 } from "../utils.js";
 import { getHooksEnabledPreference } from "../init/init.js";
@@ -63,6 +64,8 @@ export {
   searchDocuments,
   applyTrustFilter,
   rankResults,
+  applyRelevanceFloor,
+  DEFAULT_MIN_QUERY_RELEVANCE,
   selectSnippets,
   type SelectedSnippet,
 } from "../shared/retrieval.js";
@@ -92,6 +95,8 @@ import {
   searchDocumentsAsync,
   applyTrustFilter,
   rankResults,
+  applyRelevanceFloor,
+  DEFAULT_MIN_QUERY_RELEVANCE,
   selectSnippets,
   detectTaskIntent,
   type SelectedSnippet,
@@ -257,6 +262,17 @@ export async function handleHookPrompt() {
     const tRank0 = Date.now();
     rows = rankResults(rows, intent, gitCtx, detectedProject, getPhrenPath(), db, cwd, keywords);
     stage.rankMs = Date.now() - tRank0;
+    if (!rows.length) process.exit(0);
+
+    // Relevance floor: inject signal or nothing. Ranking scores on priors too,
+    // so a doc can rank well with no real tie to this prompt — drop those rather
+    // than pad to a quota with noise (env PHREN_MIN_QUERY_RELEVANCE=0 disables).
+    const relevanceFloor = clampFloat(process.env.PHREN_MIN_QUERY_RELEVANCE, DEFAULT_MIN_QUERY_RELEVANCE, 0, 1);
+    const preFloorCount = rows.length;
+    rows = applyRelevanceFloor(rows, keywords, gitCtx, detectedProject, relevanceFloor);
+    if (rows.length !== preFloorCount) {
+      debugLog(`relevance-floor: ${preFloorCount} -> ${rows.length} rows (floor=${relevanceFloor})`);
+    }
     if (!rows.length) process.exit(0);
 
     let safeTokenBudget = clampInt(process.env.PHREN_CONTEXT_TOKEN_BUDGET, 550, 180, 10000);

--- a/packages/cli/src/init-uninstall.ts
+++ b/packages/cli/src/init-uninstall.ts
@@ -72,7 +72,19 @@ function runSyncCommand(command: string, args: string[]): SyncCommandResult {
   }
 }
 
+/**
+ * When set, `phren uninstall` skips machine-global side effects that reach
+ * outside PHREN_PATH and the agent config files — removing the global npm
+ * package and any VS Code extension. The test harness sets this so a sandboxed
+ * uninstall test can never delete the developer's real install: npm's global
+ * prefix (and the `code` CLI) ignore a sandboxed HOME.
+ */
+export function skipGlobalUninstallSideEffects(): boolean {
+  return process.env.PHREN_SKIP_GLOBAL_UNINSTALL === "1";
+}
+
 function shouldUninstallCurrentGlobalPackage(): boolean {
+  if (skipGlobalUninstallSideEffects()) return false;
   // Always attempt to remove the global package if it exists, regardless of
   // whether the uninstaller was invoked from the global install or a local repo.
   const npmRootResult = runSyncCommand(getNpmCommand(), ["root", "-g"]);
@@ -494,8 +506,10 @@ export async function runUninstall(opts: { yes?: boolean } = {}) {
     uninstallCurrentGlobalPackage();
   }
 
-  // Remove VS Code extension if installed
-  try {
+  // Remove VS Code extension if installed (skipped in sandboxed/test runs —
+  // `code` ignores a sandboxed HOME and would mutate the real editor).
+  if (!skipGlobalUninstallSideEffects()) {
+   try {
     const codeResult = execFileSync("code", ["--list-extensions"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
@@ -515,8 +529,9 @@ export async function runUninstall(opts: { yes?: boolean } = {}) {
         debugLog(`uninstall: VS Code extension removal failed for ${trimmed}: ${errorMessage(err)}`);
       }
     }
-  } catch {
+   } catch {
     // code CLI not available — skip
+   }
   }
 
   log(`\nPhren config, hooks, and installed data removed.`);

--- a/packages/cli/src/init/init-uninstall.test.ts
+++ b/packages/cli/src/init/init-uninstall.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  skipGlobalUninstallSideEffects,
+  shouldUninstallCurrentGlobalPackage,
+} from "./init-uninstall.js";
+
+// Regression guard: a sandboxed `phren uninstall` (as run by the test harness)
+// must never shell out to a real `npm uninstall -g @phren/cli`. npm's global
+// prefix ignores a sandboxed HOME, so without this flag an uninstall test would
+// delete the developer's real global install.
+describe("uninstall: global side-effect guard", () => {
+  const original = process.env.PHREN_SKIP_GLOBAL_UNINSTALL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.PHREN_SKIP_GLOBAL_UNINSTALL;
+    else process.env.PHREN_SKIP_GLOBAL_UNINSTALL = original;
+  });
+
+  it("reports skip when PHREN_SKIP_GLOBAL_UNINSTALL=1", () => {
+    process.env.PHREN_SKIP_GLOBAL_UNINSTALL = "1";
+    expect(skipGlobalUninstallSideEffects()).toBe(true);
+  });
+
+  it("does not skip when the flag is unset", () => {
+    delete process.env.PHREN_SKIP_GLOBAL_UNINSTALL;
+    expect(skipGlobalUninstallSideEffects()).toBe(false);
+  });
+
+  it("never probes/removes the global npm package when skipping (no npm shell-out)", () => {
+    process.env.PHREN_SKIP_GLOBAL_UNINSTALL = "1";
+    // Returns false immediately, before any `npm root -g` call, regardless of
+    // whether a real global install exists on this machine.
+    expect(shouldUninstallCurrentGlobalPackage()).toBe(false);
+  });
+});

--- a/packages/cli/src/init/init-uninstall.ts
+++ b/packages/cli/src/init/init-uninstall.ts
@@ -67,7 +67,20 @@ function runSyncCommand(command: string, args: string[]): SyncCommandResult {
   }
 }
 
-function shouldUninstallCurrentGlobalPackage(): boolean {
+/**
+ * When set, `phren uninstall` skips machine-global side effects that reach
+ * outside PHREN_PATH and the agent config files — removing the global npm
+ * package and any VS Code extension. The test harness sets this so a sandboxed
+ * uninstall test can never delete the developer's real install: npm's global
+ * prefix (and the `code` CLI) ignore a sandboxed HOME, so without this guard a
+ * test running `phren uninstall` shells out to a real `npm uninstall -g`.
+ */
+export function skipGlobalUninstallSideEffects(): boolean {
+  return process.env.PHREN_SKIP_GLOBAL_UNINSTALL === "1";
+}
+
+export function shouldUninstallCurrentGlobalPackage(): boolean {
+  if (skipGlobalUninstallSideEffects()) return false;
   // Always attempt to remove the global package if it exists, regardless of
   // whether the uninstaller was invoked from the global install or a local repo.
   const npmRootResult = runSyncCommand(getNpmCommand(), ["root", "-g"]);
@@ -475,29 +488,32 @@ export async function runUninstall(opts: { yes?: boolean } = {}) {
     uninstallCurrentGlobalPackage();
   }
 
-  // Remove VS Code extension if installed
-  try {
-    const codeResult = execFileSync("code", ["--list-extensions"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 10_000,
-    });
-    const phrenExts = codeResult.split("\n").filter((ext) => ext.toLowerCase().includes("phren"));
-    for (const ext of phrenExts) {
-      const trimmed = ext.trim();
-      if (!trimmed) continue;
-      try {
-        execFileSync("code", ["--uninstall-extension", trimmed], {
-          stdio: ["ignore", "pipe", "ignore"],
-          timeout: 15_000,
-        });
-        log(`  Removed VS Code extension (${trimmed})`);
-      } catch (err: unknown) {
-        debugLog(`uninstall: VS Code extension removal failed for ${trimmed}: ${errorMessage(err)}`);
+  // Remove VS Code extension if installed (skipped in sandboxed/test runs —
+  // `code` ignores a sandboxed HOME and would mutate the real editor).
+  if (!skipGlobalUninstallSideEffects()) {
+    try {
+      const codeResult = execFileSync("code", ["--list-extensions"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 10_000,
+      });
+      const phrenExts = codeResult.split("\n").filter((ext) => ext.toLowerCase().includes("phren"));
+      for (const ext of phrenExts) {
+        const trimmed = ext.trim();
+        if (!trimmed) continue;
+        try {
+          execFileSync("code", ["--uninstall-extension", trimmed], {
+            stdio: ["ignore", "pipe", "ignore"],
+            timeout: 15_000,
+          });
+          log(`  Removed VS Code extension (${trimmed})`);
+        } catch (err: unknown) {
+          debugLog(`uninstall: VS Code extension removal failed for ${trimmed}: ${errorMessage(err)}`);
+        }
       }
+    } catch {
+      // code CLI not available — skip
     }
-  } catch {
-    // code CLI not available — skip
   }
 
   log(`\nPhren config, hooks, and installed data removed.`);

--- a/packages/cli/src/shared/retrieval.ts
+++ b/packages/cli/src/shared/retrieval.ts
@@ -52,6 +52,14 @@ const LOW_FOCUS_SNIPPET_SCORE = 0.3;
 const VERY_LOW_FOCUS_SNIPPET_SCORE = 0.14;
 const LOW_FOCUS_SNIPPET_LINE_CAP = 3;
 const LOW_FOCUS_SNIPPET_CHAR_FRACTION = 0.55;
+/** Query-relevance floor (see applyRelevanceFloor). A doc with no structural
+ * signal must clear this query-overlap score to be worth injecting; on the
+ * overlapScore scale (matched / max(2, min(tokens, 10))) ~0.12 means "shares at
+ * least one query token" — enough to drop priors-only noise without hurting
+ * recall. Cross-project docs face a higher bar. Tunable via
+ * PHREN_MIN_QUERY_RELEVANCE (0 disables the floor). */
+const DEFAULT_MIN_QUERY_RELEVANCE = 0.12;
+const CROSS_PROJECT_MIN_QUERY_RELEVANCE = 0.25;
 const TASK_RESCUE_MIN_OVERLAP = 0.3;
 const TASK_RESCUE_OVERLAP_MARGIN = 0.12;
 const TASK_RESCUE_SCORE_MARGIN = 0.6;
@@ -983,6 +991,46 @@ export function markStaleCitations(snippet: string): string {
     result.push(line);
   }
   return result.join("\n");
+}
+
+export { DEFAULT_MIN_QUERY_RELEVANCE };
+
+/**
+ * Relevance floor: drop ranked docs that aren't actually relevant to *this*
+ * prompt, so the hook injects signal or nothing — never noise to fill a quota.
+ *
+ * `rankResults` intentionally scores on priors too (intent, recency, project,
+ * feedback history), so a doc can rank well with zero query overlap. That's the
+ * right call for *ordering*, but the wrong thing to *inject*. This stage keeps a
+ * doc only when it has a real connection to the prompt:
+ *   - a structural signal: it's a changed file, or matches the branch name, or
+ *   - it's a canonical doc for the project you're actually in, or
+ *   - its text clears a query-overlap floor (higher for cross-project docs).
+ *
+ * When there's no usable query signal (no tokens) it is a no-op. Setting the
+ * floor to 0 (env PHREN_MIN_QUERY_RELEVANCE=0) disables it and restores the
+ * previous always-fill behavior.
+ */
+export function applyRelevanceFloor(
+  rows: DocRow[],
+  keywords: string,
+  gitCtx: { branch?: string; changedFiles?: Set<string> } | null,
+  detectedProject: string | null,
+  floor: number = DEFAULT_MIN_QUERY_RELEVANCE
+): DocRow[] {
+  if (!(floor > 0)) return rows;
+  const queryTokens = tokenizeForOverlap(keywords);
+  if (!queryTokens.length) return rows; // no query signal to judge against
+  const changedFiles = gitCtx?.changedFiles ?? new Set<string>();
+  const branch = gitCtx?.branch;
+  const crossFloor = Math.max(floor, CROSS_PROJECT_MIN_QUERY_RELEVANCE);
+  return rows.filter((doc) => {
+    if (fileRelevanceBoost(doc.path, changedFiles) > 0) return true;
+    if (branchMatchBoost(doc.content, branch) > 0) return true;
+    if (detectedProject && doc.project === detectedProject && doc.type === "canonical") return true;
+    const isCrossProject = Boolean(detectedProject) && doc.project !== detectedProject;
+    return docOverlapScore(queryTokens, doc) >= (isCrossProject ? crossFloor : floor);
+  });
 }
 
 export function selectSnippets(

--- a/packages/cli/src/test-helpers.ts
+++ b/packages/cli/src/test-helpers.ts
@@ -101,6 +101,15 @@ export function resultMsg(r: PhrenResult<unknown>): string {
 
 export const CLI_PATH = path.resolve(__dirname, "../dist/index.js");
 export const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+/**
+ * Env forced onto every spawned CLI subprocess. `phren uninstall` shells out to
+ * a real `npm uninstall -g @phren/cli` (and `code --uninstall-extension`); the
+ * npm global prefix and the `code` CLI ignore a sandboxed HOME, so without this
+ * a sandboxed uninstall test would delete the developer's real global install.
+ * Applied after caller env so a test cannot accidentally turn it off.
+ */
+const SANDBOX_GUARD_ENV = { PHREN_SKIP_GLOBAL_UNINSTALL: "1" } as const;
 const CLI_BUILD_LOCK = path.join(REPO_ROOT, ".vitest-cli-build.lock");
 const CLI_BUILD_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
@@ -183,7 +192,7 @@ export function runCliExec(args: string[], env: Record<string, string> = {}): Cl
     ensureCliBuilt();
     const stdout = execFileSync(process.execPath, [CLI_PATH, ...args], {
       encoding: "utf8",
-      env: { ...process.env, ...env },
+      env: { ...process.env, ...env, ...SANDBOX_GUARD_ENV },
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 30000,
     });
@@ -205,7 +214,7 @@ export function runCliSpawn(args: string[], env: Record<string, string> = {}): C
   ensureCliBuilt();
   const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...env, ...SANDBOX_GUARD_ENV },
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 30000,
   });

--- a/packages/cli/src/utils-helpers.ts
+++ b/packages/cli/src/utils-helpers.ts
@@ -93,6 +93,12 @@ export function clampInt(raw: string | undefined, fallback: number, min: number,
   return Math.min(max, Math.max(min, parsed));
 }
 
+export function clampFloat(raw: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseFloat(raw || "");
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
 // ── Argv parsing helpers ────────────────────────────────────────────────────
 
 export function getOptionValue(args: string[], name: string): string | undefined {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -10,6 +10,7 @@ export {
   errorMessage,
   isFeatureEnabled,
   clampInt,
+  clampFloat,
   getOptionValue,
   getPositionalArgs,
 } from "./utils-helpers.js";


### PR DESCRIPTION
Two related changes to the prompt-time retrieval pipeline and its test safety.

## 1. Query-relevance floor (`573179b`)

**Problem:** `rankResults` scores on priors too (intent, recency, project, feedback history), so a doc can rank well while sharing nothing with the actual prompt. Selection (`selectSnippets`) was budget-driven only and padded to 3 results, so in low-signal contexts (no repo, anaphoric prompts like "how can that be improved?", cross-project queries) it injected priors-only docs as noise. Filling a quota with irrelevant context costs tokens and dilutes attention.

**Fix:** a new `applyRelevanceFloor` stage between `rank` and `select`. A ranked doc is kept only if it has a real tie to the prompt:
- a structural signal (it's a changed file, or matches the branch name), or
- it's a canonical doc for the detected project, or
- its text clears a query-overlap floor (higher bar for cross-project docs).

The hook can now inject **nothing** rather than pad with noise. Defaults are conservative (≈"shares at least one query token"); tunable via `PHREN_MIN_QUERY_RELEVANCE` (set `0` to restore the previous always-fill behavior).

- Pure FTS5 / `overlapScore` based. **No embedding or Ollama dependency.**
- `rankResults` keeps its "boost, don't filter" contract; the floor is a separate, opt-out-able stage.

**Live A/B** (off-topic prompt "what should I cook for dinner tonight", no project context):
- floor on (default): injects nothing.
- `PHREN_MIN_QUERY_RELEVANCE=0`: pads with 3 unrelated findings (the old behavior).

## 2. Uninstall test-isolation guard (`83d1f19`)

**Problem:** `phren uninstall` shells out to a real `npm uninstall -g @phren/cli` and `code --uninstall-extension`. Tests sandbox `HOME`, but npm's global prefix and the `code` CLI ignore `HOME`, so a sandboxed uninstall integration test **deletes the developer's real global phren install** (hit this during a full `vitest run packages/cli`).

**Fix:**
- Guard both machine-global side effects behind `PHREN_SKIP_GLOBAL_UNINSTALL` (in the active `init/init-uninstall.ts` and the `init-uninstall.ts` duplicate).
- Force that flag in the CLI subprocess test harness (`runCliExec` / `runCliSpawn`), applied after caller env, so no test (present or future) can remove a real install.

## Tests
- New `applyRelevanceFloor` unit coverage: zero-overlap drop, structural bypass, canonical bypass, cross-project bar, disabled no-op, empty-query no-op.
- New regression test that the uninstall guard skips the global-package probe.
- Verified: integration uninstall suite passes (6/6) and the global install survives; targeted retrieval + hook suites green; package typecheck/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)