### PR TITLE
fix: wire Claude hooks to a stable entrypoint (npx-cache bug) + release 0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.36] - 2026-07-16
+
+### Fixed
+
+- **Hooks no longer break when the npx cache is pruned.** `phren init` wired Claude
+  Code's lifecycle hooks to the path of the running script, which under
+  `npx @phren/cli init` resolves into the ephemeral npx download cache
+  (`~/.npm/_npx/<hash>/…`). npx prunes that cache and the hash changes between
+  versions, so every hook would silently fail once it was gone — context stopped
+  injecting and phren appeared broken until init was re-run. Init now installs the
+  stable `~/.local/bin/phren` wrapper *before* writing hook commands, and
+  `buildLifecycleCommands` refuses to bake an npx-cache path into a fallback-less
+  `node <entry>` hook, dropping to the self-healing `npx -y` last resort instead.
+
+### Added
+
+- **`doctor` check `hook-path-stable`.** Flags hook commands still pointing into the
+  npx cache so the regression above is detected instead of failing silently.
+
 ## [0.1.34] - 2026-06-27
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ pnpm lint          # lint all packages
 
 ## Current Version
 
-`@phren/cli` 0.1.34 (see `packages/cli/package.json`).
+`@phren/cli` 0.1.36 (see `packages/cli/package.json`).
 
 ## Reference Documentation
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/hooks-platform.test.ts
+++ b/packages/cli/src/__tests__/hooks-platform.test.ts
@@ -7,6 +7,7 @@ import {
   configureAllHooks,
   readCustomHooks,
   runCustomHooks,
+  isEphemeralNpxPath,
   type CustomHookEvent,
 } from "../hooks.js";
 import { makeTempDir } from "../test-helpers.js";
@@ -101,6 +102,21 @@ describe("hooks platform compatibility", () => {
       for (const cmd of [cmds.sessionStart, cmds.userPromptSubmit, cmds.stop, cmds.hookTool]) {
         expect(cmdContainsPath(cmd, phrenPath)).toBe(true);
       }
+    });
+  });
+
+  describe("isEphemeralNpxPath", () => {
+    it("flags posix npx cache paths", () => {
+      expect(isEphemeralNpxPath("/home/u/.npm/_npx/bdb5dcd91e5f08ef/node_modules/@phren/cli/dist/index.js")).toBe(true);
+    });
+    it("flags windows npx cache paths", () => {
+      expect(isEphemeralNpxPath("C:\\Users\\u\\AppData\\npm-cache\\_npx\\ab12\\node_modules\\@phren\\cli\\dist\\index.js")).toBe(true);
+    });
+    it("does not flag stable install paths", () => {
+      expect(isEphemeralNpxPath("/home/u/.local/bin/phren")).toBe(false);
+      expect(isEphemeralNpxPath("/usr/lib/node_modules/@phren/cli/dist/index.js")).toBe(false);
+      // A directory literally named "_npxthings" must not false-positive.
+      expect(isEphemeralNpxPath("/home/u/_npxthings/index.js")).toBe(false);
     });
   });
 

--- a/packages/cli/src/hooks.ts
+++ b/packages/cli/src/hooks.ts
@@ -74,6 +74,18 @@ function resolveCliEntryScript(): string | null {
   return fs.existsSync(local) ? local : null;
 }
 
+/**
+ * True if a path lives inside an ephemeral npx download cache
+ * (`~/.npm/_npx/<hash>/…`). Baking such a path into a hook command that has no
+ * self-healing fallback is fragile: npx prunes that cache and the `<hash>`
+ * segment changes between versions, silently breaking every phren hook. Hook
+ * commands that resolve here must fall back to `npx -y <spec>` (which
+ * re-resolves on every run) or the ~/.local/bin/phren wrapper instead.
+ */
+export function isEphemeralNpxPath(p: string): boolean {
+  return /(^|[/\\])_npx[/\\]/.test(p);
+}
+
 function phrenPackageSpec(): string {
   return PACKAGE_SPEC;
 }
@@ -113,7 +125,12 @@ export function buildLifecycleCommands(
   phrenPath: string,
   options: BuildLifecycleOptions = {},
 ): LifecycleCommands {
-  const entry = resolveCliEntryScript();
+  const rawEntry = resolveCliEntryScript();
+  // A bare `node <entry>` hook has no fallback if <entry> disappears. When the
+  // package is running from the npx cache, that entry path is ephemeral, so we
+  // drop it here and let resolution fall through to the ~/.local/bin/phren
+  // wrapper (preferred) or the self-healing `npx -y <spec>` last resort.
+  const entry = rawEntry && !isEphemeralNpxPath(rawEntry) ? rawEntry : null;
   const nativeWindows = process.platform === "win32" && !options.forcePosix;
   const escapedPhren = phrenPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   const quotedPhren = shellEscape(phrenPath);

--- a/packages/cli/src/init/init-configure.ts
+++ b/packages/cli/src/init/init-configure.ts
@@ -50,6 +50,17 @@ export function configureMcpTargets(
   opts: { mcpEnabled: boolean; hooksEnabled: boolean },
   verb: "Configured" | "Updated" = "Configured",
 ): string {
+  // Install the stable ~/.local/bin/phren wrapper BEFORE writing any hook
+  // commands. buildLifecycleCommands prefers that wrapper (it carries an npx
+  // fallback, so it survives nvm switches and npx cache clears); if it doesn't
+  // yet exist, hook commands fall through to the ephemeral npx-cache entry path
+  // and break the next time npx prunes its cache. configureHooksIfEnabled runs
+  // later and re-installs the wrapper idempotently, emitting the user-facing
+  // "CLI wrapper" line — this early install is intentionally silent.
+  try { installPhrenCliWrapper(phrenPath); } catch (err: unknown) {
+    debugLog(`configureMcpTargets: early wrapper install failed: ${errorMessage(err)}`);
+  }
+
   let claudeStatus = "no_settings";
   try {
     const status = configureClaude(phrenPath, { mcpEnabled: opts.mcpEnabled, hooksEnabled: opts.hooksEnabled });

--- a/packages/cli/src/link/doctor.ts
+++ b/packages/cli/src/link/doctor.ts
@@ -18,7 +18,7 @@ import { validateGovernanceJson } from "../shared/governance.js";
 import { errorMessage } from "../utils.js";
 import { buildIndex, queryRows } from "../shared/index.js";
 import { validateTaskFormat, validateFindingsFormat } from "../shared/content.js";
-import { detectInstalledTools } from "../hooks.js";
+import { detectInstalledTools, isEphemeralNpxPath } from "../hooks.js";
 import { validateSkillFrontmatter, validateSkillsDir } from "./skills.js";
 import { verifyFileChecksums, updateFileChecksums } from "./checksums.js";
 import { buildSkillManifest } from "../skill/registry.js";
@@ -372,6 +372,7 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
   });
   let hookOk = false;
   let lifecycleOk = false;
+  let hooksEphemeral = false;
   try {
     const cfg = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
     const hooks = cfg?.hooks || {};
@@ -382,6 +383,11 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     const stopHookOk = stopHooks.includes("hook-stop");
     const startHookOk = startHooks.includes("hook-session-start");
     lifecycleOk = stopHookOk && startHookOk;
+    // A hook command that points into the npx cache (~/.npm/_npx/<hash>/…)
+    // works until npx prunes that cache, then breaks silently. Flag it so a
+    // re-init (which now resolves to the stable ~/.local/bin/phren wrapper)
+    // can repair it before the user notices context has stopped flowing.
+    hooksEphemeral = [promptHooks, stopHooks, startHooks].some(isEphemeralNpxPath);
   } catch (err: unknown) {
     debugLog(`doctor: failed to read Claude settings for hook check: ${errorMessage(err)}`);
     hookOk = false;
@@ -398,6 +404,13 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     detail: lifecycleOk
       ? "session-start + stop lifecycle hooks configured"
       : "missing lifecycle hooks (expected hook-session-start and hook-stop)",
+  });
+  checks.push({
+    name: "hook-path-stable",
+    ok: !hooksEphemeral,
+    detail: hooksEphemeral
+      ? "hook commands point into the ephemeral npx cache (~/.npm/_npx/…); re-run `npx @phren/cli init` to repoint at the stable ~/.local/bin/phren wrapper"
+      : "hook commands use a stable entrypoint",
   });
 
   const runtimeHealthPath = runtimeHealthFile(phrenPath);


### PR DESCRIPTION
## Problem

`phren init` wired Claude Code's lifecycle hooks to the path of the running script. Under `npx @phren/cli init` that resolves into the **ephemeral npx download cache** (`~/.npm/_npx/<hash>/…/dist/index.js`). npx prunes that cache and the `<hash>` changes between versions, so every phren hook silently fails once it's gone — context stops injecting and phren appears broken, "fixed" only by re-running init.

## Root causes (both fixed)

- **Ordering:** `configureMcpTargets()` wrote hooks *before* the stable `~/.local/bin/phren` wrapper was installed, so `buildLifecycleCommands()` couldn't prefer it and fell through to the cache path. The wrapper is now installed first (idempotent; user-facing log stays in `configureHooksIfEnabled`).
- **No guard:** `buildLifecycleCommands()` would bake a fallback-less `node <entry>` command even when `<entry>` was an npx-cache path. Added `isEphemeralNpxPath()` and skip that entry so resolution drops to the self-healing `npx -y <spec>` last resort.

## Also

- New `doctor` check `hook-path-stable` so a cache-path regression is detected instead of failing silently.
- Unit tests for `isEphemeralNpxPath`.
- Release prep for **0.1.36**: version bump + `## [0.1.36]` changelog entry.

## Verification

Reproduced the bug by running `init` from a fake `_npx` path into an isolated HOME; the resulting hook now points at the stable wrapper, not the cache. All release-workflow gates pass locally: frozen install, build, lint (178 files), full test suite (2687 passed), validate-docs.