### PR TITLE
feat(graph): pane prefs, peek, dossier resize, bulk-delete undo, fragment context

### DIFF
--- a/packages/cli/browser/graph/interactions.ts
+++ b/packages/cli/browser/graph/interactions.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 import type { FGNode, NodeDetail, RuntimeNode } from "./types.js";
 import { focusMode, nodeDetail, nodeRadius, scoreForNode, state } from "./state.js";
 import { applyHighlight, startIntroStagger } from "./nodes.js";
-import { mascotMoveTo } from "./mascot.js";
+import { mascotMoveTo, spawnLookupPulse } from "./mascot.js";
 import { syncProjectNavActive } from "./project-nav.js";
 import { refreshProjectPanel } from "./project-panel.js";
 
@@ -182,6 +182,19 @@ export function selectNode(nodeId: string): boolean {
   setTimeout(() => notifySelection(nodeId), 120);
   mascotMoveTo(nodeId, true);
   return true;
+}
+
+/**
+ * Fly the camera to a node and pulse it WITHOUT changing the selection — a
+ * lightweight "show me where this is" that leaves the dossier alone.
+ */
+export function peekNode(nodeId: string): void {
+  const fgNode = state.fgNodeById.get(nodeId);
+  if (!fgNode) return;
+  flyToNode(fgNode, 700);
+  const reducedMotion = typeof window.matchMedia === "function"
+    && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (!reducedMotion) spawnLookupPulse(nodeId);
 }
 
 export function getNodeAt(x: number, y: number): NodeDetail | null {

--- a/packages/cli/browser/graph/project-panel.ts
+++ b/packages/cli/browser/graph/project-panel.ts
@@ -195,6 +195,7 @@ function injectPanelCss(): void {
 let panelEl: HTMLElement | null = null;
 let reopenEl: HTMLElement | null = null;
 let renderedProjectId: string | null = null;
+let renderedFragmentId: string | null = null;
 let cursorId: string | null = null;
 let collapsed = false;
 let selectMode = false;
@@ -305,16 +306,19 @@ function projectNodeByName(name: string): RuntimeNode | undefined {
   return state.rawNodes.find((node) => node.kind === "project" && (node.project || node.id) === name);
 }
 
-/** The project node id whose contents the pane should show, or null to hide. */
-function contextProjectId(): string | null {
-  if (state.focusedProjectId) return state.focusedProjectId;
+type PaneContext = { kind: "project" | "fragment"; id: string };
+
+/** What the pane should show: a project's contents, a fragment's network, or nothing. */
+function contextNode(): PaneContext | null {
+  if (state.focusedProjectId) return { kind: "project", id: state.focusedProjectId };
   if (state.selectedNodeId) {
     const node = state.nodeById.get(state.selectedNodeId);
     if (node) {
-      if (node.kind === "project") return node.id;
+      if (node.kind === "project") return { kind: "project", id: node.id };
+      if (node.kind === "entity") return { kind: "fragment", id: node.id };
       if (node.project) {
         const project = projectNodeByName(node.project);
-        if (project) return project.id;
+        if (project) return { kind: "project", id: project.id };
       }
     }
   }
@@ -436,13 +440,15 @@ function commitBulkDelete(): void {
   picked.clear();
 }
 
-function buildPanel(projectId: string): void {
+/** Create the pane element (once) with its shared pointer/keyboard handlers. */
+function ensurePanelEl(): void {
   if (!state.container) return;
   injectPanelCss();
-  if (!panelEl || !panelEl.isConnected) {
-    panelEl = document.createElement("aside");
-    panelEl.className = "phren-project-panel";
-    panelEl.setAttribute("aria-label", "Project contents");
+  if (panelEl && panelEl.isConnected) return;
+  panelEl = document.createElement("aside");
+  panelEl.className = "phren-project-panel";
+  panelEl.setAttribute("aria-label", "Project contents");
+  {
     // Inside the force-graph container: stop the pointer sequence so ForceGraph
     // doesn't read it as a background click and clear the selection.
     panelEl.addEventListener("pointerdown", (event) => event.stopPropagation());
@@ -528,8 +534,14 @@ function buildPanel(projectId: string): void {
         event.preventDefault();
       }
     });
-    state.container.appendChild(panelEl);
   }
+  state.container.appendChild(panelEl);
+}
+
+function buildPanel(projectId: string): void {
+  if (!state.container) return;
+  ensurePanelEl();
+  if (!panelEl) return;
 
   const project = state.nodeById.get(projectId);
   const projectName = project ? project.label || project.project || project.id : "";
@@ -594,17 +606,9 @@ function buildPanel(projectId: string): void {
     "</div>",
   ].join("");
 
-  // Keep any user-chosen width (clamped to the current viewport), and (re)attach
-  // the edge resize handle (the innerHTML above wiped the previous one).
-  if (panelWidth) {
-    const cw = state.container.getBoundingClientRect().width;
-    panelEl.style.width = `${clamp(panelWidth, 260, Math.max(260, cw - 420))}px`;
-  }
-  const resize = document.createElement("div");
-  resize.className = "phren-pp-resize";
-  resize.setAttribute("aria-hidden", "true");
-  resize.addEventListener("pointerdown", startResize);
-  panelEl.appendChild(resize);
+  // Keep any user-chosen width and (re)attach the edge resize handle (the
+  // innerHTML above wiped the previous one).
+  attachResizeAndWidth();
 
   const searchInput = panelEl.querySelector<HTMLInputElement>("[data-pp-search]");
   searchInput?.addEventListener("input", () => {
@@ -620,8 +624,91 @@ function buildPanel(projectId: string): void {
   });
 
   renderedProjectId = projectId;
+  renderedFragmentId = null;
   renderList();
   syncActiveRow();
+}
+
+/** A resize handle + saved width, shared by the project and fragment panels. */
+function attachResizeAndWidth(): void {
+  if (!panelEl || !state.container) return;
+  if (panelWidth) {
+    const cw = state.container.getBoundingClientRect().width;
+    panelEl.style.width = `${clamp(panelWidth, 260, Math.max(260, cw - 420))}px`;
+  }
+  const resize = document.createElement("div");
+  resize.className = "phren-pp-resize";
+  resize.setAttribute("aria-hidden", "true");
+  resize.addEventListener("pointerdown", startResize);
+  panelEl.appendChild(resize);
+}
+
+/** Render the pane for a fragment (entity): its connected projects + references. */
+function buildFragmentPanel(entityId: string): void {
+  if (!state.container) return;
+  ensurePanelEl();
+  if (!panelEl) return;
+
+  const node = state.nodeById.get(entityId);
+  const name = node ? node.label || node.id : "fragment";
+  const type = node?.entityType || "fragment";
+  const refCount = node?.refCount || 0;
+  const adj = state.fullAdjacency.get(entityId) || new Set<string>();
+  const neighbors = [...adj]
+    .map((id) => state.nodeById.get(id))
+    .filter((n): n is RuntimeNode => Boolean(n));
+  const byName = (a: RuntimeNode, b: RuntimeNode) => (a.label || "").localeCompare(b.label || "");
+  const projects = neighbors.filter((n) => n.kind === "project").sort(byName);
+  const refs = neighbors.filter((n) => n.kind === "reference").sort(byName);
+
+  const fragRow = (n: RuntimeNode, chip: string) => {
+    const dot = n.baseColor || "#8b96c9";
+    const label = n.label || n.id;
+    const active = state.selectedNodeId === n.id ? " active" : "";
+    return (
+      `<button type="button" class="phren-pp-row${active}" data-node-id="${esc(n.id)}" title="${esc(label)}">` +
+      `<span class="phren-pp-dot" style="background:${esc(dot)};color:${esc(dot)}"></span>` +
+      `<span class="phren-pp-rowlabel">${esc(label)}</span>` +
+      `<span class="phren-pp-rowchip">${esc(chip)}</span>` +
+      `<span class="phren-pp-peek" data-pp-peek title="Show in graph">◎</span>` +
+      "</button>"
+    );
+  };
+  const projItems = (n: RuntimeNode) => {
+    const f = typeof n.findingCount === "number" ? n.findingCount : 0;
+    const t = typeof n.taskCount === "number" ? n.taskCount : 0;
+    return `${f + t} items`;
+  };
+
+  const rows: string[] = [];
+  if (projects.length) {
+    rows.push(`<div class="phren-pp-group">Connected projects · ${projects.length}</div>`);
+    rows.push(...projects.map((p) => fragRow(p, projItems(p))));
+  }
+  if (refs.length) {
+    rows.push(`<div class="phren-pp-group">References · ${refs.length}</div>`);
+    rows.push(...refs.map((r) => fragRow(r, "ref")));
+  }
+  if (!rows.length) rows.push('<div class="phren-pp-empty">No connections</div>');
+
+  panelEl.innerHTML = [
+    '<div class="phren-pp-head">',
+    '<div class="phren-pp-title">',
+    '<div class="phren-pp-kind">Fragment</div>',
+    `<div class="phren-pp-name" title="${esc(name)}">${esc(name)}</div>`,
+    `<div class="phren-pp-sub">${esc(type)} · ${refCount} refs · ${projects.length} project${projects.length === 1 ? "" : "s"}</div>`,
+    "</div>",
+    '<div class="phren-pp-headbtns">',
+    '<button type="button" class="phren-pp-iconbtn" data-pp-collapse aria-label="Collapse panel" title="Collapse">›</button>',
+    '<button type="button" class="phren-pp-iconbtn" data-pp-close aria-label="Close" title="Close">×</button>',
+    "</div>",
+    "</div>",
+    `<div class="phren-pp-list" data-pp-list>${rows.join("")}</div>`,
+  ].join("");
+
+  attachResizeAndWidth();
+  renderedFragmentId = entityId;
+  renderedProjectId = null;
 }
 
 function applyChip(chip: HTMLElement): void {
@@ -689,7 +776,7 @@ function syncActiveRow(): void {
 export function refreshProjectPanel(opts?: { data?: boolean }): void {
   if (!state.container) return;
   loadPrefs();
-  const ctx = contextProjectId();
+  const ctx = contextNode();
   if (!ctx) {
     if (panelEl) {
       panelEl.setAttribute("hidden", "");
@@ -697,6 +784,7 @@ export function refreshProjectPanel(opts?: { data?: boolean }): void {
     }
     hideReopenTab();
     renderedProjectId = null;
+    renderedFragmentId = null;
     setLegendHidden(false);
     return;
   }
@@ -705,15 +793,29 @@ export function refreshProjectPanel(opts?: { data?: boolean }): void {
   // Collapsed: hide the full pane, show a slim re-open tab instead.
   if (collapsed) {
     if (panelEl) panelEl.setAttribute("hidden", "");
-    const project = state.nodeById.get(ctx);
-    showReopenTab(project ? project.label || project.project || project.id : "project");
+    const node = state.nodeById.get(ctx.id);
+    showReopenTab(node ? node.label || node.project || node.id : ctx.kind);
     return;
   }
   hideReopenTab();
-  if (ctx !== renderedProjectId || !panelEl || !panelEl.isConnected) {
+
+  // Fragment context: a node's connected projects + references.
+  if (ctx.kind === "fragment") {
+    if (ctx.id !== renderedFragmentId || !panelEl || !panelEl.isConnected) {
+      selectMode = false;
+      picked.clear();
+      buildFragmentPanel(ctx.id);
+    }
+    panelEl?.removeAttribute("hidden");
+    syncActiveRow();
+    return;
+  }
+
+  // Project context.
+  if (ctx.id !== renderedProjectId || !panelEl || !panelEl.isConnected) {
     // Switching projects drops any in-progress multi-select (picks are per-project).
-    if (ctx !== renderedProjectId) { selectMode = false; picked.clear(); }
-    buildPanel(ctx);
+    if (ctx.id !== renderedProjectId) { selectMode = false; picked.clear(); }
+    buildPanel(ctx.id);
     panelEl?.removeAttribute("hidden");
     return;
   }
@@ -727,7 +829,7 @@ export function refreshProjectPanel(opts?: { data?: boolean }): void {
     if (node && (node.kind === "finding" || node.kind === "task") && !matchesFilters(node)) {
       filters.kind = "all";
       filters.health = "all";
-      buildPanel(ctx);
+      buildPanel(ctx.id);
       return;
     }
   }

--- a/packages/cli/browser/graph/project-panel.ts
+++ b/packages/cli/browser/graph/project-panel.ts
@@ -1,6 +1,6 @@
 import type { NodeDetail, RuntimeNode } from "./types.js";
 import { clamp, esc, nodeDetail, state } from "./state.js";
-import { clearSelection, selectNode } from "./interactions.js";
+import { clearSelection, peekNode, selectNode } from "./interactions.js";
 
 // Project contents pane — a right-docked, scrollable index of a project's
 // findings and tasks. It appears whenever a project is "in context" (its orb
@@ -144,6 +144,13 @@ const PANEL_CSS = `
 }
 .phren-pp-row:hover .phren-pp-del,.phren-pp-row.active .phren-pp-del{display:grid}
 .phren-pp-del:hover{border-color:rgba(255,84,112,0.7);background:rgba(255,84,112,0.18);color:#ffb3c1}
+.phren-pp-peek{
+  flex:0 0 auto;width:22px;height:22px;padding:0;border-radius:6px;cursor:pointer;
+  border:1px solid rgba(103,232,249,0.28);background:rgba(103,232,249,0.06);
+  color:#67e8f9;font-size:11px;line-height:1;display:none;place-items:center;
+}
+.phren-pp-row:hover .phren-pp-peek,.phren-pp-row.active .phren-pp-peek{display:grid}
+.phren-pp-peek:hover{border-color:rgba(103,232,249,0.7);background:rgba(103,232,249,0.16);color:#aef1ff}
 .phren-pp-check{
   flex:0 0 auto;width:15px;height:15px;border-radius:4px;display:grid;place-items:center;
   border:1px solid rgba(103,232,249,0.35);background:rgba(12,15,30,0.9);
@@ -197,6 +204,28 @@ const picked = new Set<string>();
 // Fixed right offset of the pane (matches `.phren-project-panel { right: 58px }`).
 const PANE_RIGHT = 58;
 
+// Persisted UI preferences (width, collapsed, sort) — survive reloads in both
+// hosts via localStorage. Filters/query stay transient (reset each session).
+const PREFS_KEY = "phren.graph.pane";
+let prefsLoaded = false;
+function loadPrefs(): void {
+  if (prefsLoaded) return;
+  prefsLoaded = true;
+  try {
+    const raw = localStorage.getItem(PREFS_KEY);
+    if (!raw) return;
+    const p = JSON.parse(raw) as { width?: unknown; collapsed?: unknown; sort?: unknown };
+    if (typeof p.width === "number" && p.width > 0) panelWidth = p.width;
+    if (typeof p.collapsed === "boolean") collapsed = p.collapsed;
+    if (p.sort === "aging" || p.sort === "recent" || p.sort === "az") filters.sort = p.sort;
+  } catch { /* storage unavailable — use defaults */ }
+}
+function savePrefs(): void {
+  try {
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ width: panelWidth, collapsed, sort: filters.sort }));
+  } catch { /* ignore */ }
+}
+
 /** Begin an edge-drag resize of the pane. */
 function startResize(event: PointerEvent): void {
   if (!panelEl || !state.container) return;
@@ -217,6 +246,7 @@ function startResize(event: PointerEvent): void {
     handle.classList.remove("dragging");
     window.removeEventListener("pointermove", onMove);
     window.removeEventListener("pointerup", onUp);
+    savePrefs();
   };
   window.addEventListener("pointermove", onMove);
   window.addEventListener("pointerup", onUp);
@@ -257,6 +287,7 @@ function showReopenTab(projectName: string): void {
     reopenEl.addEventListener("click", (event) => {
       event.stopPropagation();
       collapsed = false;
+      savePrefs();
       refreshProjectPanel();
     });
     reopenEl.addEventListener("pointerdown", (event) => event.stopPropagation());
@@ -318,9 +349,10 @@ function rowHtml(node: RuntimeNode): string {
   const chip = node.kind === "task"
     ? (node.section || "task")
     : (node.topicLabel || node.topicSlug || node.health);
-  // In select mode rows carry a checkbox; otherwise a hover delete button
-  // (only when a host registered an action handler).
+  // In select mode rows carry a checkbox; otherwise hover actions: peek (fly the
+  // camera without opening the dossier) and delete (only when a host supports it).
   const check = selectMode ? `<span class="phren-pp-check">${picked.has(node.id) ? "✓" : ""}</span>` : "";
+  const peek = !selectMode ? `<span class="phren-pp-peek" data-pp-peek title="Show in graph">◎</span>` : "";
   const del = !selectMode && hasActions
     ? `<span class="phren-pp-del" data-pp-del title="Delete this ${esc(node.kind)}">🗑</span>`
     : "";
@@ -330,6 +362,7 @@ function rowHtml(node: RuntimeNode): string {
     `<span class="phren-pp-dot" style="background:${esc(dotColor)};color:${esc(dotColor)}"></span>` +
     `<span class="phren-pp-rowlabel">${esc(label)}</span>` +
     `<span class="phren-pp-rowchip">${esc(chip)}</span>` +
+    peek +
     del +
     `</button>`
   );
@@ -422,6 +455,7 @@ function buildPanel(projectId: string): void {
       }
       if (target?.closest("[data-pp-collapse]")) {
         collapsed = true;
+        savePrefs();
         refreshProjectPanel();
         return;
       }
@@ -468,6 +502,10 @@ function buildPanel(projectId: string): void {
         const check = row.querySelector(".phren-pp-check");
         if (check) check.textContent = picked.has(id) ? "✓" : "";
         renderBulkBar();
+        return;
+      }
+      if (target?.closest("[data-pp-peek]")) {
+        peekNode(id);
         return;
       }
       if (target?.closest("[data-pp-del]")) {
@@ -556,9 +594,12 @@ function buildPanel(projectId: string): void {
     "</div>",
   ].join("");
 
-  // Keep any user-chosen width, and (re)attach the edge resize handle (innerHTML
-  // above wiped the previous one).
-  if (panelWidth) panelEl.style.width = `${panelWidth}px`;
+  // Keep any user-chosen width (clamped to the current viewport), and (re)attach
+  // the edge resize handle (the innerHTML above wiped the previous one).
+  if (panelWidth) {
+    const cw = state.container.getBoundingClientRect().width;
+    panelEl.style.width = `${clamp(panelWidth, 260, Math.max(260, cw - 420))}px`;
+  }
   const resize = document.createElement("div");
   resize.className = "phren-pp-resize";
   resize.setAttribute("aria-hidden", "true");
@@ -574,6 +615,7 @@ function buildPanel(projectId: string): void {
   const sortSelect = panelEl.querySelector<HTMLSelectElement>("[data-pp-sort]");
   sortSelect?.addEventListener("change", () => {
     filters.sort = (sortSelect.value as typeof filters.sort) || "aging";
+    savePrefs();
     renderList();
   });
 
@@ -646,6 +688,7 @@ function syncActiveRow(): void {
  */
 export function refreshProjectPanel(opts?: { data?: boolean }): void {
   if (!state.container) return;
+  loadPrefs();
   const ctx = contextProjectId();
   if (!ctx) {
     if (panelEl) {

--- a/packages/cli/e2e/_vscode_shots.spec.ts
+++ b/packages/cli/e2e/_vscode_shots.spec.ts
@@ -71,4 +71,12 @@ test("vscode webview node dossier docks left", async ({ page }) => {
   await page.waitForTimeout(300);
   await expect(page.locator(".phren-project-panel [data-pp-bulk-delete]")).toBeEnabled();
   await page.screenshot({ path: `${SHOT_DIR}/vscode-04-bulk-select.png` });
+
+  // Batch-undo toast wiring: simulate the extension's batchRemoved message and
+  // confirm the undo toast surfaces (the extension round-trip is covered by the
+  // web-ui undo e2e).
+  await page.evaluate(() => window.postMessage({ type: "batchRemoved", undo: { items: [{ kind: "finding", projectName: "api-server", text: "x" }], label: "Deleted 3 items" } }, "*"));
+  await page.waitForTimeout(300);
+  await expect(page.locator("#graph-toast")).toBeVisible();
+  await expect(page.locator("#graph-toast")).toContainText("Undo");
 });

--- a/packages/cli/e2e/_vscode_shots.spec.ts
+++ b/packages/cli/e2e/_vscode_shots.spec.ts
@@ -37,6 +37,15 @@ test("vscode webview node dossier docks left", async ({ page }) => {
   expect(box!.height).toBeGreaterThan(vp.height * 0.5); // full-height pane
   await page.screenshot({ path: `${SHOT_DIR}/vscode-01-finding-docked.png` });
 
+  // The docked dossier is resizable via its right-edge handle.
+  const dossierW = box!.width;
+  const dh = (await popover.locator(".dossier-resize").boundingBox())!;
+  await page.mouse.move(dh.x + dh.width / 2, dh.y + dh.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(dh.x + 120, dh.y + dh.height / 2, { steps: 8 });
+  await page.mouse.up();
+  expect((await popover.boundingBox())!.width).toBeGreaterThan(dossierW + 50);
+
   // A project selection should also dock left, with the contents pane at right.
   await page.evaluate(() => (window as any).phrenGraph.selectNode("project:api-server"));
   await page.waitForTimeout(1000);

--- a/packages/cli/e2e/_vscode_shots.spec.ts
+++ b/packages/cli/e2e/_vscode_shots.spec.ts
@@ -79,4 +79,12 @@ test("vscode webview node dossier docks left", async ({ page }) => {
   await page.waitForTimeout(300);
   await expect(page.locator("#graph-toast")).toBeVisible();
   await expect(page.locator("#graph-toast")).toContainText("Undo");
+
+  // Fragment context: selecting a fragment lists its connected projects + refs.
+  await page.evaluate(() => (window as any).phrenGraph.selectNode("entity:AuthService"));
+  await page.waitForTimeout(1000);
+  const panel = page.locator(".phren-project-panel");
+  await expect(panel.locator(".phren-pp-kind")).toHaveText("Fragment");
+  await expect(panel.locator(".phren-pp-group", { hasText: "Connected projects" })).toBeVisible();
+  await page.screenshot({ path: `${SHOT_DIR}/vscode-05-fragment.png` });
 });

--- a/packages/cli/e2e/graph.spec.ts
+++ b/packages/cli/e2e/graph.spec.ts
@@ -1046,6 +1046,24 @@ test.describe.serial("graph visualization e2e", () => {
     await expect(panel.locator(".phren-pp-check")).toHaveCount(0);
   });
 
+  test("left detail dossier is resizable", async ({ page }) => {
+    await openGraphTab(page);
+    const findingId = await selectNodeOfKind(page, "finding");
+    expect(findingId).toBeTruthy();
+    const pop = page.locator("#graph-node-popover");
+    await expect(pop).toBeVisible({ timeout: 8_000 });
+
+    const before = (await pop.boundingBox())!.width;
+    const handle = pop.locator(".phren-dossier-resize");
+    const hb = (await handle.boundingBox())!;
+    await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(hb.x + 130, hb.y + hb.height / 2, { steps: 8 }); // drag outward → wider
+    await page.mouse.up();
+    const after = (await pop.boundingBox())!.width;
+    expect(after).toBeGreaterThan(before + 60);
+  });
+
   test("row peek flies to a node without changing selection", async ({ page }) => {
     await openGraphTab(page);
     const projectId = await selectNodeOfKind(page, "project");

--- a/packages/cli/e2e/graph.spec.ts
+++ b/packages/cli/e2e/graph.spec.ts
@@ -932,6 +932,40 @@ test.describe.serial("graph visualization e2e", () => {
     await expect(stats).toHaveText(/\d+ NODES · \d+ LINKS · \d+ PROJECTS/, { timeout: 8_000 });
   });
 
+  test("selecting a fragment shows its connected projects and references", async ({ page }) => {
+    await openGraphTab(page);
+    await page.evaluate(() => {
+      (window as any).phrenGraph.mount({
+        nodes: [
+          { id: "project:alpha", label: "alpha", group: "project", project: "alpha", findingCount: 2, taskCount: 1 },
+          { id: "project:beta", label: "beta", group: "project", project: "beta", findingCount: 1, taskCount: 0 },
+          { id: "entity:auth", label: "AuthService", group: "entity", entityType: "class", refCount: 5, connectedProjects: ["alpha", "beta"] },
+          { id: "ref:alpha/auth.ts", label: "auth.ts", group: "reference", project: "alpha" },
+        ],
+        links: [
+          { source: "entity:auth", target: "project:alpha" },
+          { source: "entity:auth", target: "project:beta" },
+          { source: "entity:auth", target: "ref:alpha/auth.ts" },
+        ],
+        topics: [],
+      });
+    });
+    await page.waitForTimeout(800);
+
+    await page.evaluate(() => (window as any).phrenGraph.selectNode("entity:auth"));
+    const panel = page.locator(".phren-project-panel");
+    await expect(panel).toBeVisible({ timeout: 8_000 });
+    await expect(panel.locator(".phren-pp-kind")).toHaveText("Fragment");
+    await expect(panel.locator(".phren-pp-group", { hasText: "Connected projects" })).toBeVisible();
+    await expect(panel.locator('.phren-pp-row[data-node-id="project:alpha"]')).toBeVisible();
+    await expect(panel.locator('.phren-pp-row[data-node-id="project:beta"]')).toBeVisible();
+    await expect(panel.locator(".phren-pp-group", { hasText: "References" })).toBeVisible();
+
+    // Clicking a connected project navigates the pane to that project.
+    await panel.locator('.phren-pp-row[data-node-id="project:alpha"]').click();
+    await expect(panel.locator(".phren-pp-kind")).toHaveText("Project");
+  });
+
   test("remount clears stale eager project labels", async ({ page }) => {
     await openGraphTab(page);
     const mountPayload = (proj: string, label: string) => ({

--- a/packages/cli/e2e/graph.spec.ts
+++ b/packages/cli/e2e/graph.spec.ts
@@ -1118,6 +1118,31 @@ test.describe.serial("graph visualization e2e", () => {
     expect(after).toBeGreaterThan(before + 60);
   });
 
+  test("bulk delete offers undo that restores the findings", async ({ page }) => {
+    page.on("dialog", (d) => d.accept());
+    await openGraphTab(page);
+    const repoAFindings = () => page.evaluate(() =>
+      (window as any).phrenGraph.getData().nodes.filter((n: any) => n.kind === "finding" && n.projectName === "repo-a").length);
+    const before = await repoAFindings();
+    expect(before).toBeGreaterThan(1);
+
+    await page.evaluate(() => {
+      const pg = (window as any).phrenGraph;
+      pg.selectNode(pg.getData().nodes.find((n: any) => n.kind === "project" && n.projectName === "repo-a").id);
+    });
+    const panel = page.locator(".phren-project-panel");
+    await expect(panel).toBeVisible({ timeout: 8_000 });
+    await panel.locator('[data-pp-chip][data-kind="finding"]').click();
+    await panel.locator("[data-pp-select]").click();
+    await panel.locator("[data-pp-bulk-all]").click();
+    await panel.locator("[data-pp-bulk-delete]").click();
+    await expect.poll(repoAFindings, { timeout: 10_000 }).toBe(0);
+
+    // The undo toast restores everything (leaves the fixture as it was).
+    await page.locator("#toast-container button", { hasText: "Undo" }).click();
+    await expect.poll(repoAFindings, { timeout: 10_000 }).toBe(before);
+  });
+
   test("contents pane collapses to a tab and reopens", async ({ page }) => {
     await openGraphTab(page);
     const projectId = await selectNodeOfKind(page, "project");

--- a/packages/cli/e2e/graph.spec.ts
+++ b/packages/cli/e2e/graph.spec.ts
@@ -1046,6 +1046,42 @@ test.describe.serial("graph visualization e2e", () => {
     await expect(panel.locator(".phren-pp-check")).toHaveCount(0);
   });
 
+  test("row peek flies to a node without changing selection", async ({ page }) => {
+    await openGraphTab(page);
+    const projectId = await selectNodeOfKind(page, "project");
+    expect(projectId).toBeTruthy();
+    const panel = page.locator(".phren-project-panel");
+    await expect(panel).toBeVisible({ timeout: 8_000 });
+    // The focused project shows an active navigator orb; no row is selected yet.
+    await expect(page.locator(".phren-project-orb.active")).toHaveCount(1);
+    await expect(panel.locator(".phren-pp-row.active")).toHaveCount(0);
+
+    // Peek a finding row → camera flies, but selection/focus is untouched.
+    const row = panel.locator(".phren-pp-row").first();
+    await row.hover();
+    await row.locator("[data-pp-peek]").click();
+    await page.waitForTimeout(300);
+    await expect(panel.locator(".phren-pp-row.active")).toHaveCount(0);
+    await expect(page.locator(".phren-project-orb.active")).toHaveCount(1);
+    await expect(panel).toBeVisible();
+  });
+
+  test("pane sort preference persists across reload", async ({ page }) => {
+    await openGraphTab(page);
+    let projectId = await selectNodeOfKind(page, "project");
+    expect(projectId).toBeTruthy();
+    const panel = page.locator(".phren-project-panel");
+    await expect(panel).toBeVisible({ timeout: 8_000 });
+    await panel.locator("[data-pp-sort]").selectOption("recent");
+
+    // Reload the app (same origin → localStorage persists), reopen a project.
+    await openGraphTab(page);
+    projectId = await selectNodeOfKind(page, "project");
+    expect(projectId).toBeTruthy();
+    await expect(panel).toBeVisible({ timeout: 8_000 });
+    await expect(panel.locator("[data-pp-sort]")).toHaveValue("recent");
+  });
+
   test("contents pane is resizable via its edge handle", async ({ page }) => {
     await openGraphTab(page);
     const projectId = await selectNodeOfKind(page, "project");

--- a/packages/cli/src/ui/graph-chrome.ts
+++ b/packages/cli/src/ui/graph-chrome.ts
@@ -67,6 +67,37 @@ body:has(#tab-graph.active) .header-brand { color: #dbe6ff; }
   pointer-events: none;
   z-index: 12;
 }
+/* Edge drag handle to widen/narrow the docked dossier (symmetric with the
+   contents pane). The popover itself is pointer-transparent, so the handle
+   re-enables pointer events for itself. */
+#graph-node-popover.phren-docked .phren-dossier-resize {
+  position: absolute;
+  right: -4px;
+  top: 0;
+  bottom: 0;
+  width: 9px;
+  cursor: ew-resize;
+  z-index: 20;
+  pointer-events: auto;
+  touch-action: none;
+}
+#graph-node-popover.phren-docked .phren-dossier-resize::after {
+  content: "";
+  position: absolute;
+  right: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 38px;
+  border-radius: 999px;
+  background: rgba(103, 232, 249, 0.28);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+#graph-node-popover.phren-docked .phren-dossier-resize:hover::after,
+#graph-node-popover.phren-docked .phren-dossier-resize.dragging::after {
+  opacity: 1;
+}
 /* GraphRAG-style stats row + relationships in the inspector */
 .phren-dossier-stats {
   display: grid;

--- a/packages/cli/src/ui/scripts.ts
+++ b/packages/cli/src/ui/scripts.ts
@@ -1863,6 +1863,28 @@ export function renderGraphHostScript(): string {
     }, 2600);
   }
 
+  function graphUndoToast(message, onUndo) {
+    var container = document.getElementById('toast-container');
+    if (!container) return;
+    var toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.style.display = 'flex';
+    toast.style.alignItems = 'center';
+    toast.style.gap = '10px';
+    var msg = document.createElement('span');
+    msg.textContent = message;
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = 'Undo';
+    btn.style.cssText = 'cursor:pointer;border:1px solid var(--accent,#67e8f9);background:transparent;color:var(--accent,#67e8f9);border-radius:6px;padding:2px 10px;font:inherit;font-size:12px';
+    var remove = function() { if (toast.parentNode) toast.parentNode.removeChild(toast); };
+    btn.addEventListener('click', function() { remove(); onUndo(); });
+    toast.appendChild(msg);
+    toast.appendChild(btn);
+    container.appendChild(toast);
+    setTimeout(remove, 8000);
+  }
+
   function fetchCsrfToken() {
     return fetch(authUrl('/api/csrf-token')).then(function(r) { return r.json(); }).then(function(data) {
       return data && data.ok ? (data.token || null) : null;
@@ -2315,16 +2337,39 @@ export function renderGraphHostScript(): string {
     });
   }
 
+  function reAddNodes(items) {
+    return Promise.all(items.map(function(it) {
+      if (it.kind === 'finding') {
+        return graphRequest('/api/findings/' + encodeURIComponent(it.projectName), 'POST', { text: it.text }).catch(function() { return { ok: false }; });
+      }
+      if (it.kind === 'task') {
+        return graphRequest('/api/tasks/add', 'POST', { project: it.projectName, item: it.item }).catch(function() { return { ok: false }; });
+      }
+      return Promise.resolve({ ok: false });
+    })).then(function() {
+      graphToast('Restored ' + items.length + ' items', 'ok');
+      return reloadGraph(null);
+    });
+  }
+
   function deleteNodes(nodes) {
     if (!nodes || !nodes.length) return;
     if (nodes.length === 1) { deleteNode(nodes[0]); return; }
     if (!confirm('Delete ' + nodes.length + ' items?')) return;
+    var undoItems = nodes.map(function(n) {
+      return {
+        kind: n.kind, projectName: n.projectName,
+        text: n.tooltipLabel || n.fullLabel || '',
+        item: n.stableId || n.id || n.tooltipLabel || n.fullLabel || n.displayLabel || ''
+      };
+    });
     Promise.all(nodes.map(function(n) {
       return deleteNodeRequest(n).catch(function() { return { ok: false }; });
     })).then(function(results) {
       var ok = results.filter(function(r) { return r && r.ok; }).length;
-      graphToast('Deleted ' + ok + ' of ' + nodes.length, ok === nodes.length ? 'ok' : 'err');
-      return reloadGraph(null);
+      return reloadGraph(null).then(function() {
+        graphUndoToast('Deleted ' + ok + ' item' + (ok === 1 ? '' : 's'), function() { reAddNodes(undoItems); });
+      });
     });
   }
 

--- a/packages/cli/src/ui/scripts.ts
+++ b/packages/cli/src/ui/scripts.ts
@@ -1901,6 +1901,33 @@ export function renderGraphHostScript(): string {
   // The dossier docks to the right edge of the graph viewport — a stable
   // reading pane instead of a cursor-chasing popover. Signature kept for
   // callers; the x/y hint is no longer needed.
+  function ensureDossierResize(popover) {
+    if (!popover || popover.querySelector('.phren-dossier-resize')) return;
+    var handle = document.createElement('div');
+    handle.className = 'phren-dossier-resize';
+    handle.setAttribute('aria-hidden', 'true');
+    handle.addEventListener('pointerdown', function(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      handle.classList.add('dragging');
+      try { handle.setPointerCapture(ev.pointerId); } catch (_) { /* ignore */ }
+      function move(e) {
+        var rect = popover.getBoundingClientRect();
+        var w = Math.max(280, Math.min(680, e.clientX - rect.left));
+        popover.style.width = w + 'px';
+        popover.style.maxWidth = 'none';
+      }
+      function up() {
+        handle.classList.remove('dragging');
+        window.removeEventListener('pointermove', move);
+        window.removeEventListener('pointerup', up);
+      }
+      window.addEventListener('pointermove', move);
+      window.addEventListener('pointerup', up);
+    });
+    popover.appendChild(handle);
+  }
+
   function positionPopover(x, y) {
     var popover = document.getElementById('graph-node-popover');
     if (!popover) return;
@@ -1909,6 +1936,7 @@ export function renderGraphHostScript(): string {
     popover.style.top = '';
     popover.style.visibility = 'visible';
     popover.style.display = 'block';
+    ensureDossierResize(popover);
   }
 
   function currentPopoverPoint() {

--- a/packages/vscode/scratch/render-webview.mjs
+++ b/packages/vscode/scratch/render-webview.mjs
@@ -60,6 +60,13 @@ for (const proj of ["api-server", "web-app"]) {
     edges.push({ source: "project:" + proj, target: id });
   }
 }
+// A fragment (entity) touching both projects + a reference doc.
+nodes.push({ id: "entity:AuthService", kind: "entity", projectName: "", label: "AuthService", text: "AuthService (class) - 5 refs", subtype: "class", entityType: "class", refCount: 5, connectedProjects: ["api-server", "web-app"], docs: ["api-server/auth.ts"], radius: 10, color: "#00E5FF" });
+edges.push({ source: "entity:AuthService", target: "project:api-server" });
+edges.push({ source: "entity:AuthService", target: "project:web-app" });
+nodes.push({ id: "ref:api-server/auth.ts", kind: "reference", projectName: "api-server", label: "auth.ts", text: "api-server/auth.ts", subtype: "reference", radius: 6, color: "#14b8a6" });
+edges.push({ source: "entity:AuthService", target: "ref:api-server/auth.ts" });
+
 const payload = { nodes, edges, summaries: {}, scores: { schemaVersion: 1, entries }, topics: topics.map(([slug, label]) => ({ slug, label })) };
 
 let html = renderGraphHtmlForTests(payload);

--- a/packages/vscode/src/graphWebview.ts
+++ b/packages/vscode/src/graphWebview.ts
@@ -438,7 +438,7 @@ export async function showGraphWebview(client: PhrenClient, context: vscode.Exte
       );
       if (confirmed !== "Delete") return;
 
-      let ok = 0;
+      const deleted: Array<{ kind: string; projectName: string; text: string; item: string }> = [];
       await mutate(async () => {
         for (const it of items) {
           const kind = asString(it.kind);
@@ -446,11 +446,13 @@ export async function showGraphWebview(client: PhrenClient, context: vscode.Exte
           if (!projectName || !isValidProjectName(projectName)) continue;
           try {
             if (kind === "finding") {
-              await client.removeFinding(projectName, asString(it.text) ?? "");
-              ok++;
+              const text = asString(it.text) ?? "";
+              await client.removeFinding(projectName, text);
+              deleted.push({ kind, projectName, text, item: "" });
             } else if (kind === "task") {
-              await client.removeTask(projectName, asString(it.item) ?? asString(it.text) ?? "");
-              ok++;
+              const item = asString(it.item) ?? asString(it.text) ?? "";
+              await client.removeTask(projectName, item);
+              deleted.push({ kind, projectName, text: asString(it.text) ?? "", item });
             }
           } catch {
             // Skip failures; the refresh below reflects whatever succeeded.
@@ -458,9 +460,36 @@ export async function showGraphWebview(client: PhrenClient, context: vscode.Exte
         }
       });
       await refreshGraph();
-      if (ok < items.length) {
-        vscode.window.showWarningMessage(`Deleted ${ok} of ${items.length} items.`);
+      // Offer an in-graph undo for the whole batch.
+      void panel.webview.postMessage({
+        type: "batchRemoved",
+        undo: { items: deleted, label: `Deleted ${deleted.length} item${deleted.length === 1 ? "" : "s"}` },
+      });
+      if (deleted.length < items.length) {
+        vscode.window.showWarningMessage(`Deleted ${deleted.length} of ${items.length} items.`);
       }
+      return;
+    }
+
+    if (command === "undoDeleteBatch") {
+      const items = asArray(message.items)
+        .map((entry) => asRecord(entry))
+        .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+      if (!items.length) return;
+      await mutate(async () => {
+        for (const it of items) {
+          const kind = asString(it.kind);
+          const projectName = asString(it.projectName);
+          if (!projectName || !isValidProjectName(projectName)) continue;
+          try {
+            if (kind === "finding") await client.addFinding(projectName, asString(it.text) ?? "");
+            else if (kind === "task") await client.addTask(projectName, asString(it.item) ?? asString(it.text) ?? "");
+          } catch {
+            // best-effort restore
+          }
+        }
+      });
+      await refreshGraph();
       return;
     }
 
@@ -2035,6 +2064,12 @@ ${graphScript}
           }
         });
       }
+    }
+    if (data.type === 'batchRemoved' && data.undo && data.undo.items && data.undo.items.length) {
+      var batch = data.undo;
+      showUndoToast(batch.label || ('Deleted ' + batch.items.length + ' items'), function() {
+        vscode.postMessage({ command: 'undoDeleteBatch', items: batch.items });
+      });
     }
   });
 

--- a/packages/vscode/src/graphWebview.ts
+++ b/packages/vscode/src/graphWebview.ts
@@ -1203,6 +1203,32 @@ function renderGraphHtml(webview: vscode.Webview, payload: GraphPayload): string
       overflow: auto;
     }
     #node-popover.docked #node-popover-handle { display: none; }
+    #node-popover.docked .dossier-resize {
+      position: absolute;
+      right: -4px;
+      top: 0;
+      bottom: 0;
+      width: 9px;
+      cursor: ew-resize;
+      z-index: 20;
+      pointer-events: auto;
+      touch-action: none;
+    }
+    #node-popover.docked .dossier-resize::after {
+      content: "";
+      position: absolute;
+      right: 3px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 3px;
+      height: 38px;
+      border-radius: 999px;
+      background: rgba(103, 232, 249, 0.28);
+      opacity: 0;
+      transition: opacity 0.15s ease;
+    }
+    #node-popover.docked .dossier-resize:hover::after,
+    #node-popover.docked .dossier-resize.dragging::after { opacity: 1; }
     #node-popover-content {
       display: flex;
       flex-direction: column;
@@ -1626,6 +1652,33 @@ ${graphScript}
   // The dossier docks to the left edge of the graph viewport — a stable reading
   // pane instead of a cursor-chasing popover that covered the node you clicked.
   // The x/y hint is kept for callers but no longer used for placement.
+  function ensureDossierResize() {
+    if (!popover || popover.querySelector('.dossier-resize')) return;
+    var handle = document.createElement('div');
+    handle.className = 'dossier-resize';
+    handle.setAttribute('aria-hidden', 'true');
+    handle.addEventListener('pointerdown', function(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      handle.classList.add('dragging');
+      try { handle.setPointerCapture(ev.pointerId); } catch (_) { /* ignore */ }
+      function move(e) {
+        var rect = popover.getBoundingClientRect();
+        var w = Math.max(280, Math.min(680, e.clientX - rect.left));
+        popover.style.width = w + 'px';
+        popover.style.maxWidth = 'none';
+      }
+      function up() {
+        handle.classList.remove('dragging');
+        window.removeEventListener('pointermove', move);
+        window.removeEventListener('pointerup', up);
+      }
+      window.addEventListener('pointermove', move);
+      window.addEventListener('pointerup', up);
+    });
+    popover.appendChild(handle);
+  }
+
   function positionPopover(x, y) {
     if (!popover || !popoverCard) return;
     popover.classList.add('docked');
@@ -1634,6 +1687,7 @@ ${graphScript}
     popover.setAttribute('aria-hidden', 'false');
     popover.style.visibility = 'visible';
     popover.style.display = 'block';
+    ensureDossierResize();
   }
 
   function renderDocs(node) {
@@ -1815,7 +1869,8 @@ ${graphScript}
   function outsidePointer(event) {
     if (!currentNode || !popoverCard) return;
     var target = event.target;
-    if (target instanceof Node && popoverCard.contains(target)) return;
+    // Anywhere inside the popover (card OR its resize handle) is not "outside".
+    if (target instanceof Node && ((popover && popover.contains(target)) || popoverCard.contains(target))) return;
     // Renderer-owned HUD overlays (project navigator, contents pane + its
     // re-open tab, filter bar, zoom controls) are legitimate UI, not a
     // click-away dismiss. The 3D background still clears via onBackgroundClick.


### PR DESCRIPTION
Follow-up to #69 — the queued next-set list, all five items completed and verified.

## 1. Persist pane preferences
The contents pane remembers its **width, collapsed state, and sort mode** across reloads (localStorage; filters/query stay transient).

## 2. Quick "focus in graph" row action
Each row gets a hover **peek (◎)** that flies the camera to the node and pulses it **without** opening the dossier or changing the selection.

## 3. Resizable left detail dossier
The docked node dossier gains a right-edge drag handle (both hosts), symmetric with the contents pane. The VS Code capture-phase outside-pointer dismiss now treats the whole popover subtree (handle included) as "inside".

## 4. Undo for bulk delete
After a bulk prune, both hosts surface an **Undo toast** that restores the whole batch (web-ui re-adds via the add endpoints; VS Code posts `undoDeleteBatch` and the extension re-adds + refreshes). `deleteBatch` reports the deleted items so undo knows what to restore.

## 5. Fragment/entity context
Selecting a fragment populates the pane with its network — a **Connected projects** section (rows navigate to the project) and a **References** section — instead of project-only context. The pane element + resize handle are shared between the project and fragment views.

## Tests & verification
- Real round-trips verified against a live server (bulk delete → undo restores repo-a 2→0→2).
- New e2e: persistence-across-reload, peek-without-selection, dossier resize (both hosts), bulk-undo, fragment context.
- Full graph suite: **44 passing**; unit suite: **2688 passing**; lint + VS Code tsc clean.
- Every VS Code state (docked dossier, collapse, bulk bar, slimmed project view, fragment pane, batch-undo toast) verified by rendering the real webview HTML standalone and screenshotting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01St4Qq4oLXvG8nbLPQX5Nm5

---
_Generated by [Claude Code](https://claude.ai/code/session_01St4Qq4oLXvG8nbLPQX5Nm5)_