### PR TITLE
fix: stop sparse-checkout from silently hiding root config (0.1.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.38] - 2026-07-19
+
+### Fixed
+
+- **Sparse-checkout no longer hides root config, which silently broke MCP and team
+  stores.** `setupSparseCheckout` omitted `phren.root.yaml` and `stores.yaml` from its
+  always-include list, leaving them tracked in git but absent from the working tree on
+  any profile-linked store. Both failures were silent: the MCP entrypoint gates on
+  reading the root manifest, so a missing one made `phren <store-path>` fall through to
+  "Unknown command" and exit — surfacing in clients as `Cannot call write after a stream
+  was destroyed` — while a missing `stores.yaml` made the registry fall back to a single
+  implicit store, hiding every configured team store.
+- `phren store list` reported `projects: 0` for every store. `countStoreProjects` used a
+  CommonJS `require()` inside an ESM module, which always threw `ReferenceError` into a
+  bare `catch` that returned `0`.
+
+### Added
+
+- `phren doctor` now checks that root config is materialized on disk, not merely tracked
+  in git, and distinguishes sparse-checkout exclusion from an outright missing file.
+  `phren doctor --fix` repairs it by widening the sparse-checkout patterns.
+
 ## [0.1.37] - 2026-07-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [0.1.38] - 2026-07-19
+## [0.1.38] - 2026-07-20
+
+### Added
+
+- **First-class daily notes across CLI, MCP, web UI, and VS Code.** Notes live in
+  per-project daily Markdown files, support add/list/edit/remove operations, and can be
+  promoted into durable typed findings when they become reusable knowledge.
+- Notes are explicitly searchable and sync with team stores while remaining excluded
+  from automatic hook injection and the knowledge graph, keeping lightweight working
+  context separate from curated findings.
+- Project-level **Add finding** and **Add note** operations are now directly available
+  in both the web UI and VS Code activity bar, including multiline capture and complete
+  note management in the project view.
+- `phren doctor` now checks that root config is materialized on disk, not merely tracked
+  in git, and distinguishes sparse-checkout exclusion from an outright missing file.
+  `phren doctor --fix` repairs it by widening the sparse-checkout patterns.
 
 ### Fixed
 
@@ -20,12 +35,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `phren store list` reported `projects: 0` for every store. `countStoreProjects` used a
   CommonJS `require()` inside an ESM module, which always threw `ReferenceError` into a
   bare `catch` that returned `0`.
-
-### Added
-
-- `phren doctor` now checks that root config is materialized on disk, not merely tracked
-  in git, and distinguishes sparse-checkout exclusion from an outright missing file.
-  `phren doctor --fix` repairs it by widening the sparse-checkout patterns.
+- Web UI lifecycle hook rows are selectable again, hook config reads remain constrained
+  to the exact supported config files, and edited review items now retain working
+  approve/reject actions.
 
 ## [0.1.37] - 2026-07-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ pnpm lint          # lint all packages
 
 ## Current Version
 
-`@phren/cli` 0.1.37 (see `packages/cli/package.json`).
+`@phren/cli` 0.1.38 (see `packages/cli/package.json`).
 
 ## Reference Documentation
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Drop custom slash commands into `~/.phren/global/skills/`. Hooks run on user pro
 phren                                   Interactive memory shell
 phren search <query>                    Full-text search with FTS5
 phren add-finding <project> "insight"
+phren note add <project> "daily note"  Add a lightweight daily note
 phren task add <project> "item"         Add a task
 phren session_start <project>           Start a session
 phren store list                        List personal + team stores
@@ -109,7 +110,7 @@ See full CLI docs at [alaarab.github.io/phren](https://alaarab.github.io/phren/)
 
 ## Team stores
 
-Shared knowledge repos for teams. One person creates with `phren team init`, others join with `phren team join`. Findings, tasks, and skills sync across team members.
+Shared knowledge repos for teams. One person creates with `phren team init`, others join with `phren team join`. Findings, daily notes, tasks, and skills sync across team members.
 
 Each team store can be configured with per-project subscriptions so people only see what they care about.
 
@@ -130,7 +131,7 @@ All use the same phren store. No vendor lock-in.
 
 | Package | Description |
 |---------|-------------|
-| [`@phren/cli`](packages/cli) | CLI, MCP server, data layer (54 tools, FTS5, hooks) |
+| [`@phren/cli`](packages/cli) | CLI, MCP server, data layer (59 tools, FTS5, hooks) |
 | [`phren-vscode`](packages/vscode) | VS Code extension (sidebar, graph, onboarding) |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ tectonic docs/whitepaper.tex --outdir docs
 
 - `docs/architecture.md`: Data flow diagrams for hooks, MCP server, FTS5 index, and memory governance.
 - `docs/architecture-team-stores.md`: Team-store and multi-store architecture notes.
-- `docs/llms-install.md`: Installation guide, all 54 MCP tools, hooks, and memory governance pipeline.
+- `docs/llms-install.md`: Installation guide, all 59 MCP tools, hooks, and memory governance pipeline.
 - `docs/environment.md`: Full reference for all environment variables with types and defaults.
 - `docs/governance.md`: Governance model, review flows, and access controls.
 - `docs/ide-setup.md`: IDE and editor integration setup notes.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,10 +1,10 @@
 # MCP API Reference
 
-Phren exposes 54 MCP tools across 12 modules through the Model Context Protocol. These are available to any MCP-compatible client when the phren server is running.
+Phren exposes 59 MCP tools across 13 modules through the Model Context Protocol. These are available to any MCP-compatible client when the phren server is running.
 
 All tools return structured JSON: `{ ok, message, data?, error? }`.
 
-Module layout: search, tasks, findings, memory quality, data management, fragment graph, sessions, operations/review, skills, hooks, extraction, configuration.
+Module layout: search, tasks, findings, daily notes, memory quality, data management, fragment graph, sessions, operations/review, skills, hooks, extraction, configuration.
 
 ---
 
@@ -29,7 +29,7 @@ Search the user's personal project store using FTS5 full-text search with synony
 | `query` | string | yes | Search query. Supports FTS5 syntax: AND, OR, NOT, phrase matching with quotes. |
 | `limit` | number | no | Max results to return (1-20, default 5). |
 | `project` | string | no | Filter results to a specific project. |
-| `type` | enum | no | Filter by document type. One of: `claude`, `findings`, `reference`, `skills`, `summary`, `task`, `changelog`, `canonical`, `review-queue`, `skill`, `other`. |
+| `type` | enum | no | Filter by document type. One of: `claude`, `findings`, `notes`, `reference`, `skills`, `summary`, `task`, `changelog`, `canonical`, `review-queue`, `skill`, `other`. |
 | `tag` | enum | no | Filter findings by type tag: `decision`, `pitfall`, `pattern`, `tradeoff`, `architecture`, `bug`. |
 | `since` | string | no | Filter findings by creation date. Formats: `7d`, `30d`, `YYYY-MM`, `YYYY-MM-DD`. |
 | `status` | enum | no | Filter findings by lifecycle status: `active`, `superseded`, `contradicted`, `stale`, `invalid_citation`, `retracted`. |
@@ -64,6 +64,57 @@ List recent findings for a project without requiring a search query.
 | `include_superseded` | boolean | no | Include superseded findings (legacy compatibility flag). |
 | `include_history` | boolean | no | Include historical findings (`superseded`, `retracted`). |
 | `status` | enum | no | Filter by lifecycle status: `active`, `superseded`, `contradicted`, `stale`, `invalid_citation`, `retracted`. |
+
+---
+
+## Daily Notes
+
+Notes are lightweight, user-authored scratch context stored in `<project>/notes/YYYY-MM-DD.md`. They are indexed for explicit search and synchronized with team stores, but are excluded from automatic prompt injection, finding decay/review, and the fragment graph. Promote a note when it becomes durable reusable knowledge.
+
+### `get_notes`
+
+List daily notes newest-first.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name, optionally store-qualified. |
+| `date` | string | no | Filter to a `YYYY-MM-DD` date. |
+| `limit` | number | no | Maximum results (1-500, default 100). |
+
+### `add_note`
+
+Add Markdown text to a daily note file.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name, optionally store-qualified. |
+| `text` | string | yes | Note text; multiple lines and Markdown are supported. |
+| `date` | string | no | Target `YYYY-MM-DD`; defaults to today. |
+
+### `edit_note`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name. |
+| `note` | string | yes | Stable `nid:xxxxxxxx` or unambiguous text match. |
+| `text` | string | yes | Replacement Markdown text. |
+
+### `remove_note`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name. |
+| `note` | string | yes | Stable `nid:xxxxxxxx` or unambiguous text match. |
+
+### `promote_note`
+
+Copy a note into `FINDINGS.md` and mark the original as promoted without deleting it.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `project` | string | yes | Project name. |
+| `note` | string | yes | Stable `nid:xxxxxxxx` or unambiguous text match. |
+| `findingType` | enum | no | `decision`, `pitfall`, `pattern`, `tradeoff`, `architecture`, or `bug`. |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 How project memory flows through the system, from user prompt to repo-backed state and back into bounded retrieval.
 
-Current public surface: 54 MCP tools across 12 modules.
+Current public surface: 59 MCP tools across 13 modules.
 
 ## System Overview
 
@@ -27,7 +27,7 @@ Claude / Copilot / Cursor / Codex
                 v
 +---------------+---------------+
 | MCP Server (phren-mcp)       |
-| 54 tools across 12 modules    |
+| 59 tools across 13 modules    |
 +---------------+---------------+
                 |
                 v
@@ -101,20 +101,21 @@ This gives Claude full native lifecycle parity while keeping other tools synchro
 
 ## MCP Server Modules
 
-Phren MCP is split into 12 modules:
+Phren MCP is split into 13 modules:
 
 1. Search and browse
 2. Task management
 3. Finding capture and lifecycle
-4. Memory quality
-5. Data management
-6. Fragment graph
-7. Session management
-8. Operations and review queue
-9. Skills management
-10. Hooks management
-11. Extraction
-12. Configuration
+4. Daily notes
+5. Memory quality
+6. Data management
+7. Fragment graph
+8. Session management
+9. Operations and review queue
+10. Skills management
+11. Hooks management
+12. Extraction
+13. Configuration
 
 Finding lifecycle and editing tools:
 
@@ -140,6 +141,8 @@ All state stays local as files (markdown/json), with git as transport in shared 
     CLAUDE.md
     summary.md
     FINDINGS.md
+    notes/
+      YYYY-MM-DD.md
     tasks.md
     review.md
     truths.md

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1574,7 +1574,7 @@ phren hooks add-custom Stop "curl -s http://localhost:9090/notify"</code></pre>
       <!-- ============================================================ -->
       <section class="docs-section" id="mcp-tools">
         <h1>MCP Tools</h1>
-        <p class="docs-subtitle">All 54 tools exposed by the phren MCP server. Every tool returns <code>{ ok, message, data?, error? }</code>.</p>
+        <p class="docs-subtitle">All 59 tools exposed by the phren MCP server. Every tool returns <code>{ ok, message, data?, error? }</code>.</p>
 
         <h2 id="mcp-search">Search &amp; Browse <span class="cat-badge cat-search">10 tools</span> <a href="#mcp-search" class="anchor-link">#</a></h2>
 
@@ -1588,6 +1588,14 @@ phren hooks add-custom Stop "curl -s http://localhost:9090/notify"</code></pre>
         <details class="ref-card"><summary><span class="ref-card-name">get_review_queue</span><span class="ref-card-desc">Items waiting for review</span></summary><div class="ref-card-details"><div class="ref-card-params">(project?)</div></div></details>
         <details class="ref-card"><summary><span class="ref-card-name">manage_review_item</span><span class="ref-card-desc">Approve, reject, or edit a review queue item</span></summary><div class="ref-card-details"><div class="ref-card-params">(project, line, action, new_text?)</div></div></details>
         <details class="ref-card"><summary><span class="ref-card-name">doctor_fix</span><span class="ref-card-desc">Run doctor self-heal and apply fixes</span></summary><div class="ref-card-details"><div class="ref-card-params">()</div></div></details>
+
+        <h2 id="mcp-notes">Daily Notes <span class="cat-badge cat-memory">5 tools</span> <a href="#mcp-notes" class="anchor-link">#</a></h2>
+        <p>Lightweight daily Markdown notes are explicitly searchable but are not automatically injected or included in finding lifecycle and graph processing.</p>
+        <details class="ref-card"><summary><span class="ref-card-name">get_notes</span><span class="ref-card-desc">List daily notes newest-first</span></summary><div class="ref-card-details"><div class="ref-card-params">(project, date?, limit?)</div></div></details>
+        <details class="ref-card"><summary><span class="ref-card-name">add_note</span><span class="ref-card-desc">Add a daily Markdown note</span></summary><div class="ref-card-details"><div class="ref-card-params">(project, text, date?)</div></div></details>
+        <details class="ref-card"><summary><span class="ref-card-name">edit_note</span><span class="ref-card-desc">Replace note text</span></summary><div class="ref-card-details"><div class="ref-card-params">(project, note, text)</div></div></details>
+        <details class="ref-card"><summary><span class="ref-card-name">remove_note</span><span class="ref-card-desc">Remove one note</span></summary><div class="ref-card-details"><div class="ref-card-params">(project, note)</div></div></details>
+        <details class="ref-card"><summary><span class="ref-card-name">promote_note</span><span class="ref-card-desc">Copy a note to durable findings</span></summary><div class="ref-card-details"><div class="ref-card-params">(project, note, findingType?)</div></div></details>
 
         <h2 id="mcp-tasks">Task Management <span class="cat-badge cat-task">6 tools</span> <a href="#mcp-tasks" class="anchor-link">#</a></h2>
 
@@ -2079,7 +2087,7 @@ npm test</code></pre>
             <tr><th>Path</th><th>What it does</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>mcp/src/index.ts</code></td><td>CLI routing + MCP server bootstrap (53 public tools across 12 modules)</td></tr>
+            <tr><td><code>packages/cli/src/index.ts</code></td><td>CLI routing + MCP server bootstrap (59 public tools across 13 modules)</td></tr>
             <tr><td><code>mcp/src/shared.ts</code></td><td>Shared path/runtime helpers and core exports</td></tr>
             <tr><td><code>mcp/src/cli.ts</code></td><td>CLI subcommands (search, doctor, shell, etc.)</td></tr>
             <tr><td><code>mcp/src/utils.ts</code></td><td>FTS5 sanitization, synonym expansion, keyword extraction</td></tr>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -144,7 +144,7 @@ Project setup note:
 
 ## Does phren require MCP?
 
-No. MCP is recommended. It gives agents 54 tools across 12 modules for reading and writing memory directly. But phren also works in hooks-only mode, where context injection still happens automatically via the prompt hook. The simpler default story is still markdown + git + local FTS5; semantic and LLM-assisted paths are optional layers, not prerequisites.
+No. MCP is recommended. It gives agents 59 tools across 13 modules for reading and writing memory directly. But phren also works in hooks-only mode, where context injection still happens automatically via the prompt hook. The simpler default story is still markdown + git + local FTS5; semantic and LLM-assisted paths are optional layers, not prerequisites.
 
 ```bash
 phren init --mcp off

--- a/docs/index.html
+++ b/docs/index.html
@@ -1081,7 +1081,7 @@
     <div class="container">
       <div class="skills-header reveal">
         <div class="section-label">Phren's tricks</div>
-        <h2 class="section-title">54 MCP tools built in.<br>Skills for the bigger stuff.</h2>
+        <h2 class="section-title">59 MCP tools built in.<br>Skills for the bigger stuff.</h2>
         <p class="section-sub" style="margin-top:12px"><span class="kw">MCP tools</span> handle search, capture, review, and sync. <span class="kw-skill">Skills</span> are shortcuts for larger jobs. Global skills live in <code style="font-size:14px;color:var(--copper-mid)">~/.phren/global/skills/</code>, project skills in <code style="font-size:14px;color:var(--copper-mid)">~/.phren/&lt;project&gt;/skills/</code>. Project skills override global ones with the same name.</p>
       </div>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6,7 +6,7 @@ Quick start:
   This creates ~/.phren, registers MCP for detected agents, sets up lifecycle hooks, and registers your machine.
   Open a prompt in your project directory. Context injection starts immediately.
 
-MCP Tools (54 across 12 modules):
+MCP Tools (59 across 13 modules):
 
   Search and browse:
     search_knowledge(query, type?, limit?, project?, tag?, since?, status?, include_history?, synthesize?) - FTS5 search with synonym expansion, filterable by tag/date/lifecycle
@@ -14,6 +14,13 @@ MCP Tools (54 across 12 modules):
     get_project_summary(name) - project summary card and file list
     list_projects(page?, page_size?) - all projects in active profile with pagination
     get_findings(project, limit?, include_superseded?, include_history?, status?) - read recent findings without a search query
+
+  Daily notes (searchable, never automatically injected):
+    get_notes(project, date?, limit?) - list daily notes newest-first
+    add_note(project, text, date?) - add Markdown text to notes/YYYY-MM-DD.md
+    edit_note(project, note, text) - replace a note by stable nid or unambiguous match
+    remove_note(project, note) - remove one note
+    promote_note(project, note, findingType?) - copy a note into findings and retain its promoted source
 
   Task management:
     get_tasks(project?, id?, item?, status?, limit?, done_limit?, offset?, summary?) - read tasks with pagination, summary mode, and section filtering

--- a/docs/llms-install.md
+++ b/docs/llms-install.md
@@ -64,13 +64,13 @@ List registered stores:
 phren team list
 ```
 
-Team stores sync independently via git. Findings and tasks in a team store are visible to all members through federated search and context injection.
+Team stores sync independently via git. Findings, notes, and tasks in a team store are visible to all members through federated search. Notes remain opt-in search context and are not automatically injected.
 
 ## Maintenance Safety
 
 Destructive maintenance commands (`prune` and `consolidate`) should be run with `--dry-run` first. On write paths that rewrite `FINDINGS.md`, phren creates/updates `FINDINGS.md.bak` and reports changed backup paths (for example, `Updated backups (1): <project>/FINDINGS.md.bak`). `--dry-run` previews changes without creating backups.
 
-## MCP Tools (54)
+## MCP Tools (59)
 
 ### Search and Browse
 
@@ -81,6 +81,18 @@ Destructive maintenance commands (`prune` and `consolidate`) should be run with 
 | `get_project_summary` | `name` | Returns a project's summary card, CLAUDE.md path, and list of indexed files. |
 | `list_projects` | `page?`, `page_size?` | Lists all projects in the active profile with pagination. |
 | `get_findings` | `project`, `limit?`, `include_superseded?`, `include_history?`, `status?` | Read recent findings, filterable by lifecycle status. |
+
+### Daily Notes
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `get_notes` | `project`, `date?`, `limit?` | List lightweight daily notes newest-first. |
+| `add_note` | `project`, `text`, `date?` | Add Markdown text to `<project>/notes/YYYY-MM-DD.md`. |
+| `edit_note` | `project`, `note`, `text` | Replace a note by stable `nid` or unambiguous match. |
+| `remove_note` | `project`, `note` | Remove one note. |
+| `promote_note` | `project`, `note`, `findingType?` | Copy a note to findings and retain it with a promoted marker. |
+
+Notes are explicitly searchable but excluded from automatic hook context, finding lifecycle/review, and the fragment graph.
 
 ### Task Management (`task` tools)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,8 @@ Install: npm install -g @phren/cli && phren init
 
 Key features:
 - Automatic context injection into every prompt via lifecycle hooks
-- 54 MCP tools across 12 modules (search, tasks, findings, memory, data, graph, sessions, ops/review, skills, hooks, extraction, configuration)
+- 59 MCP tools across 13 modules (search, tasks, findings, notes, memory, data, graph, sessions, ops/review, skills, hooks, extraction, configuration)
+- Daily notes are explicitly searchable lightweight scratch context with CRUD and promote-to-finding; they are not automatically injected
 - Finding lifecycle tooling (`supersede_finding`, `retract_finding`, `resolve_contradiction`, `get_contradictions`) with provenance and impact scoring
 - Session continuity via cross-session task checkpoints + `session_history`
 - Skill system with source precedence, alias-collision handling, visibility gating, and generated `skill-manifest.json`

--- a/docs/whitepaper.tex
+++ b/docs/whitepaper.tex
@@ -171,7 +171,7 @@ Lifecycle automation is now a four-event model with tool-level continuity suppor
 Claude uses native lifecycle hooks; Copilot/Cursor/Codex use generated wrappers + tool configs to enforce equivalent lifecycle semantics. The architectural point is unchanged: memory capture and retrieval stay inside the normal agent loop rather than becoming a separate manual habit.
 
 \subsection{MCP Module Surface}
-Phren MCP currently exposes \textbf{54 tools across 12 modules}: search/browse, task management, finding capture and lifecycle, memory quality, data management, fragment graph, session management, operations/review, skills management, hooks management, and extraction. Newly expanded lifecycle surfaces include contradiction/supersession tools for findings and session history/continuity tooling.
+Phren MCP currently exposes \textbf{59 tools across 13 modules}: search/browse, task management, finding capture and lifecycle, lightweight daily notes, memory quality, data management, fragment graph, session management, operations/review, skills management, hooks management, extraction, and configuration. Notes provide explicit-search scratch context and promotion to findings without automatic prompt injection.
 
 \subsection{Token Budget and Progressive Disclosure}
 \label{sec:context-opt}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,11 +4,12 @@ MCP server that indexes your personal phren and exposes it to AI agents via full
 
 On startup it walks your phren directory, reads all `.md` files, and builds an in-memory SQLite FTS5 index.
 
-Public surface: 54 MCP tools across 12 modules (search, tasks, findings, memory, data, graph, sessions, ops/review, skills, hooks, config, extraction).
+Public surface: 59 MCP tools across 13 modules (search, tasks, findings, notes, memory, data, graph, sessions, ops/review, skills, hooks, config, extraction).
 
 Notable shipped capabilities:
 - finding lifecycle tools: `supersede_finding`, `retract_finding`, `resolve_contradiction`, `get_contradictions`
 - finding provenance: `add_finding.source` (`human|agent|hook|extract|consolidation|unknown`)
+- lightweight daily notes: CRUD in `<project>/notes/YYYY-MM-DD.md`, explicit search, and promotion to findings without automatic prompt injection
 - cross-session continuity: task checkpoints + `session_history`
 - finding impact scoring from injected-context outcomes
 - skill registry behavior: scope precedence, alias-collision handling, visibility gating, generated `skill-manifest.json`
@@ -94,7 +95,7 @@ No parameters.
 5. Builds an in-memory SQLite FTS5 index with Porter stemming
 6. Serves tools over stdio using the MCP protocol
 
-File types are derived from filenames: `CLAUDE.md` -> "claude", `summary.md` -> "summary", `FINDINGS.md` -> "findings", `tasks.md` -> "task", files under `reference/` -> "reference", files under `skills/` -> "skill".
+File types are derived from filenames and directories: `CLAUDE.md` -> "claude", `summary.md` -> "summary", `FINDINGS.md` -> "findings", `tasks.md` -> "task", files under `notes/` -> "notes", files under `reference/` -> "reference", files under `skills/` -> "skill".
 
 ## Development
 

--- a/packages/cli/e2e/web-ui-harness.ts
+++ b/packages/cli/e2e/web-ui-harness.ts
@@ -136,6 +136,7 @@ function seedProjectFixtures(phrenDir: string): void {
       "",
       "- [pattern] Browser smoke finding",
       "- [decision] Web UI should launch from an isolated test store",
+      "- [pattern] Review me first",
       "",
     ].join("\n"),
   );

--- a/packages/cli/e2e/web-ui.spec.ts
+++ b/packages/cli/e2e/web-ui.spec.ts
@@ -98,9 +98,43 @@ test.describe.serial("web-ui browser e2e", () => {
 
     await page.locator("button.nav-item").filter({ hasText: "Graph" }).click();
     await expect(page.locator("#graph-canvas")).toBeVisible();
-    await expect(page.locator("#graph-project-filter")).toContainText("repo-a");
-    await page.locator("#graph-project-filter .graph-proj-btn").filter({ hasText: "repo-a" }).click();
-    await expect(page.locator("#graph-project-filter .graph-proj-btn.active")).toHaveText("repo-a");
+    const projectNav = page.getByRole("navigation", { name: "Project navigator" });
+    const repoAOrb = projectNav.locator('.phren-project-orb[data-project-id="repo-a"]');
+    await expect(repoAOrb).toBeVisible();
+    await repoAOrb.click();
+    await expect(repoAOrb).toHaveClass(/active/);
+  });
+
+  test("captures a finding from the project operation and refreshes the list", async ({ page }) => {
+    await openWebUi(page);
+
+    await page.locator(".project-card").filter({ hasText: "repo-b" }).click();
+    await page.getByRole("button", { name: "+ Add finding" }).click();
+
+    const text = `web-capture-${Date.now()}`;
+    await page.locator("#finding-add-input").fill(text);
+    await page.getByRole("button", { name: "Add finding", exact: true }).click();
+
+    await expect(page.locator("#project-content")).toContainText(text);
+    await expect(page.locator(".finding-detail-card summary").filter({ hasText: text })).not.toContainText("<!--");
+  });
+
+  test("captures and promotes a daily note from the project operation", async ({ page }) => {
+    await openWebUi(page);
+
+    await page.locator(".project-card").filter({ hasText: "repo-b" }).click();
+    await page.getByRole("button", { name: "+ Add note" }).click();
+    const text = `web-note-${Date.now()}`;
+    await page.locator("#note-add-text").fill(text);
+    await page.getByRole("button", { name: "Add note", exact: true }).click();
+    await expect(page.locator(".note-card").filter({ hasText: text })).toBeVisible();
+
+    page.once("dialog", async (dialog) => dialog.accept("pattern"));
+    await page.locator(".note-card").filter({ hasText: text }).getByRole("button", { name: "Promote to finding" }).click();
+    await expect(page.locator(".note-card").filter({ hasText: text })).toContainText("promoted");
+
+    await page.locator(".project-detail-tab").filter({ hasText: "Findings" }).click();
+    await expect(page.locator("#project-content")).toContainText(text);
   });
 
   test("edits and approves a queued memory end-to-end", async ({ page }) => {
@@ -119,7 +153,7 @@ test.describe.serial("web-ui browser e2e", () => {
 
     await page.locator(".review-card-check").click();
     await expect(page.locator("#batch-bar")).toContainText("1 selected");
-    await page.getByRole("button", { name: "Approve All" }).click();
+    await page.getByRole("button", { name: "Approve selected" }).click();
     await expect(page.locator(".review-card")).toHaveCount(0, { timeout: 8_000 });
 
     await page.locator("button.nav-item").filter({ hasText: "Projects" }).click();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,9 +35,17 @@
       "types": "./dist/data/tasks.d.ts",
       "default": "./dist/data/tasks.js"
     },
+    "./data/notes": {
+      "types": "./dist/data/notes.d.ts",
+      "default": "./dist/data/notes.js"
+    },
     "./core/finding": {
       "types": "./dist/core/finding.d.ts",
       "default": "./dist/core/finding.js"
+    },
+    "./core/note": {
+      "types": "./dist/core/note.d.ts",
+      "default": "./dist/core/note.js"
     },
     "./auth/profiles": {
       "types": "./dist/auth/profiles.d.ts",

--- a/packages/cli/src/__tests__/finding-types.test.ts
+++ b/packages/cli/src/__tests__/finding-types.test.ts
@@ -22,6 +22,7 @@ describe("taxonomy consistency", () => {
   it("DOC_TYPES includes findings and canonical", () => {
     expect(DOC_TYPES).toContain("findings");
     expect(DOC_TYPES).toContain("canonical");
+    expect(DOC_TYPES).toContain("notes");
   });
 
   it("FINDING_TYPES has all 6 unified tags", () => {

--- a/packages/cli/src/__tests__/rbac.test.ts
+++ b/packages/cli/src/__tests__/rbac.test.ts
@@ -151,6 +151,10 @@ describe("contributor role", () => {
     expect(permissionDeniedError(phrenPath, "add_task")).toBeNull();
     expect(permissionDeniedError(phrenPath, "complete_task")).toBeNull();
     expect(permissionDeniedError(phrenPath, "edit_finding")).toBeNull();
+    expect(permissionDeniedError(phrenPath, "add_note")).toBeNull();
+    expect(permissionDeniedError(phrenPath, "edit_note")).toBeNull();
+    expect(permissionDeniedError(phrenPath, "remove_note")).toBeNull();
+    expect(permissionDeniedError(phrenPath, "promote_note")).toBeNull();
   });
 
   it("blocks contributors from admin-only actions", () => {
@@ -178,6 +182,7 @@ describe("reader role", () => {
     expect(permissionDeniedError(phrenPath, "add_finding")).not.toBeNull();
     expect(permissionDeniedError(phrenPath, "remove_finding")).not.toBeNull();
     expect(permissionDeniedError(phrenPath, "add_task")).not.toBeNull();
+    expect(permissionDeniedError(phrenPath, "add_note")).not.toBeNull();
     expect(permissionDeniedError(phrenPath, "manage_config")).not.toBeNull();
   });
 });

--- a/packages/cli/src/cli-hooks-git.test.ts
+++ b/packages/cli/src/cli-hooks-git.test.ts
@@ -87,5 +87,6 @@ describe("addTeamPathspecs", () => {
     expect(TEAM_STORE_PATHSPECS).toContain("*/FINDINGS.md");
     expect(TEAM_STORE_PATHSPECS).toContain("*/reference/**");
     expect(TEAM_STORE_PATHSPECS).toContain("*/skills/**");
+    expect(TEAM_STORE_PATHSPECS).toContain("*/notes/**");
   });
 });

--- a/packages/cli/src/cli-hooks-git.ts
+++ b/packages/cli/src/cli-hooks-git.ts
@@ -180,6 +180,7 @@ export const TEAM_STORE_PATHSPECS = [
   "*/phren.project.yaml",
   "*/reference/**",
   "*/skills/**",
+  "*/notes/**",
   ".phren-team.yaml",
 ] as const;
 

--- a/packages/cli/src/cli-registry.ts
+++ b/packages/cli/src/cli-registry.ts
@@ -371,6 +371,25 @@ export const REGISTRY: Command[] = [
     },
   },
   {
+    name: "note",
+    aliases: ["notes"],
+    topic: "core",
+    usage: "phren note <add|list|edit|remove|promote>",
+    summary: "Manage lightweight daily notes",
+    subcommands: [
+      { name: "add", usage: 'phren note add <project> "<text>" [--date YYYY-MM-DD]', summary: "Add a daily note" },
+      { name: "list", usage: "phren note list <project> [--date YYYY-MM-DD]", summary: "List notes" },
+      { name: "edit", usage: 'phren note edit <project> <nid> "<text>"', summary: "Edit a note" },
+      { name: "remove", usage: "phren note remove <project> <nid>", summary: "Remove a note" },
+      { name: "promote", usage: "phren note promote <project> <nid> [--type <type>]", summary: "Promote a note to a finding" },
+    ],
+    featured: true,
+    run: async (args, ctx) => {
+      const { handleNoteNamespace } = await import("./cli/namespaces.js");
+      await handleNoteNamespace(args, ctx.profile());
+    },
+  },
+  {
     name: "search-fragments",
     topic: "core",
     usage: "phren search-fragments <query>",

--- a/packages/cli/src/cli/hooks.ts
+++ b/packages/cli/src/cli/hooks.ts
@@ -241,6 +241,9 @@ export async function handleHookPrompt() {
       getPhrenPath()
     );
     rows = trustResult.rows;
+    // Notes are intentionally available to explicit search, but are personal scratch
+    // context and should never be injected into an agent prompt automatically.
+    rows = rows.filter((row) => row.type !== "notes");
     stage.trustMs = Date.now() - tTrust0;
     if (!rows.length) process.exit(0);
 

--- a/packages/cli/src/cli/namespaces-notes.ts
+++ b/packages/cli/src/cli/namespaces-notes.ts
@@ -1,0 +1,151 @@
+import { getPhrenPath, FINDING_TYPES, type FindingType } from "../shared.js";
+import { resolveProject } from "../store-routing.js";
+import { addNote, editNote, listNotes, removeNote } from "../data/notes.js";
+import { promoteNote } from "../core/note.js";
+
+function usage(): void {
+  console.log("Usage:");
+  console.log('  phren note add <project> "<text>" [--date YYYY-MM-DD]');
+  console.log("  phren note list <project> [--date YYYY-MM-DD] [--limit N]");
+  console.log('  phren note edit <project> <nid> "<text>"');
+  console.log("  phren note remove <project> <nid>");
+  console.log("  phren note promote <project> <nid> [--type pattern]");
+}
+
+function option(args: string[], name: string): string | undefined {
+  const equal = args.find((arg) => arg.startsWith(`--${name}=`));
+  if (equal) return equal.slice(name.length + 3);
+  const index = args.indexOf(`--${name}`);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function positionalAfter(args: string[], start: number): string[] {
+  const values: string[] = [];
+  for (let index = start; index < args.length; index++) {
+    const arg = args[index];
+    if (arg.startsWith("--")) {
+      if (!arg.includes("=")) index++;
+      continue;
+    }
+    values.push(arg);
+  }
+  return values;
+}
+
+function target(projectInput: string, profile: string): { phrenPath: string; project: string } {
+  const resolved = resolveProject(getPhrenPath(), projectInput, profile);
+  if (resolved.store.role === "readonly") throw new Error(`Store "${resolved.store.name}" is read-only.`);
+  return { phrenPath: resolved.store.path, project: resolved.projectName };
+}
+
+export async function handleNoteNamespace(args: string[], profile: string): Promise<void> {
+  const subcommand = args[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    usage();
+    return;
+  }
+  const projectInput = args[1];
+  if (!projectInput) {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  let resolved: { phrenPath: string; project: string };
+  try {
+    resolved = target(projectInput, profile);
+  } catch (err: unknown) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+    return;
+  }
+  const { phrenPath, project } = resolved;
+
+  if (subcommand === "list") {
+    const limitRaw = option(args, "limit");
+    const limit = limitRaw ? Number.parseInt(limitRaw, 10) : 100;
+    if (!Number.isFinite(limit) || limit < 1) {
+      console.error("--limit must be a positive integer.");
+      process.exitCode = 1;
+      return;
+    }
+    const result = listNotes(phrenPath, project, { date: option(args, "date"), limit });
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    if (!result.data.length) {
+      console.log(`No notes found for "${project}".`);
+      return;
+    }
+    for (const note of result.data) {
+      console.log(`${note.date} ${note.time.slice(0, 5)}  ${note.id}${note.promoted ? "  [promoted]" : ""}`);
+      console.log(note.text.split("\n").map((line) => `  ${line}`).join("\n"));
+    }
+    return;
+  }
+
+  if (subcommand === "add") {
+    const text = positionalAfter(args, 2).join(" ");
+    const result = addNote(phrenPath, project, text, { date: option(args, "date") });
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Note added: ${result.data.id} (${result.data.date})`);
+    return;
+  }
+
+  const note = args[2];
+  if (!note) {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  if (subcommand === "edit") {
+    const text = positionalAfter(args, 3).join(" ");
+    const result = editNote(phrenPath, project, note, text);
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Updated ${result.data.id}.`);
+    return;
+  }
+
+  if (subcommand === "remove") {
+    const result = removeNote(phrenPath, project, note);
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Removed ${result.data.id}.`);
+    return;
+  }
+
+  if (subcommand === "promote") {
+    const typeRaw = option(args, "type");
+    if (typeRaw && !FINDING_TYPES.includes(typeRaw as FindingType)) {
+      console.error(`Invalid finding type "${typeRaw}". Use: ${FINDING_TYPES.join(", ")}.`);
+      process.exitCode = 1;
+      return;
+    }
+    const result = promoteNote(phrenPath, project, note, typeRaw as FindingType | undefined);
+    if (!result.ok) {
+      console.error(result.error);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Promoted ${result.data.note.id} to a finding.`);
+    return;
+  }
+
+  console.error(`Unknown note subcommand: ${subcommand}`);
+  usage();
+  process.exitCode = 1;
+}

--- a/packages/cli/src/cli/namespaces-store.ts
+++ b/packages/cli/src/cli/namespaces-store.ts
@@ -8,6 +8,7 @@ import {
   addStoreToRegistry,
   removeStoreFromRegistry,
   generateStoreId,
+  getStoreProjectDirs,
   readTeamBootstrap,
   type StoreEntry,
 } from "../store-registry.js";
@@ -26,8 +27,7 @@ function printStoreUsage() {
 function countStoreProjects(store: StoreEntry): number {
   if (!fs.existsSync(store.path)) return 0;
   try {
-    const storeRegistry = require("../store-registry.js");
-    return storeRegistry.getStoreProjectDirs(store).length;
+    return getStoreProjectDirs(store).length;
   } catch {
     return 0;
   }

--- a/packages/cli/src/cli/namespaces.ts
+++ b/packages/cli/src/cli/namespaces.ts
@@ -3,6 +3,7 @@ export { handleSkillsNamespace, handleHooksNamespace, handleSkillList, handleDet
 export { handleProjectsNamespace } from "./namespaces-projects.js";
 export { handleTaskNamespace } from "./namespaces-tasks.js";
 export { handleFindingNamespace } from "./namespaces-findings.js";
+export { handleNoteNamespace } from "./namespaces-notes.js";
 export { handleStoreNamespace, handlePromoteNamespace } from "./namespaces-store.js";
 export { handleProfileNamespace } from "./namespaces-profile.js";
 export { handleReviewNamespace } from "./namespaces-review.js";

--- a/packages/cli/src/core/note.ts
+++ b/packages/cli/src/core/note.ts
@@ -1,0 +1,30 @@
+import type { FindingType, PhrenResult } from "../shared.js";
+import { forwardErr, phrenErr, phrenOk, PhrenError } from "../shared.js";
+import { addFinding, applyFindingTypePrefix } from "./finding.js";
+import { getNote, markNotePromoted, type NoteItem } from "../data/notes.js";
+
+export interface PromoteNoteResult {
+  note: NoteItem;
+  finding: string;
+  message: string;
+}
+
+/** Copy a note into durable findings while retaining and marking its daily-note source. */
+export function promoteNote(
+  phrenPath: string,
+  project: string,
+  selector: string,
+  findingType?: FindingType,
+): PhrenResult<PromoteNoteResult> {
+  const found = getNote(phrenPath, project, selector);
+  if (!found.ok) return forwardErr(found);
+  if (found.data.promoted) {
+    return phrenErr(`Note ${found.data.id} has already been promoted.`, PhrenError.VALIDATION_ERROR);
+  }
+  const added = addFinding(phrenPath, project, found.data.text, undefined, findingType);
+  if (!added.ok) return phrenErr(added.message, PhrenError.VALIDATION_ERROR);
+  const marked = markNotePromoted(phrenPath, project, found.data.stableId);
+  if (!marked.ok) return forwardErr(marked);
+  const finding = applyFindingTypePrefix(found.data.text, findingType);
+  return phrenOk({ note: marked.data, finding, message: added.message });
+}

--- a/packages/cli/src/data/notes.ts
+++ b/packages/cli/src/data/notes.ts
@@ -1,0 +1,225 @@
+import * as fs from "fs";
+import * as path from "path";
+import { randomBytes } from "crypto";
+import {
+  PhrenError,
+  forwardErr,
+  phrenErr,
+  phrenOk,
+  type PhrenResult,
+} from "../shared.js";
+import { scanForSecrets } from "../content/dedup.js";
+import { atomicWriteText } from "../phren-paths.js";
+import { ensureProject, withSafeLock } from "../shared/data-utils.js";
+
+export const NOTES_DIRNAME = "notes";
+export const MAX_NOTE_LENGTH = 10_000;
+
+export interface NoteItem {
+  id: string;
+  stableId: string;
+  project: string;
+  date: string;
+  time: string;
+  text: string;
+  promoted: boolean;
+  path: string;
+}
+
+export interface ListNotesOptions {
+  date?: string;
+  limit?: number;
+}
+
+export interface AddNoteOptions {
+  date?: string;
+  now?: Date;
+}
+
+const NOTE_HEADING_RE = /^##\s+(\d{2}:\d{2}(?::\d{2})?)\s+<!--\s*nid:([a-f0-9]{8})\s*-->(?:\s+<!--\s*promoted\s*-->)?\s*$/i;
+
+function isValidDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function notesDirectory(projectDir: string): string {
+  return path.join(projectDir, NOTES_DIRNAME);
+}
+
+export function noteFilePath(phrenPath: string, project: string, date: string): PhrenResult<string> {
+  if (!isValidDate(date)) {
+    return phrenErr(`Invalid note date "${date}". Use YYYY-MM-DD.`, PhrenError.VALIDATION_ERROR);
+  }
+  const ensured = ensureProject(phrenPath, project);
+  if (!ensured.ok) return forwardErr(ensured);
+  return phrenOk(path.join(notesDirectory(ensured.data), `${date}.md`));
+}
+
+function normalizeNoteText(text: string): PhrenResult<string> {
+  const normalized = text.replace(/\r\n?/g, "\n").trim();
+  if (!normalized) return phrenErr("Note text cannot be empty.", PhrenError.EMPTY_INPUT);
+  if (normalized.length > MAX_NOTE_LENGTH) {
+    return phrenErr(`Note text exceeds ${MAX_NOTE_LENGTH} characters.`, PhrenError.VALIDATION_ERROR);
+  }
+  const secret = scanForSecrets(normalized);
+  if (secret) {
+    return phrenErr(`Rejected: note appears to contain a secret (${secret}). Strip credentials before saving.`, PhrenError.VALIDATION_ERROR);
+  }
+  // An exact internal heading inside a note would otherwise be parsed as a new note.
+  return phrenOk(normalized.split("\n").map((line) => NOTE_HEADING_RE.test(line) ? `#${line}` : line).join("\n"));
+}
+
+function parseDailyFile(filePath: string, project: string, date: string): NoteItem[] {
+  if (!fs.existsSync(filePath)) return [];
+  const lines = fs.readFileSync(filePath, "utf8").split("\n");
+  const items: NoteItem[] = [];
+  let current: { stableId: string; time: string; promoted: boolean; body: string[] } | null = null;
+
+  const finish = () => {
+    if (!current) return;
+    const text = current.body.join("\n").trim();
+    if (text) {
+      items.push({
+        id: `nid:${current.stableId}`,
+        stableId: current.stableId,
+        project,
+        date,
+        time: current.time.length === 5 ? `${current.time}:00` : current.time,
+        text,
+        promoted: current.promoted,
+        path: filePath,
+      });
+    }
+  };
+
+  for (const line of lines) {
+    const match = line.match(NOTE_HEADING_RE);
+    if (match) {
+      finish();
+      current = {
+        time: match[1],
+        stableId: match[2].toLowerCase(),
+        promoted: /<!--\s*promoted\s*-->/i.test(line),
+        body: [],
+      };
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  finish();
+  return items;
+}
+
+function renderDailyFile(project: string, date: string, notes: NoteItem[]): string {
+  const entries = notes.map((note) => {
+    const promoted = note.promoted ? " <!-- promoted -->" : "";
+    return `## ${note.time} <!-- nid:${note.stableId} -->${promoted}\n\n${note.text}`;
+  });
+  return `# ${project} Notes — ${date}\n${entries.length ? `\n${entries.join("\n\n")}\n` : ""}`;
+}
+
+function selectorMatches(note: NoteItem, selector: string): boolean {
+  const query = selector.trim().toLowerCase();
+  if (!query) return false;
+  const stable = query.startsWith("nid:") ? query.slice(4) : query;
+  return note.stableId === stable || note.id === query || note.text.toLowerCase() === query || note.text.toLowerCase().includes(query);
+}
+
+function resolveNote(notes: NoteItem[], selector: string): PhrenResult<NoteItem> {
+  const matches = notes.filter((note) => selectorMatches(note, selector));
+  if (matches.length === 0) return phrenErr(`No note matching "${selector}" was found.`, PhrenError.NOT_FOUND);
+  if (matches.length > 1) {
+    return phrenErr(`Multiple notes match "${selector}". Use a stable nid: ${matches.map((note) => note.id).join(", ")}.`, PhrenError.AMBIGUOUS_MATCH);
+  }
+  return phrenOk(matches[0]);
+}
+
+export function listNotes(phrenPath: string, project: string, options: ListNotesOptions = {}): PhrenResult<NoteItem[]> {
+  const ensured = ensureProject(phrenPath, project);
+  if (!ensured.ok) return forwardErr(ensured);
+  if (options.date && !isValidDate(options.date)) {
+    return phrenErr(`Invalid note date "${options.date}". Use YYYY-MM-DD.`, PhrenError.VALIDATION_ERROR);
+  }
+  const dir = notesDirectory(ensured.data);
+  if (!fs.existsSync(dir)) return phrenOk([]);
+  const files = fs.readdirSync(dir)
+    .filter((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))
+    .filter((name) => !options.date || name === `${options.date}.md`)
+    .sort((a, b) => b.localeCompare(a));
+  const notes = files.flatMap((name) => parseDailyFile(path.join(dir, name), project, name.slice(0, 10)))
+    .sort((a, b) => `${b.date}T${b.time}`.localeCompare(`${a.date}T${a.time}`));
+  const limit = options.limit === undefined ? notes.length : Math.max(0, Math.floor(options.limit));
+  return phrenOk(notes.slice(0, limit));
+}
+
+export function getNote(phrenPath: string, project: string, selector: string): PhrenResult<NoteItem> {
+  const notes = listNotes(phrenPath, project);
+  if (!notes.ok) return forwardErr(notes);
+  return resolveNote(notes.data, selector);
+}
+
+export function addNote(phrenPath: string, project: string, text: string, options: AddNoteOptions = {}): PhrenResult<NoteItem> {
+  const normalized = normalizeNoteText(text);
+  if (!normalized.ok) return forwardErr(normalized);
+  const now = options.now ?? new Date();
+  if (!Number.isFinite(now.getTime())) return phrenErr("Invalid note timestamp.", PhrenError.VALIDATION_ERROR);
+  const date = options.date ?? now.toISOString().slice(0, 10);
+  const file = noteFilePath(phrenPath, project, date);
+  if (!file.ok) return forwardErr(file);
+
+  return withSafeLock(file.data, () => {
+    const existing = parseDailyFile(file.data, project, date);
+    let stableId = randomBytes(4).toString("hex");
+    while (existing.some((note) => note.stableId === stableId)) stableId = randomBytes(4).toString("hex");
+    const note: NoteItem = {
+      id: `nid:${stableId}`,
+      stableId,
+      project,
+      date,
+      time: now.toISOString().slice(11, 19),
+      text: normalized.data,
+      promoted: false,
+      path: file.data,
+    };
+    atomicWriteText(file.data, renderDailyFile(project, date, [...existing, note]));
+    return phrenOk(note);
+  });
+}
+
+function mutateNote(
+  phrenPath: string,
+  project: string,
+  selector: string,
+  mutate: (note: NoteItem) => NoteItem | null,
+): PhrenResult<NoteItem> {
+  const found = getNote(phrenPath, project, selector);
+  if (!found.ok) return forwardErr(found);
+  return withSafeLock(found.data.path, () => {
+    const notes = parseDailyFile(found.data.path, project, found.data.date);
+    const current = resolveNote(notes, found.data.stableId);
+    if (!current.ok) return forwardErr(current);
+    const updated = mutate(current.data);
+    const next = updated
+      ? notes.map((note) => note.stableId === current.data.stableId ? updated : note)
+      : notes.filter((note) => note.stableId !== current.data.stableId);
+    if (next.length === 0) fs.unlinkSync(found.data.path);
+    else atomicWriteText(found.data.path, renderDailyFile(project, found.data.date, next));
+    return phrenOk(updated ?? current.data);
+  });
+}
+
+export function editNote(phrenPath: string, project: string, selector: string, text: string): PhrenResult<NoteItem> {
+  const normalized = normalizeNoteText(text);
+  if (!normalized.ok) return forwardErr(normalized);
+  return mutateNote(phrenPath, project, selector, (note) => ({ ...note, text: normalized.data }));
+}
+
+export function removeNote(phrenPath: string, project: string, selector: string): PhrenResult<NoteItem> {
+  return mutateNote(phrenPath, project, selector, () => null);
+}
+
+export function markNotePromoted(phrenPath: string, project: string, selector: string): PhrenResult<NoteItem> {
+  return mutateNote(phrenPath, project, selector, (note) => ({ ...note, promoted: true }));
+}

--- a/packages/cli/src/governance/rbac.ts
+++ b/packages/cli/src/governance/rbac.ts
@@ -32,6 +32,10 @@ type RbacAction =
   | "remove_task"
   | "update_task"
   | "pin_task"
+  | "add_note"
+  | "edit_note"
+  | "remove_note"
+  | "promote_note"
   | "manage_config";
 
 interface AccessControl {
@@ -145,6 +149,10 @@ const CONTRIBUTOR_ACTIONS = new Set<RbacAction>([
   "remove_task",
   "update_task",
   "pin_task",
+  "add_note",
+  "edit_note",
+  "remove_note",
+  "promote_note",
 ]);
 
 const ADMIN_ONLY_ACTIONS = new Set<RbacAction>([

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -190,6 +190,7 @@ async function main() {
   // InputValidationError until the schema is fetched.
   const ALWAYS_LOAD_TOOLS = new Set([
     "add_finding",
+    "add_note",
     "add_task",
     "complete_task",
     "search_knowledge",
@@ -277,6 +278,7 @@ async function main() {
     import("./tools/hooks.js"),
     import("./tools/extract.js"),
     import("./tools/config.js"),
+    import("./tools/notes.js"),
   ]);
   for (const mod of toolModules) mod.register(server, ctx);
 

--- a/packages/cli/src/link/doctor.ts
+++ b/packages/cli/src/link/doctor.ts
@@ -13,6 +13,8 @@ import {
   runtimeHealthFile,
 } from "../shared.js";
 import { migrateInvalidProjectNames, formatMigrationSummary } from "../project-migrate.js";
+import { ROOT_MANIFEST_FILENAME } from "../phren-paths.js";
+import { STORES_FILENAME } from "../store-registry.js";
 import { commandVersion, versionAtLeast, nearestWritableTarget } from "../init/shared.js";
 import { validateGovernanceJson } from "../shared/governance.js";
 import { errorMessage } from "../utils.js";
@@ -109,6 +111,46 @@ function gitRemoteStatus(phrenPath: string, syncIntent?: "sync" | "local"): { ok
   }
 }
 
+/**
+ * Root-level config the CLI reads straight off disk. Sparse-checkout can leave these
+ * tracked-but-unmaterialized, and both failures are silent: without the root manifest
+ * the MCP entrypoint never recognizes the store path (so MCP never starts), and without
+ * stores.yaml the registry falls back to a single implicit store, hiding every team store.
+ */
+function rootConfigStatus(
+  phrenPath: string,
+  filename: string,
+): { present: boolean; trackedInHead: boolean } {
+  if (fs.existsSync(path.join(phrenPath, filename))) {
+    return { present: true, trackedInHead: false };
+  }
+  try {
+    execFileSync("git", ["cat-file", "-e", `HEAD:${filename}`], {
+      cwd: phrenPath,
+      stdio: "ignore",
+      timeout: EXEC_TIMEOUT_QUICK_MS,
+    });
+    return { present: false, trackedInHead: true };
+  } catch {
+    return { present: false, trackedInHead: false };
+  }
+}
+
+/** Materialize a tracked-but-excluded root config file by widening sparse-checkout. */
+function materializeRootConfig(phrenPath: string, filename: string): boolean {
+  try {
+    execFileSync("git", ["sparse-checkout", "add", `/${filename}`], {
+      cwd: phrenPath,
+      stdio: "ignore",
+      timeout: EXEC_TIMEOUT_QUICK_MS,
+    });
+    return fs.existsSync(path.join(phrenPath, filename));
+  } catch (err: unknown) {
+    debugLog(`materializeRootConfig(${filename}): ${errorMessage(err)}`);
+    return false;
+  }
+}
+
 function pushSkillMirrorChecks(
   checks: Array<{ name: string; ok: boolean; detail: string }>,
   scope: string,
@@ -181,6 +223,38 @@ export async function runDoctor(phrenPath: string, fix: boolean = false, checkDa
     ok: gitRemote.ok,
     detail: gitRemote.detail,
   });
+
+  // Root config must be materialized on disk, not merely tracked in git.
+  const manifestStatus = rootConfigStatus(phrenPath, ROOT_MANIFEST_FILENAME);
+  const manifestRepaired =
+    !manifestStatus.present && manifestStatus.trackedInHead && fix
+      ? materializeRootConfig(phrenPath, ROOT_MANIFEST_FILENAME)
+      : false;
+  checks.push({
+    name: "root-manifest",
+    ok: manifestStatus.present || manifestRepaired,
+    detail: manifestStatus.present
+      ? path.join(phrenPath, ROOT_MANIFEST_FILENAME)
+      : manifestRepaired
+        ? `${ROOT_MANIFEST_FILENAME} restored (was excluded by sparse-checkout)`
+        : manifestStatus.trackedInHead
+          ? `${ROOT_MANIFEST_FILENAME} is tracked in git but excluded by sparse-checkout — MCP cannot start; run 'phren doctor --fix'`
+          : `${ROOT_MANIFEST_FILENAME} missing from ${phrenPath}`,
+  });
+
+  // stores.yaml is optional (single-store installs have none), so this is only a
+  // failure when it exists in git but was never materialized.
+  const storesStatus = rootConfigStatus(phrenPath, STORES_FILENAME);
+  if (!storesStatus.present && storesStatus.trackedInHead) {
+    const storesRepaired = fix ? materializeRootConfig(phrenPath, STORES_FILENAME) : false;
+    checks.push({
+      name: "store-registry-materialized",
+      ok: storesRepaired,
+      detail: storesRepaired
+        ? `${STORES_FILENAME} restored (was excluded by sparse-checkout)`
+        : `${STORES_FILENAME} is tracked in git but excluded by sparse-checkout — team stores are hidden; run 'phren doctor --fix'`,
+    });
+  }
 
   checks.push({
     name: "machine-registered",

--- a/packages/cli/src/link/link.ts
+++ b/packages/cli/src/link/link.ts
@@ -28,6 +28,8 @@ import {
 } from "../shared.js";
 import { errorMessage } from "../utils.js";
 import { FINDINGS_FILENAME } from "../data/access.js";
+import { ROOT_MANIFEST_FILENAME } from "../phren-paths.js";
+import { STORES_FILENAME } from "../store-registry.js";
 import { log } from "../init/shared.js";
 import {
   listMachines as listMachinesShared,
@@ -188,7 +190,21 @@ function setupSparseCheckout(phrenPath: string, projects: string[]) {
     return;
   }
 
-  const alwaysInclude = ["profiles", "machines.yaml", "global", "scripts", "link.sh", "README.md", ".gitignore"];
+  // Root-level config the CLI needs on disk regardless of profile. Omitting these
+  // leaves them tracked-but-unmaterialized: the MCP entrypoint can't find the root
+  // manifest (so MCP never starts) and a missing stores.yaml silently degrades to a
+  // single implicit store, hiding every team store.
+  const alwaysInclude = [
+    "profiles",
+    "machines.yaml",
+    "global",
+    "scripts",
+    "link.sh",
+    "README.md",
+    ".gitignore",
+    ROOT_MANIFEST_FILENAME,
+    STORES_FILENAME,
+  ];
   const paths = [...alwaysInclude, ...projects];
   try {
     execFileSync("git", ["sparse-checkout", "set", ...paths], { cwd: phrenPath, stdio: "ignore", timeout: EXEC_TIMEOUT_MS });

--- a/packages/cli/src/memory-ui.test.ts
+++ b/packages/cli/src/memory-ui.test.ts
@@ -46,11 +46,20 @@ async function postForm(
   route: string,
   body: Record<string, string>
 ): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+  return requestForm(port, "POST", route, body);
+}
+
+async function requestForm(
+  port: number,
+  method: "POST" | "PUT" | "DELETE",
+  route: string,
+  body: Record<string, string>
+): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
   const payload = querystring.stringify(body);
   return await new Promise((resolve, reject) => {
     const req = http.request(
       {
-        method: "POST",
+        method,
         host: "127.0.0.1",
         port,
         path: route,
@@ -203,6 +212,32 @@ describe.sequential("web-ui server", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.indexPolicy.includeGlobs).toContain("docs/**/*.md");
     expect(parsed.indexPolicy.includeHidden).toBe(true);
+  });
+
+  it("supports daily note CRUD and promotion through the web API", async () => {
+    const added = await postForm(port, "/api/notes/demo", { text: "Web daily note", date: "2026-07-20" });
+    const addedBody = JSON.parse(added.body);
+    expect(addedBody.ok).toBe(true);
+    const noteId = addedBody.data.note.id as string;
+
+    const read = await new Promise<string>((resolve, reject) => {
+      http.get(`http://127.0.0.1:${port}/api/notes/demo`, (res) => {
+        let out = "";
+        res.on("data", (chunk) => { out += String(chunk); });
+        res.on("end", () => resolve(out));
+      }).on("error", reject);
+    });
+    expect(JSON.parse(read).data.notes[0].id).toBe(noteId);
+
+    const edited = await requestForm(port, "PUT", "/api/notes/demo", { note: noteId, text: "Edited web daily note" });
+    expect(JSON.parse(edited.body).ok).toBe(true);
+
+    const promoted = await postForm(port, "/api/notes/demo", { action: "promote", note: noteId, finding_type: "pattern" });
+    expect(JSON.parse(promoted.body).ok).toBe(true);
+    expect(fs.readFileSync(path.join(tmpRoot, "demo", "FINDINGS.md"), "utf8")).toContain("[pattern] Edited web daily note");
+
+    const removed = await requestForm(port, "DELETE", "/api/notes/demo", { note: noteId });
+    expect(JSON.parse(removed.body).ok).toBe(true);
   });
 
   it("change token updates when project content changes", async () => {
@@ -448,6 +483,34 @@ describe("web-ui HTML rendering", () => {
       expect(body).toContain('id="graph-node-content"');
       expect(body).toContain("phrenGraph");
       expect(body).toContain("/api/tasks/update");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("renders a project-level finding capture operation with a working refresh bridge", () => {
+    const { path: tmpRoot, cleanup } = makeTempDir("phren-web-ui-capture-html-");
+    try {
+      seedProject(tmpRoot);
+      const body = renderPageForTests(tmpRoot, "csrf-token");
+      expect(body).toContain("+ Add finding");
+      expect(body).toContain("window.selectProjectFile = function(file)");
+      expect(body).toContain("data-finding-capture-submit");
+      expect(body).toContain("Record durable knowledge");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("renders the daily notes tab and full note operations", () => {
+    const { path: tmpRoot, cleanup } = makeTempDir("phren-web-ui-notes-html-");
+    try {
+      seedProject(tmpRoot);
+      const body = renderPageForTests(tmpRoot, "csrf-token");
+      expect(body).toContain("+ Add note");
+      expect(body).toContain("notes:daily");
+      expect(body).toContain("Promote to finding");
+      expect(body).toContain("What happened today?");
     } finally {
       cleanup();
     }

--- a/packages/cli/src/notes.test.ts
+++ b/packages/cli/src/notes.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { grantAdmin, makeTempDir } from "./test-helpers.js";
+import { addNote, editNote, getNote, listNotes, removeNote } from "./data/notes.js";
+import { promoteNote } from "./core/note.js";
+import { buildIndex, queryRows } from "./shared/index.js";
+import { buildGraph } from "./ui/data.js";
+
+describe("daily notes", () => {
+  let phrenPath: string;
+
+  beforeEach(() => {
+    phrenPath = makeTempDir("phren-notes-").path;
+    fs.mkdirSync(path.join(phrenPath, "sample"), { recursive: true });
+    grantAdmin(phrenPath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(phrenPath, { recursive: true, force: true });
+  });
+
+  it("stores multiline notes in a daily Markdown file and lists newest first", () => {
+    const first = addNote(phrenPath, "sample", "First line\n\nMore detail", {
+      date: "2026-07-19",
+      now: new Date("2026-07-19T08:00:01.000Z"),
+    });
+    const second = addNote(phrenPath, "sample", "Today's note", {
+      date: "2026-07-20",
+      now: new Date("2026-07-20T14:03:02.000Z"),
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    const listed = listNotes(phrenPath, "sample");
+    expect(listed.ok && listed.data.map((note) => note.text)).toEqual(["Today's note", "First line\n\nMore detail"]);
+    expect(fs.readFileSync(path.join(phrenPath, "sample", "notes", "2026-07-20.md"), "utf8"))
+      .toContain("## 14:03:02 <!-- nid:");
+  });
+
+  it("edits and removes notes by stable nid", () => {
+    const added = addNote(phrenPath, "sample", "Draft", { now: new Date("2026-07-20T10:00:00.000Z") });
+    expect(added.ok).toBe(true);
+    if (!added.ok) return;
+
+    const edited = editNote(phrenPath, "sample", added.data.id, "Final\nversion");
+    expect(edited.ok && edited.data.text).toBe("Final\nversion");
+    expect(getNote(phrenPath, "sample", added.data.stableId).ok).toBe(true);
+
+    const removed = removeNote(phrenPath, "sample", added.data.stableId);
+    expect(removed.ok).toBe(true);
+    const listed = listNotes(phrenPath, "sample");
+    expect(listed.ok && listed.data).toEqual([]);
+    expect(fs.existsSync(added.data.path)).toBe(false);
+  });
+
+  it("rejects empty notes, invalid dates, and secrets", () => {
+    expect(addNote(phrenPath, "sample", "   ").ok).toBe(false);
+    expect(addNote(phrenPath, "sample", "hello", { date: "2026-02-31" }).ok).toBe(false);
+    expect(addNote(phrenPath, "sample", "token sk-proj-abcdefghijklmnopqrstuvwxyz1234567890").ok).toBe(false);
+  });
+
+  it("promotes a note to a finding without removing the source note", () => {
+    const added = addNote(phrenPath, "sample", "Keep the adapter boundary small", {
+      now: new Date("2026-07-20T12:00:00.000Z"),
+    });
+    expect(added.ok).toBe(true);
+    if (!added.ok) return;
+
+    const promoted = promoteNote(phrenPath, "sample", added.data.id, "pattern");
+    expect(promoted.ok).toBe(true);
+    const source = getNote(phrenPath, "sample", added.data.id);
+    expect(source.ok && source.data.promoted).toBe(true);
+    expect(fs.readFileSync(path.join(phrenPath, "sample", "FINDINGS.md"), "utf8"))
+      .toContain("[pattern] Keep the adapter boundary small");
+    expect(promoteNote(phrenPath, "sample", added.data.id).ok).toBe(false);
+  });
+
+  it("indexes notes for explicit search while keeping them out of the graph", async () => {
+    const phrase = "quartz notebook observation";
+    expect(addNote(phrenPath, "sample", phrase).ok).toBe(true);
+    const db = await buildIndex(phrenPath);
+    try {
+      const rows = queryRows(db, "SELECT type, content FROM docs WHERE docs MATCH ?", ["quartz"]);
+      expect(rows?.some((row) => row[0] === "notes" && String(row[1]).includes(phrase))).toBe(true);
+    } finally {
+      db.close();
+    }
+    const graph = await buildGraph(phrenPath);
+    expect(graph.nodes.some((node) => node.fullLabel.includes(phrase))).toBe(false);
+  });
+});

--- a/packages/cli/src/phren-core.ts
+++ b/packages/cli/src/phren-core.ts
@@ -117,7 +117,7 @@ export type FindingTag = FindingType;
 export const KNOWN_OBSERVATION_TAGS: Set<string> = new Set(FINDING_TYPES);
 
 /** Document types in the FTS index */
-export const DOC_TYPES = ["claude", "findings", "reference", "skills", "summary", "task", "changelog", "canonical", "review-queue", "skill", "other"] as const;
+export const DOC_TYPES = ["claude", "findings", "notes", "reference", "skills", "summary", "task", "changelog", "canonical", "review-queue", "skill", "other"] as const;
 export type DocType = (typeof DOC_TYPES)[number];
 
 // ── Cache eviction helper ────────────────────────────────────────────────────

--- a/packages/cli/src/shared/index.ts
+++ b/packages/cli/src/shared/index.ts
@@ -210,6 +210,7 @@ function pathHasSegment(relPath: string, segment: string): boolean {
 
 export function classifyFile(filename: string, relPath: string): string {
   // Directory takes priority over filename-based classification
+  if (pathHasSegment(relPath, "notes")) return "notes";
   if (pathHasSegment(relPath, "reference")) return "reference";
   if (pathHasSegment(relPath, "skills")) return "skill";
   const mapped = FILE_TYPE_MAP[filename.toLowerCase()];

--- a/packages/cli/src/store-registry.ts
+++ b/packages/cli/src/store-registry.ts
@@ -43,7 +43,7 @@ export interface TeamBootstrap {
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-const STORES_FILENAME = "stores.yaml";
+export const STORES_FILENAME = "stores.yaml";
 const TEAM_BOOTSTRAP_FILENAME = ".phren-team.yaml";
 const VALID_ROLES: ReadonlySet<string> = new Set(["primary", "team", "readonly"]);
 const VALID_SYNC_MODES: ReadonlySet<string> = new Set(["managed-git", "pull-only"]);

--- a/packages/cli/src/tools/notes.ts
+++ b/packages/cli/src/tools/notes.ts
@@ -1,0 +1,159 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import * as path from "path";
+import { FINDING_TYPES } from "../shared.js";
+import { FINDINGS_FILENAME } from "../data/access.js";
+import { addNote, editNote, listNotes, removeNote, type NoteItem } from "../data/notes.js";
+import { promoteNote } from "../core/note.js";
+import { permissionDeniedError } from "../governance/rbac.js";
+import { mcpResponse, resolveStoreForProject, type McpContext } from "./types.js";
+
+function resolve(ctx: McpContext, projectInput: string) {
+  try {
+    return { ok: true as const, value: resolveStoreForProject(ctx, projectInput) };
+  } catch (err: unknown) {
+    return { ok: false as const, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function noteSummary(note: NoteItem): string {
+  const promoted = note.promoted ? " · promoted" : "";
+  return `- ${note.date} ${note.time.slice(0, 5)} · ${note.id}${promoted}\n  ${note.text.replace(/\n/g, "\n  ")}`;
+}
+
+async function refreshIndex(ctx: McpContext, storeRole: string, ...files: string[]): Promise<void> {
+  if (storeRole === "primary") {
+    for (const file of files) ctx.updateFileInIndex(file);
+    return;
+  }
+  // Incremental indexing is rooted at the primary store. A federated/team-store
+  // write therefore needs a rebuild so the file retains its real project/store identity.
+  await ctx.rebuildIndex();
+}
+
+export function register(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    "get_notes",
+    {
+      title: "◆ phren · notes",
+      description: "List lightweight daily notes for a project. Notes are searchable scratch context and are not injected into agent prompts automatically.",
+      inputSchema: z.object({
+        project: z.string().describe("Project name, optionally store-qualified (for example team/project)."),
+        date: z.string().optional().describe("Optional YYYY-MM-DD date filter."),
+        limit: z.number().int().min(1).max(500).optional().describe("Maximum notes to return. Defaults to 100."),
+      }),
+    },
+    async ({ project: projectInput, date, limit }) => {
+      const target = resolve(ctx, projectInput);
+      if (!target.ok) return mcpResponse({ ok: false, error: target.error });
+      const { phrenPath, project } = target.value;
+      const result = listNotes(phrenPath, project, { date, limit: limit ?? 100 });
+      if (!result.ok) return mcpResponse({ ok: false, error: result.error, errorCode: result.code });
+      return mcpResponse({
+        ok: true,
+        message: result.data.length ? result.data.map(noteSummary).join("\n\n") : `No notes found for ${project}${date ? ` on ${date}` : ""}.`,
+        data: { project, notes: result.data },
+      });
+    },
+  );
+
+  server.registerTool(
+    "add_note",
+    {
+      title: "◆ phren · add note",
+      description: "Add a lightweight Markdown note to a project's daily notes. Use findings instead for durable, agent-curated knowledge.",
+      inputSchema: z.object({
+        project: z.string().describe("Project name, optionally store-qualified."),
+        text: z.string().min(1).describe("Note text; Markdown and multiple lines are supported."),
+        date: z.string().optional().describe("Optional YYYY-MM-DD date. Defaults to today."),
+      }),
+    },
+    async ({ project: projectInput, text, date }) => {
+      const target = resolve(ctx, projectInput);
+      if (!target.ok) return mcpResponse({ ok: false, error: target.error });
+      const { phrenPath, project, storeRole } = target.value;
+      const denied = permissionDeniedError(phrenPath, "add_note", project);
+      if (denied) return mcpResponse({ ok: false, error: denied });
+      return ctx.withWriteQueue(async () => {
+        const result = addNote(phrenPath, project, text, { date });
+        if (!result.ok) return mcpResponse({ ok: false, error: result.error, errorCode: result.code });
+        await refreshIndex(ctx, storeRole, result.data.path);
+        return mcpResponse({ ok: true, message: `Note added to ${project}: ${result.data.id}`, data: { project, note: result.data } });
+      });
+    },
+  );
+
+  server.registerTool(
+    "edit_note",
+    {
+      title: "◆ phren · edit note",
+      description: "Replace the text of one daily note. Identify it with the stable nid returned by get_notes.",
+      inputSchema: z.object({
+        project: z.string(),
+        note: z.string().min(1).describe("Stable nid (preferred) or an unambiguous text match."),
+        text: z.string().min(1).describe("Replacement Markdown text."),
+      }),
+    },
+    async ({ project: projectInput, note, text }) => {
+      const target = resolve(ctx, projectInput);
+      if (!target.ok) return mcpResponse({ ok: false, error: target.error });
+      const { phrenPath, project, storeRole } = target.value;
+      const denied = permissionDeniedError(phrenPath, "edit_note", project);
+      if (denied) return mcpResponse({ ok: false, error: denied });
+      return ctx.withWriteQueue(async () => {
+        const result = editNote(phrenPath, project, note, text);
+        if (!result.ok) return mcpResponse({ ok: false, error: result.error, errorCode: result.code });
+        await refreshIndex(ctx, storeRole, result.data.path);
+        return mcpResponse({ ok: true, message: `Updated ${result.data.id}.`, data: { project, note: result.data } });
+      });
+    },
+  );
+
+  server.registerTool(
+    "remove_note",
+    {
+      title: "◆ phren · remove note",
+      description: "Remove one daily note by stable nid or unambiguous text match.",
+      inputSchema: z.object({ project: z.string(), note: z.string().min(1) }),
+    },
+    async ({ project: projectInput, note }) => {
+      const target = resolve(ctx, projectInput);
+      if (!target.ok) return mcpResponse({ ok: false, error: target.error });
+      const { phrenPath, project, storeRole } = target.value;
+      const denied = permissionDeniedError(phrenPath, "remove_note", project);
+      if (denied) return mcpResponse({ ok: false, error: denied });
+      return ctx.withWriteQueue(async () => {
+        const result = removeNote(phrenPath, project, note);
+        if (!result.ok) return mcpResponse({ ok: false, error: result.error, errorCode: result.code });
+        await refreshIndex(ctx, storeRole, result.data.path);
+        return mcpResponse({ ok: true, message: `Removed ${result.data.id}.`, data: { project, note: result.data } });
+      });
+    },
+  );
+
+  server.registerTool(
+    "promote_note",
+    {
+      title: "◆ phren · promote note",
+      description: "Copy a daily note into durable findings and mark the source note as promoted. The note remains in the daily record.",
+      inputSchema: z.object({
+        project: z.string(),
+        note: z.string().min(1),
+        findingType: z.enum(FINDING_TYPES).optional(),
+      }),
+    },
+    async ({ project: projectInput, note, findingType }) => {
+      const target = resolve(ctx, projectInput);
+      if (!target.ok) return mcpResponse({ ok: false, error: target.error });
+      const { phrenPath, project, storeRole } = target.value;
+      const denied = permissionDeniedError(phrenPath, "promote_note", project);
+      if (denied) return mcpResponse({ ok: false, error: denied });
+      return ctx.withWriteQueue(async () => {
+        const result = promoteNote(phrenPath, project, note, findingType);
+        if (!result.ok) return mcpResponse({ ok: false, error: result.error, errorCode: result.code });
+        await refreshIndex(ctx, storeRole, result.data.note.path, path.join(phrenPath, project, FINDINGS_FILENAME));
+        return mcpResponse({ ok: true, message: `Promoted ${result.data.note.id} to a finding.`, data: { project, ...result.data } });
+      });
+    },
+  );
+}

--- a/packages/cli/src/ui/data.ts
+++ b/packages/cli/src/ui/data.ts
@@ -188,6 +188,15 @@ export function isAllowedSkillPath(filePath: string, phrenPath: string): boolean
   return segments.some((seg) => seg === "skills");
 }
 
+/** Allow only the four exact lifecycle-hook config files surfaced by the UI. */
+export function isAllowedHookConfigPath(filePath: string, phrenPath: string): boolean {
+  if (!isAllowedFilePath(filePath, phrenPath)) return false;
+  const resolved = path.resolve(filePath);
+  return Object.values(hookConfigPaths(phrenPath)).some(
+    (configPath) => path.resolve(configPath) === resolved,
+  );
+}
+
 export function collectSkillsForUI(phrenPath: string, profile = ""): Array<{ name: string; source: string; path: string; enabled: boolean }> {
   return getAllSkills(phrenPath, profile).map((skill) => ({
     name: skill.name,

--- a/packages/cli/src/ui/page.ts
+++ b/packages/cli/src/ui/page.ts
@@ -1,12 +1,14 @@
 import { WEB_UI_STYLES, renderWebUiScript } from "./assets.js";
 import { renderGraphScript } from "./graph.js";
-import { LAYOUT_VIEWPORT_STYLES, PROJECT_REFERENCE_UI_STYLES, REVIEW_UI_STYLES, SETTINGS_TAB_UI_STYLES, TASK_UI_STYLES } from "./styles.js";
+import { FINDING_CAPTURE_UI_STYLES, LAYOUT_VIEWPORT_STYLES, NOTES_UI_STYLES, PROJECT_REFERENCE_UI_STYLES, REVIEW_UI_STYLES, SETTINGS_TAB_UI_STYLES, TASK_UI_STYLES } from "./styles.js";
 import { PHREN_DEEP_VOID_STYLES } from "./deep-void.js";
 import { GRAPH_HUD_STYLES } from "./graph-chrome.js";
 import {
   renderSharedWebUiHelpers,
   renderSkillUiEnhancementScript,
   renderProfileSwitcherScript,
+  renderFindingCaptureEnhancementScript,
+  renderNotesEnhancementScript,
   renderProjectReferenceEnhancementScript,
   renderTasksAndSettingsScript,
   renderReviewQueueKeyboardScript,
@@ -46,6 +48,8 @@ ${REVIEW_UI_STYLES}
 ${PHREN_DEEP_VOID_STYLES}
 ${LAYOUT_VIEWPORT_STYLES}
 ${GRAPH_HUD_STYLES}
+${FINDING_CAPTURE_UI_STYLES}
+${NOTES_UI_STYLES}
   </style>
 </head>
 <body>
@@ -418,6 +422,12 @@ ${renderGraphHostScript()}
 </script>
 <script${nonceAttr}>
 ${renderSharedWebUiHelpers(authToken || "")}
+</script>
+<script${nonceAttr}>
+${renderFindingCaptureEnhancementScript()}
+</script>
+<script${nonceAttr}>
+${renderNotesEnhancementScript()}
 </script>
 <script${nonceAttr}>
 ${renderSkillUiEnhancementScript(h(authToken || ""))}

--- a/packages/cli/src/ui/scripts.ts
+++ b/packages/cli/src/ui/scripts.ts
@@ -87,6 +87,253 @@ export function renderProfileSwitcherScript(_authToken: string): string {
 })();`;
 }
 
+export function renderFindingCaptureEnhancementScript(): string {
+  return `(function() {
+  function selectedProject() {
+    var card = document.querySelector('.project-card.selected');
+    return card ? (card.getAttribute('data-project') || '') : '';
+  }
+
+  function findingsTab() {
+    return document.querySelector('.project-detail-tab[data-file="FINDINGS.md"]');
+  }
+
+  function wireCaptureBar() {
+    var container = document.getElementById('project-content');
+    var tab = findingsTab();
+    if (!container || !tab || !tab.classList.contains('active')) return;
+
+    container.querySelectorAll('.finding-detail-card summary').forEach(function(summary) {
+      summary.textContent = (summary.textContent || '').replace(/\\s*<!--.*?-->\\s*/g, ' ').trim();
+    });
+
+    var input = document.getElementById('finding-add-input');
+    if (!input) {
+      var project = selectedProject();
+      if (!project || container.querySelector('.project-detail-empty')) return;
+      var bar = document.createElement('div');
+      bar.className = 'finding-capture-bar';
+      bar.innerHTML = '<input id="finding-add-input" type="text" placeholder="Record durable knowledge…" aria-label="Finding text">' +
+        '<button type="button" class="btn btn-sm btn-primary" data-finding-capture-submit>Add finding</button>';
+      container.insertBefore(bar, container.firstChild);
+      input = bar.querySelector('#finding-add-input');
+    } else {
+      var existingBar = input.parentElement;
+      if (existingBar) existingBar.classList.add('finding-capture-bar');
+    }
+
+    if (!input || input.getAttribute('data-capture-wired') === 'true') return;
+    input.setAttribute('data-capture-wired', 'true');
+    input.setAttribute('placeholder', 'Record durable knowledge…');
+    input.addEventListener('keydown', function(event) {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      window.phrenAddFinding(selectedProject());
+    });
+    var button = input.parentElement && input.parentElement.querySelector('button');
+    if (button) {
+      button.textContent = 'Add finding';
+      button.addEventListener('click', function(event) {
+        event.preventDefault();
+        window.phrenAddFinding(selectedProject());
+      });
+    }
+  }
+
+  window.selectProjectFile = function(file) {
+    var tab = document.querySelector('.project-detail-tab[data-file="' + file + '"]');
+    if (tab && typeof window.loadProjectFile === 'function') window.loadProjectFile(file, tab);
+  };
+
+  var baseSelectProject = window.selectProject;
+  if (typeof baseSelectProject === 'function') {
+    window.selectProject = function(name, el) {
+      baseSelectProject(name, el);
+      var header = document.querySelector('.project-detail-header');
+      if (header && !header.querySelector('.capture-finding-btn')) {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm btn-primary capture-finding-btn';
+        button.textContent = '+ Add finding';
+        button.addEventListener('click', function() {
+          window.selectProjectFile('FINDINGS.md');
+          window.setTimeout(function() {
+            wireCaptureBar();
+            var input = document.getElementById('finding-add-input');
+            if (input) input.focus();
+          }, 0);
+        });
+        header.appendChild(button);
+      }
+    };
+  }
+
+  var detailArea = document.getElementById('project-detail-area');
+  if (detailArea) {
+    new MutationObserver(function() { window.setTimeout(wireCaptureBar, 0); })
+      .observe(detailArea, { childList: true, subtree: true });
+  }
+})();`;
+}
+
+export function renderNotesEnhancementScript(): string {
+  return `(function() {
+  var esc = window._phrenEsc;
+  var authUrl = window._phrenAuthUrl;
+
+  function selectedProject() {
+    var card = document.querySelector('.project-card.selected');
+    return card ? (card.getAttribute('data-project') || '') : '';
+  }
+
+  function request(project, method, values, done) {
+    window._phrenFetchCsrfToken(function(csrfToken) {
+      var body = new URLSearchParams(values || {});
+      if (csrfToken) body.set('_csrf', csrfToken);
+      fetch(authUrl('/api/notes/' + encodeURIComponent(project)), {
+        method: method,
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: window._phrenAuthBody(body.toString())
+      }).then(function(r) { return r.json(); }).then(function(data) {
+        if (!data.ok) throw new Error(data.error || 'Note operation failed');
+        done(data);
+      }).catch(function(err) { alert(String(err.message || err)); });
+    });
+  }
+
+  function renderNotes(project, notes) {
+    var container = document.getElementById('project-content');
+    if (!container) return;
+    var today = new Date().toISOString().slice(0, 10);
+    var html = '<div class="notes-panel">' +
+      '<div class="note-capture">' +
+        '<textarea id="note-add-text" rows="3" placeholder="What happened today? Markdown is welcome." aria-label="Note text"></textarea>' +
+        '<div class="note-capture-actions"><input id="note-add-date" type="date" value="' + today + '" aria-label="Note date">' +
+        '<button type="button" class="btn btn-primary" data-note-action="add">Add note</button></div>' +
+      '</div>';
+    if (!notes.length) {
+      html += '<div class="project-detail-empty">No notes yet. Add a quick daily note above.</div>';
+    } else {
+      var lastDate = '';
+      notes.forEach(function(note) {
+        if (note.date !== lastDate) {
+          if (lastDate) html += '</div>';
+          lastDate = note.date;
+          html += '<div class="note-day"><div class="note-day-heading">' + esc(note.date) + '</div>';
+        }
+        html += '<article class="note-card" data-note-id="' + esc(note.id) + '">' +
+          '<div class="note-card-meta"><span>' + esc(String(note.time || '').slice(0, 5)) + '</span>' +
+          '<code>' + esc(note.id) + '</code>' +
+          (note.promoted ? '<span class="note-promoted">promoted</span>' : '') + '</div>' +
+          '<div class="note-card-text">' + esc(note.text).replace(/\\n/g, '<br>') + '</div>' +
+          '<div class="note-card-actions">' +
+            '<button type="button" class="btn btn-sm" data-note-action="edit">Edit</button>' +
+            (!note.promoted ? '<button type="button" class="btn btn-sm" data-note-action="promote">Promote to finding</button>' : '') +
+            '<button type="button" class="btn btn-sm note-remove" data-note-action="remove">Remove</button>' +
+          '</div>' +
+          '<textarea class="note-raw-text" hidden>' + esc(note.text) + '</textarea>' +
+        '</article>';
+      });
+      if (lastDate) html += '</div>';
+    }
+    container.innerHTML = html + '</div>';
+  }
+
+  function loadNotes(focusCapture) {
+    var project = selectedProject();
+    var container = document.getElementById('project-content');
+    if (!project || !container) return;
+    container.innerHTML = '<div class="project-detail-empty">Loading notes...</div>';
+    fetch(authUrl('/api/notes/' + encodeURIComponent(project)))
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (!data.ok) throw new Error(data.error || 'Failed to load notes');
+        renderNotes(project, (data.data && data.data.notes) || []);
+        if (focusCapture) {
+          var input = document.getElementById('note-add-text');
+          if (input) input.focus();
+        }
+      }).catch(function(err) {
+        container.innerHTML = '<div class="project-detail-empty">' + esc(err.message || err) + '</div>';
+      });
+  }
+
+  var baseSelectProject = window.selectProject;
+  if (typeof baseSelectProject === 'function') {
+    window.selectProject = function(name, el) {
+      baseSelectProject(name, el);
+      var tabs = document.querySelector('.project-detail-tabs');
+      if (tabs && !tabs.querySelector('[data-file="notes:daily"]')) {
+        var tab = document.createElement('button');
+        tab.type = 'button';
+        tab.className = 'project-detail-tab';
+        tab.setAttribute('data-ui-action', 'loadProjectFile');
+        tab.setAttribute('data-file', 'notes:daily');
+        tab.textContent = 'Notes';
+        var reference = tabs.querySelector('[data-file="reference:browser"]');
+        tabs.insertBefore(tab, reference);
+      }
+      var header = document.querySelector('.project-detail-header');
+      if (header && !header.querySelector('.capture-note-btn')) {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'btn btn-sm capture-note-btn';
+        button.textContent = '+ Add note';
+        button.addEventListener('click', function() {
+          window.selectProjectFile('notes:daily');
+          window.setTimeout(function() { loadNotes(true); }, 0);
+        });
+        header.appendChild(button);
+      }
+    };
+  }
+
+  var baseLoadProjectFile = window.loadProjectFile;
+  window.loadProjectFile = function(file, btn) {
+    if (file !== 'notes:daily') return baseLoadProjectFile(file, btn);
+    document.querySelectorAll('.project-detail-tab').forEach(function(tab) { tab.classList.remove('active'); });
+    var notesTab = btn || document.querySelector('.project-detail-tab[data-file="notes:daily"]');
+    if (notesTab) notesTab.classList.add('active');
+    loadNotes(false);
+  };
+
+  document.addEventListener('click', function(event) {
+    var button = event.target && event.target.closest ? event.target.closest('[data-note-action]') : null;
+    if (!button) return;
+    var project = selectedProject();
+    if (!project) return;
+    var action = button.getAttribute('data-note-action');
+    if (action === 'add') {
+      var text = document.getElementById('note-add-text');
+      var date = document.getElementById('note-add-date');
+      if (!text || !text.value.trim()) return;
+      request(project, 'POST', { text: text.value.trim(), date: date ? date.value : '' }, function() { loadNotes(true); });
+      return;
+    }
+    var card = button.closest('.note-card');
+    if (!card) return;
+    var note = card.getAttribute('data-note-id') || '';
+    var raw = card.querySelector('.note-raw-text');
+    var current = raw ? raw.value : '';
+    if (action === 'edit') {
+      var next = prompt('Edit note', current);
+      if (next === null || !next.trim() || next === current) return;
+      request(project, 'PUT', { note: note, text: next.trim() }, function() { loadNotes(false); });
+    } else if (action === 'remove') {
+      if (!confirm('Remove this note?')) return;
+      request(project, 'DELETE', { note: note }, function() { loadNotes(false); });
+    } else if (action === 'promote') {
+      var findingType = prompt('Finding type (optional): decision, pitfall, pattern, tradeoff, architecture, bug', '');
+      if (findingType === null) return;
+      findingType = findingType.trim().toLowerCase();
+      var valid = ['', 'decision', 'pitfall', 'pattern', 'tradeoff', 'architecture', 'bug'];
+      if (valid.indexOf(findingType) === -1) { alert('Unknown finding type.'); return; }
+      request(project, 'POST', { action: 'promote', note: note, finding_type: findingType }, function() { loadNotes(false); });
+    }
+  });
+})();`;
+}
+
 export function renderSkillUiEnhancementScript(_authToken: string): string {
   return `(function() {
     var _skillCurrent = null;
@@ -1770,6 +2017,36 @@ export function renderEventWiringScript(): string {
     if (action === 'approve') { batchAction('approve'); }
     else if (action === 'reject') { batchAction('reject'); }
     else if (action === 'clear') { clearBatchSelection(); }
+  });
+
+  // The legacy hook rows use .hook-item rather than .split-item. Their original
+  // delegated handler therefore passes null to selectHookFromEl; wire the actual
+  // row here so lifecycle hook details remain selectable.
+  document.addEventListener('click', function(e) {
+    var target = e.target;
+    if (!target || typeof target.closest !== 'function') return;
+    var hook = target.closest('.hook-item[data-ui-action="selectHookFromEl"]');
+    if (hook && typeof selectHookFromEl === 'function') selectHookFromEl(hook);
+  });
+
+  // Keep review-card action metadata aligned with the queue line after an edit.
+  // The base submit handler sends the old line first; this listener then updates
+  // the DOM identity used by subsequent approve/reject actions.
+  document.addEventListener('submit', function(e) {
+    var form = e.target;
+    if (!form || form.getAttribute('data-ui-action') !== 'reviewEditSubmit') return;
+    var card = form.closest('.review-card');
+    var textarea = form.querySelector('textarea[name="new_text"]');
+    if (!card || !textarea) return;
+    var oldLine = form.getAttribute('data-line') || '';
+    var text = String(textarea.value || '').replace(/[\\r\\n]+/g, ' ').trim();
+    if (!text) return;
+    var dateMatch = oldLine.match(/^- \\[(\\d{4}-\\d{2}-\\d{2})\\]\\s*/);
+    var updatedLine = dateMatch ? '- [' + dateMatch[1] + '] ' + text : '- ' + text;
+    var project = card.getAttribute('data-project') || form.getAttribute('data-project') || '';
+    card.setAttribute('data-key', project + '\\\\x00' + updatedLine);
+    form.setAttribute('data-line', updatedLine);
+    card.querySelectorAll('[data-line]').forEach(function(el) { el.setAttribute('data-line', updatedLine); });
   });
 
   // --- Graph controls ---

--- a/packages/cli/src/ui/server.ts
+++ b/packages/cli/src/ui/server.ts
@@ -12,7 +12,10 @@ import {
 import { getNonPrimaryStores, subscribeStoreProjects, unsubscribeStoreProjects } from "../store-registry.js";
 import {
   editFinding,
+  editQueueItem,
+  approveQueueItem,
   readReviewQueue,
+  rejectQueueItem,
   removeFinding,
   readFindings,
   addFinding as addFindingStore,
@@ -25,13 +28,14 @@ import {
   FINDINGS_FILENAME,
 } from "../data/access.js";
 import { entryScoreKey } from "../governance/scores.js";
-import { isValidProjectName, errorMessage, queueFilePath, safeProjectPath } from "../utils.js";
+import { isValidProjectName, errorMessage, safeProjectPath } from "../utils.js";
 import { readInstallPreferences, writeInstallPreferences, writeGovernanceInstallPreferences, type InstallPreferences } from "../init/preferences.js";
 import {
   buildGraph,
   collectProjectsForUI,
   collectSkillsForUI,
   getHooksData,
+  isAllowedHookConfigPath,
   isAllowedSkillPath,
   readSyncSnapshot,
   recentAccepted,
@@ -51,7 +55,7 @@ import {
   writeProjectTopics,
 } from "../project-topics.js";
 import { getWorkflowPolicy, updateWorkflowPolicy, mergeConfig, getRetentionPolicy, getProjectConfigOverrides, getIndexPolicy, updateIndexPolicy, VALID_TASK_MODES } from "../governance/policy.js";
-import { setAccessRoles, ACCESS_ROLE_KEYS, type AccessRolePatch } from "../governance/rbac.js";
+import { setAccessRoles, ACCESS_ROLE_KEYS, permissionDeniedError, type AccessRolePatch } from "../governance/rbac.js";
 import { readProjectConfig, updateProjectConfigOverrides } from "../project-config.js";
 import { buildConfigView } from "../config/resolve.js";
 import { CONFIG_DOMAINS } from "../config/schema.js";
@@ -59,6 +63,9 @@ import { findSkill } from "../skill/registry.js";
 import { setSkillEnabledAndSync } from "../skill/files.js";
 import { repairPreexistingInstall } from "../init/setup.js";
 import { logger } from "../logger.js";
+import { addNote, editNote, listNotes, removeNote } from "../data/notes.js";
+import { promoteNote } from "../core/note.js";
+import { FINDING_TYPES, type FindingType } from "../shared.js";
 
 export interface WebUiOptions {
   authToken?: string;
@@ -585,7 +592,9 @@ function handleGetSkills(res: Res, ctx: RouteCtx): void {
 
 function handleGetSkillContent(res: Res, url: string, ctx: RouteCtx): void {
   const filePath = String(parseQs(url).path || "");
-  if (!filePath || !isAllowedSkillPath(filePath, ctx.phrenPath)) return jsonErr(res, "Invalid path", 400);
+  if (!filePath || (!isAllowedSkillPath(filePath, ctx.phrenPath) && !isAllowedHookConfigPath(filePath, ctx.phrenPath))) {
+    return jsonErr(res, "Invalid path", 400);
+  }
   if (!fs.existsSync(filePath)) return jsonErr(res, "File not found");
   jsonOk(res, { ok: true, content: fs.readFileSync(filePath, "utf8") });
 }
@@ -757,6 +766,17 @@ function handleGetFindings(res: Res, pathname: string, ctx: RouteCtx): void {
   jsonOk(res, result.ok ? { ok: true, data: { project, findings: result.data } } : { ok: false, error: result.error });
 }
 
+function handleGetNotes(res: Res, url: string, pathname: string, ctx: RouteCtx): void {
+  const project = decodeURIComponent(pathname.slice("/api/notes/".length));
+  if (!project || !isValidProjectName(project)) return jsonErr(res, "Invalid project name", 400);
+  const date = String(parseQs(url).date || "") || undefined;
+  const basePath = resolveProjectBasePath(ctx.phrenPath, project);
+  const result = listNotes(basePath, project, { date, limit: 500 });
+  jsonOk(res, result.ok
+    ? { ok: true, data: { project, notes: result.data } }
+    : { ok: false, error: result.error, errorCode: result.code });
+}
+
 // ── POST handlers ─────────────────────────────────────────────────────────────
 
 function handlePostSync(req: Req, res: Res, url: string, ctx: RouteCtx): void {
@@ -788,12 +808,8 @@ function handlePostApprove(req: Req, res: Res, url: string, ctx: RouteCtx): void
     const line = String(parsed.line || "");
     if (!project || !isValidProjectName(project) || !line) return jsonErr(res, "Missing project or line");
     try {
-      const qPath = queueFilePath(ctx.phrenPath, project);
-      if (fs.existsSync(qPath)) {
-        const lines = fs.readFileSync(qPath, "utf8").split("\n").filter((l) => l.trim() !== line.trim());
-        fs.writeFileSync(qPath, lines.join("\n"));
-      }
-      jsonOk(res, { ok: true });
+      const result = approveQueueItem(ctx.phrenPath, project, line);
+      jsonOk(res, { ok: result.ok, error: result.ok ? undefined : result.error });
     } catch (err: unknown) {
       jsonErr(res, errorMessage(err));
     }
@@ -806,14 +822,8 @@ function handlePostReject(req: Req, res: Res, url: string, ctx: RouteCtx): void 
     const line = String(parsed.line || "");
     if (!project || !isValidProjectName(project) || !line) return jsonErr(res, "Missing project or line");
     try {
-      const qPath = queueFilePath(ctx.phrenPath, project);
-      if (fs.existsSync(qPath)) {
-        const lines = fs.readFileSync(qPath, "utf8").split("\n").filter((l) => l.trim() !== line.trim());
-        fs.writeFileSync(qPath, lines.join("\n"));
-      }
-      const findingText = line.replace(/^-\s*/, "").replace(/<!--.*?-->/g, "").trim();
-      if (findingText) removeFinding(ctx.phrenPath, project, findingText);
-      jsonOk(res, { ok: true });
+      const result = rejectQueueItem(ctx.phrenPath, project, line);
+      jsonOk(res, { ok: result.ok, error: result.ok ? undefined : result.error });
     } catch (err: unknown) {
       jsonErr(res, errorMessage(err));
     }
@@ -827,8 +837,7 @@ function handlePostEdit(req: Req, res: Res, url: string, ctx: RouteCtx): void {
     const newText = String(parsed.new_text || "");
     if (!project || !isValidProjectName(project) || !line || !newText) return jsonErr(res, "Missing project, line, or new_text");
     try {
-      const oldText = line.replace(/^-\s*/, "").replace(/<!--.*?-->/g, "").trim();
-      const result = editFinding(ctx.phrenPath, project, oldText, newText);
+      const result = editQueueItem(ctx.phrenPath, project, line, newText);
       jsonOk(res, { ok: result.ok, error: result.ok ? undefined : result.error });
     } catch (err: unknown) {
       jsonErr(res, errorMessage(err));
@@ -840,7 +849,9 @@ function handlePostSkillSave(req: Req, res: Res, url: string, ctx: RouteCtx): vo
   withPostBody(req, res, url, ctx, (parsed) => {
     const filePath = String(parsed.path || "");
     const content = String(parsed.content || "");
-    if (!filePath || !isAllowedSkillPath(filePath, ctx.phrenPath)) return jsonErr(res, "Invalid path");
+    if (!filePath || (!isAllowedSkillPath(filePath, ctx.phrenPath) && !isAllowedHookConfigPath(filePath, ctx.phrenPath))) {
+      return jsonErr(res, "Invalid path");
+    }
     try {
       fs.mkdirSync(path.dirname(filePath), { recursive: true });
       const tmpPath = `${filePath}.tmp-${crypto.randomUUID()}`;
@@ -1269,6 +1280,57 @@ function handleFindingsWrite(req: Req, res: Res, url: string, pathname: string, 
   }
 }
 
+function handleNotesWrite(req: Req, res: Res, url: string, pathname: string, ctx: RouteCtx): void {
+  const project = decodeURIComponent(pathname.slice("/api/notes/".length));
+  if (!project || !isValidProjectName(project)) return jsonErr(res, "Invalid project name", 400);
+  const basePath = resolveProjectBasePath(ctx.phrenPath, project);
+
+  withPostBody(req, res, url, ctx, (parsed) => {
+    const selector = String(parsed.note || "");
+    if (req.method === "POST" && String(parsed.action || "") === "promote") {
+      if (!selector) return jsonErr(res, "note is required", 400);
+      const denied = permissionDeniedError(basePath, "promote_note", project);
+      if (denied) return jsonErr(res, denied, 403);
+      const findingTypeRaw = String(parsed.finding_type || "");
+      if (findingTypeRaw && !FINDING_TYPES.includes(findingTypeRaw as FindingType)) {
+        return jsonErr(res, `Invalid finding type: ${findingTypeRaw}`, 400);
+      }
+      const result = promoteNote(basePath, project, selector, findingTypeRaw as FindingType | undefined);
+      return jsonOk(res, result.ok
+        ? { ok: true, data: result.data, message: `Promoted ${result.data.note.id} to a finding.` }
+        : { ok: false, error: result.error, errorCode: result.code });
+    }
+    if (req.method === "POST") {
+      const text = String(parsed.text || "");
+      if (!text) return jsonErr(res, "text is required", 400);
+      const denied = permissionDeniedError(basePath, "add_note", project);
+      if (denied) return jsonErr(res, denied, 403);
+      const date = String(parsed.date || "") || undefined;
+      const result = addNote(basePath, project, text, { date });
+      return jsonOk(res, result.ok
+        ? { ok: true, data: { note: result.data }, message: `Added ${result.data.id}.` }
+        : { ok: false, error: result.error, errorCode: result.code });
+    }
+    if (!selector) return jsonErr(res, "note is required", 400);
+    if (req.method === "PUT") {
+      const text = String(parsed.text || "");
+      if (!text) return jsonErr(res, "text is required", 400);
+      const denied = permissionDeniedError(basePath, "edit_note", project);
+      if (denied) return jsonErr(res, denied, 403);
+      const result = editNote(basePath, project, selector, text);
+      return jsonOk(res, result.ok
+        ? { ok: true, data: { note: result.data }, message: `Updated ${result.data.id}.` }
+        : { ok: false, error: result.error, errorCode: result.code });
+    }
+    const denied = permissionDeniedError(basePath, "remove_note", project);
+    if (denied) return jsonErr(res, denied, 403);
+    const result = removeNote(basePath, project, selector);
+    return jsonOk(res, result.ok
+      ? { ok: true, data: { note: result.data }, message: `Removed ${result.data.id}.` }
+      : { ok: false, error: result.error, errorCode: result.code });
+  });
+}
+
 // ── Main router ───────────────────────────────────────────────────────────────
 
 export function createWebUiHttpServer(
@@ -1334,6 +1396,7 @@ export function createWebUiHttpServer(
       if (pathname.startsWith("/api/skill-content")) return handleGetSkillContent(res, url, ctx);
       if (pathname.startsWith("/api/graph")) return await handleGetGraph(res, url, ctx);
       if (pathname.startsWith("/api/findings/")) return handleGetFindings(res, pathname, ctx);
+      if (pathname.startsWith("/api/notes/")) return handleGetNotes(res, url, pathname, ctx);
     }
 
     // ── POST/PUT/DELETE routes ──
@@ -1368,6 +1431,7 @@ export function createWebUiHttpServer(
       }
       // Prefix-matched write routes
       if (pathname.startsWith("/api/findings/")) return handleFindingsWrite(req, res, url, pathname, ctx);
+      if (pathname.startsWith("/api/notes/")) return handleNotesWrite(req, res, url, pathname, ctx);
     }
 
     res.writeHead(404, { "content-type": "text/plain" });

--- a/packages/cli/src/ui/styles.ts
+++ b/packages/cli/src/ui/styles.ts
@@ -705,4 +705,63 @@ export const LAYOUT_VIEWPORT_STYLES = `
   }
 `;
 
+export const FINDING_CAPTURE_UI_STYLES = `
+  .project-detail-header .capture-finding-btn { margin-left: auto; }
+  .finding-capture-bar {
+    display: flex;
+    gap: 8px;
+    padding: 14px 14px 0;
+  }
+  .finding-capture-bar input {
+    flex: 1;
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 7px 10px;
+    background: var(--surface);
+    color: var(--ink);
+    font: var(--text-sm) var(--font);
+  }
+  .finding-capture-bar input:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-dim);
+  }
+`;
 
+export const NOTES_UI_STYLES = `
+  .capture-note-btn { white-space: nowrap; }
+  .notes-panel { padding: 14px; }
+  .note-capture {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 14px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-raised);
+    margin-bottom: 20px;
+  }
+  .note-capture textarea {
+    width: 100%; min-height: 76px; resize: vertical; padding: 10px 12px;
+    border: 1px solid var(--border); border-radius: var(--radius-sm);
+    background: var(--surface); color: var(--ink); font: var(--text-base) var(--font); line-height: 1.5;
+  }
+  .note-capture textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
+  .note-capture-actions { display: flex; flex-direction: column; gap: 8px; align-items: stretch; }
+  .note-capture-actions input { padding: 7px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); color: var(--ink); }
+  .note-day { display: flex; flex-direction: column; gap: 9px; margin-bottom: 20px; }
+  .note-day-heading { font-size: var(--text-xs); font-weight: 700; color: var(--muted); letter-spacing: .06em; text-transform: uppercase; }
+  .note-card { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 12px 14px; background: var(--surface-raised); }
+  .note-card-meta { display: flex; gap: 8px; align-items: center; color: var(--muted); font-size: var(--text-xs); margin-bottom: 8px; }
+  .note-card-meta code { font-family: var(--mono); }
+  .note-promoted { color: var(--success); background: var(--success-dim); border-radius: 999px; padding: 1px 7px; font-weight: 600; }
+  .note-card-text { color: var(--ink-secondary); font-size: var(--text-base); line-height: 1.6; overflow-wrap: anywhere; }
+  .note-card-actions { display: flex; gap: 7px; margin-top: 11px; padding-top: 10px; border-top: 1px solid var(--border-light); }
+  .note-card-actions .note-remove { margin-left: auto; color: var(--danger); }
+  @media (max-width: 680px) {
+    .note-capture { grid-template-columns: 1fr; }
+    .note-capture-actions { flex-direction: row; }
+    .project-detail-header { flex-wrap: wrap; }
+  }
+`;

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -2,12 +2,12 @@
 
 Phren inside the editor, where it belongs.
 
-This extension connects VS Code to your local Phren store and MCP server so you can inspect projects, search memory, review findings, work through tasks, and edit skills without leaving the editor.
+This extension connects VS Code to your local Phren store and MCP server so you can inspect projects, capture daily notes, search memory, review findings, work through tasks, and edit skills without leaving the editor.
 
 ## What It Does
 
 - Adds a dedicated **Phren** view in the activity bar.
-- Lists tracked Phren projects with drill-down sections for findings, tasks, sessions, review queue, and reference docs.
+- Lists tracked Phren projects with drill-down sections for findings, daily notes, tasks, sessions, review queue, and reference docs.
 - Shows **priority, pinned, and GitHub issue badges** on task tree items. At a glance you can see task priority (`high`/`medium`/`low`), whether a task is pinned, and which tasks are linked to a GitHub issue.
 - Shows **type and confidence badges** on finding tree items. Each finding displays its type tag (`[decision]`, `[pitfall]`, etc.) and a confidence indicator when confidence is below threshold.
 - Theme-aware **status bar** that uses VS Code color tokens for seamless integration with any installed theme.
@@ -15,6 +15,7 @@ This extension connects VS Code to your local Phren store and MCP server so you 
 - Updated **review queue viewer** with a contextual notice explaining what each queue section contains.
 - Opens findings, skills, reference files, queue items, and sessions in read-only or editable panels directly in VS Code.
 - Lets you add a finding from the editor context menu by selecting text and running **Phren: Add Finding**.
+- Lets you add lightweight notes from the Notes category or selected editor text, then edit, remove, or promote them to findings.
 - **Finding lifecycle commands**: supersede, retract, and resolve contradictions between findings directly from the sidebar.
 - **GitHub issue integration**: link tasks to existing issues or create new issues from tasks, all from the sidebar.
 - Syncs your Phren store (`git push`) without leaving VS Code.
@@ -48,7 +49,7 @@ Once set, open the Phren activity bar item and the extension loads your projects
 
 ## Commands
 
-### Command Palette (17)
+### Command Palette
 
 These commands are available via `Ctrl+Shift+P` / `Cmd+Shift+P`:
 
@@ -58,6 +59,7 @@ These commands are available via `Ctrl+Shift+P` / `Cmd+Shift+P`:
 | `Phren: Show Fragment Graph` | — | Open the fragment graph in a webview with animated nodes and keyboard navigation. |
 | `Phren: Refresh` | — | Reload all data from the Phren MCP server. |
 | `Phren: Add Finding` | — | Save a finding to the active project (also available in the editor context menu when text is selected). |
+| `Phren: Add Note` | — | Add a lightweight daily note to the active project or selected project category. |
 | `Phren: Set Active Project` | — | Switch the active project context. |
 | `Phren: Sync` | — | Commit and push all Phren changes to remote. |
 | `Phren: Doctor` | — | Run health checks and report any issues. |
@@ -72,7 +74,7 @@ These commands are available via `Ctrl+Shift+P` / `Cmd+Shift+P`:
 | `Phren: Open machines.yaml` | — | Open the machines config file directly. |
 | `Phren: Project Config` | — | View and edit project-level configuration. |
 
-### Sidebar and Context Menu (16)
+### Sidebar and Context Menu
 
 These commands fire from the Phren sidebar or editor context menu. They are not shown in the command palette by default:
 
@@ -88,6 +90,10 @@ These commands fire from the Phren sidebar or editor context menu. They are not 
 | `Phren: Pin Task` | Active task inline action | Pin a task so it stays visible across sessions. |
 | `Phren: Update Task` | Active task inline action | Edit a task's text or priority. |
 | `Phren: Remove Finding` | Finding item inline action | Remove a finding by match. |
+| `Phren: Open Note` | Note item click | Open a Markdown preview of the note. |
+| `Phren: Edit Note` | Note item context menu | Edit the note text. |
+| `Phren: Remove Note` | Note item context menu | Remove the note. |
+| `Phren: Promote Note to Finding` | Note item inline action | Copy a note to durable findings while keeping its daily source. |
 | `Phren: Supersede Finding` | Finding item context menu | Mark a finding as superseded by a newer one. |
 | `Phren: Retract Finding` | Finding item context menu | Retract a finding with a reason. |
 | `Phren: Resolve Contradiction` | Finding item context menu | Resolve a contradiction between two conflicting findings. |
@@ -103,7 +109,7 @@ Tree item clicks (findings, tasks, skills, queue items, project files) open deta
 
 The sidebar is structured around real Phren objects:
 
-- **Projects**: expands into Findings (with date groups), Tasks (Queue/Active/Done), Sessions, Review Queue, and Reference.
+- **Projects**: expands into Findings and Notes (both grouped by date), Tasks (Queue/Active/Done), Sessions, Review Queue, and Reference.
 - **Skills**: grouped by scope, project-local and global skills shown separately.
 - **Hooks**: current hook state for each registered tool.
 - **Fragment Graph**: one-click entry into the graph view.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "phren-vscode",
   "displayName": "Phren",
   "description": "Browse, search, and manage Phren knowledge directly from VS Code.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "alaarab",
   "author": "Ala Arab",
   "license": "MIT",
@@ -53,7 +53,33 @@
       },
       {
         "command": "phren.addFinding",
-        "title": "Phren: Add Finding"
+        "title": "Phren: Add Finding",
+        "icon": "$(add)"
+      },
+      {
+        "command": "phren.addNote",
+        "title": "Phren: Add Note",
+        "icon": "$(note)"
+      },
+      {
+        "command": "phren.openNote",
+        "title": "Phren: Open Note",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "phren.editNote",
+        "title": "Phren: Edit Note",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "phren.removeNote",
+        "title": "Phren: Remove Note",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "phren.promoteNote",
+        "title": "Phren: Promote Note to Finding",
+        "icon": "$(arrow-up)"
       },
       {
         "command": "phren.setActiveProject",
@@ -292,6 +318,22 @@
           "when": "false"
         },
         {
+          "command": "phren.openNote",
+          "when": "false"
+        },
+        {
+          "command": "phren.editNote",
+          "when": "false"
+        },
+        {
+          "command": "phren.removeNote",
+          "when": "false"
+        },
+        {
+          "command": "phren.promoteNote",
+          "when": "false"
+        },
+        {
           "command": "phren.supersedeFinding",
           "when": "false"
         },
@@ -330,15 +372,46 @@
       ],
       "editor/context": [
         {
+          "command": "phren.addNote",
+          "when": "editorHasSelection",
+          "group": "phren@1"
+        },
+        {
           "command": "phren.addFinding",
-          "when": "editorHasSelection"
+          "when": "editorHasSelection",
+          "group": "phren@2"
         }
       ],
       "view/item/context": [
         {
+          "command": "phren.addFinding",
+          "when": "viewItem == phren.category.findings",
+          "group": "inline@1"
+        },
+        {
           "command": "phren.filterFindingsByDate",
           "when": "viewItem == phren.category.findings",
-          "group": "inline"
+          "group": "inline@2"
+        },
+        {
+          "command": "phren.addNote",
+          "when": "viewItem == phren.category.notes",
+          "group": "inline@1"
+        },
+        {
+          "command": "phren.promoteNote",
+          "when": "viewItem == phren.note",
+          "group": "inline@1"
+        },
+        {
+          "command": "phren.editNote",
+          "when": "viewItem == phren.note || viewItem == phren.note.promoted",
+          "group": "navigation@1"
+        },
+        {
+          "command": "phren.removeNote",
+          "when": "viewItem == phren.note || viewItem == phren.note.promoted",
+          "group": "navigation@2"
         },
         {
           "command": "phren.toggleHook",

--- a/packages/vscode/src/commands/finding-commands.ts
+++ b/packages/vscode/src/commands/finding-commands.ts
@@ -6,23 +6,47 @@ export function registerFindingCommands(ctx: ExtensionContext): vscode.Disposabl
   const { phrenClient, statusBar, treeDataProvider } = ctx;
   const refreshTree = () => treeDataProvider.refresh();
 
-  const addFinding = vscode.commands.registerCommand("phren.addFinding", async () => {
-    const activeProject = statusBar.getActiveProjectName();
-    if (!activeProject) {
-      await vscode.window.showWarningMessage("No active Phren project selected.");
-      return;
+  const addFinding = vscode.commands.registerCommand("phren.addFinding", async (node?: { projectName?: string }) => {
+    let project = node?.projectName || statusBar.getActiveProjectName();
+    if (!project) {
+      let projectsRaw: unknown;
+      try {
+        projectsRaw = await phrenClient.listProjects();
+      } catch (error) {
+        await vscode.window.showErrorMessage(`Failed to list projects: ${toErrorMessage(error)}`);
+        return;
+      }
+      const projectsData = asRecord(asRecord(projectsRaw)?.data);
+      const projectNames = asArraySafe(projectsData?.projects)
+        .map((entry) => asRecord(entry))
+        .map((entry) => typeof entry?.name === "string" ? entry.name : undefined)
+        .filter((name): name is string => Boolean(name));
+      if (projectNames.length === 0) {
+        await vscode.window.showWarningMessage("No Phren projects found.");
+        return;
+      }
+      project = await vscode.window.showQuickPick(projectNames, { placeHolder: "Select a project" });
+      if (!project) return;
     }
 
-    const findingText = await vscode.window.showInputBox({ prompt: "Enter finding text" });
+    const editor = vscode.window.activeTextEditor;
+    const selectedText = editor && !editor.selection.isEmpty
+      ? editor.document.getText(editor.selection).trim()
+      : "";
+    const findingText = await vscode.window.showInputBox({
+      prompt: "Record durable knowledge worth carrying into future work",
+      placeHolder: "Decision, pattern, pitfall, workaround, or other reusable insight",
+      value: selectedText,
+    });
     const trimmedFindingText = findingText?.trim();
     if (!trimmedFindingText) {
       return;
     }
 
     try {
-      await phrenClient.addFinding(activeProject, trimmedFindingText);
+      await phrenClient.addFinding(project, trimmedFindingText);
       treeDataProvider.refresh();
-      await vscode.window.showInformationMessage(`Finding added to ${activeProject}`);
+      await vscode.window.showInformationMessage(`Finding added to ${project}`);
     } catch (error) {
       await vscode.window.showErrorMessage(`Failed to add finding: ${toErrorMessage(error)}`);
     }

--- a/packages/vscode/src/commands/note-commands.ts
+++ b/packages/vscode/src/commands/note-commands.ts
@@ -1,0 +1,111 @@
+import * as vscode from "vscode";
+import { asArraySafe, asRecord, toErrorMessage, type ExtensionContext } from "../extensionContext";
+
+interface NoteCommandNode {
+  projectName: string;
+  id: string;
+  date: string;
+  time: string;
+  text: string;
+  promoted: boolean;
+}
+
+async function chooseProject(ctx: ExtensionContext, node?: { projectName?: string }): Promise<string | undefined> {
+  const active = node?.projectName || ctx.statusBar.getActiveProjectName();
+  if (active) return active;
+  try {
+    const raw = await ctx.phrenClient.listProjects();
+    const projects = asArraySafe(asRecord(asRecord(raw)?.data)?.projects)
+      .map((entry) => asRecord(entry))
+      .map((entry) => typeof entry?.name === "string" ? entry.name : undefined)
+      .filter((name): name is string => Boolean(name));
+    if (!projects.length) {
+      await vscode.window.showWarningMessage("No Phren projects found.");
+      return undefined;
+    }
+    return vscode.window.showQuickPick(projects, { placeHolder: "Select a project for the note" });
+  } catch (error) {
+    await vscode.window.showErrorMessage(`Failed to list projects: ${toErrorMessage(error)}`);
+    return undefined;
+  }
+}
+
+export function registerNoteCommands(ctx: ExtensionContext): vscode.Disposable[] {
+  const { phrenClient, treeDataProvider } = ctx;
+
+  const add = vscode.commands.registerCommand("phren.addNote", async (node?: { projectName?: string }) => {
+    const project = await chooseProject(ctx, node);
+    if (!project) return;
+    const editor = vscode.window.activeTextEditor;
+    const selected = editor && !editor.selection.isEmpty ? editor.document.getText(editor.selection).trim() : "";
+    const text = await vscode.window.showInputBox({
+      prompt: `Add a lightweight daily note to ${project}`,
+      placeHolder: "A reminder, status update, observation, or scratch thought",
+      value: selected,
+    });
+    if (!text?.trim()) return;
+    try {
+      await phrenClient.addNote(project, text.trim());
+      treeDataProvider.refresh();
+      await vscode.window.showInformationMessage(`Note added to ${project}.`);
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to add note: ${toErrorMessage(error)}`);
+    }
+  });
+
+  const open = vscode.commands.registerCommand("phren.openNote", async (note?: NoteCommandNode) => {
+    if (!note) return;
+    const document = await vscode.workspace.openTextDocument({
+      language: "markdown",
+      content: `# ${note.projectName} note\n\n${note.date} ${note.time.slice(0, 5)} · ${note.id}${note.promoted ? " · promoted" : ""}\n\n${note.text}\n`,
+    });
+    await vscode.window.showTextDocument(document, { preview: true });
+  });
+
+  const edit = vscode.commands.registerCommand("phren.editNote", async (note?: NoteCommandNode) => {
+    if (!note) {
+      await vscode.window.showWarningMessage("Edit Note is available from a note in the Phren explorer.");
+      return;
+    }
+    const text = await vscode.window.showInputBox({ prompt: `Edit ${note.id}`, value: note.text });
+    if (!text?.trim() || text.trim() === note.text) return;
+    try {
+      await phrenClient.editNote(note.projectName, note.id, text.trim());
+      treeDataProvider.refresh();
+      await vscode.window.showInformationMessage(`Updated ${note.id}.`);
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to edit note: ${toErrorMessage(error)}`);
+    }
+  });
+
+  const remove = vscode.commands.registerCommand("phren.removeNote", async (note?: NoteCommandNode) => {
+    if (!note) return;
+    const confirmed = await vscode.window.showWarningMessage(`Remove note ${note.id}?`, { modal: true }, "Remove");
+    if (confirmed !== "Remove") return;
+    try {
+      await phrenClient.removeNote(note.projectName, note.id);
+      treeDataProvider.refresh();
+      await vscode.window.showInformationMessage(`Removed ${note.id}.`);
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to remove note: ${toErrorMessage(error)}`);
+    }
+  });
+
+  const promote = vscode.commands.registerCommand("phren.promoteNote", async (note?: NoteCommandNode) => {
+    if (!note) return;
+    const choice = await vscode.window.showQuickPick([
+      { label: "No type", value: undefined },
+      ...["decision", "pitfall", "pattern", "tradeoff", "architecture", "bug"].map((value) => ({ label: value, value })),
+    ], { placeHolder: "Optional finding type" });
+    if (!choice) return;
+    try {
+      await phrenClient.promoteNote(note.projectName, note.id, choice.value);
+      treeDataProvider.refresh();
+      await vscode.window.showInformationMessage(`Promoted ${note.id} to a finding.`);
+    } catch (error) {
+      await vscode.window.showErrorMessage(`Failed to promote note: ${toErrorMessage(error)}`);
+    }
+  });
+
+  return [add, open, edit, remove, promote];
+}

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -13,6 +13,7 @@ import { registerFindingCommands } from "./commands/finding-commands";
 import { registerTaskCommands } from "./commands/task-commands";
 import { registerProjectCommands } from "./commands/project-commands";
 import { registerMachineCommands } from "./commands/machine-commands";
+import { registerNoteCommands } from "./commands/note-commands";
 
 let client: PhrenClient | undefined;
 let outputChannel: vscode.OutputChannel;
@@ -111,6 +112,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // --- Register all commands from modules ---
   context.subscriptions.push(
     ...registerFindingCommands(extCtx),
+    ...registerNoteCommands(extCtx),
     ...registerTaskCommands(extCtx),
     ...registerProjectCommands(extCtx),
     ...registerMachineCommands(extCtx),

--- a/packages/vscode/src/phrenClient.ts
+++ b/packages/vscode/src/phrenClient.ts
@@ -169,6 +169,26 @@ export class PhrenClient {
     return this.callTool("get_findings", { project });
   }
 
+  async getNotes(project: string, date?: string): Promise<unknown> {
+    return this.callTool("get_notes", date ? { project, date } : { project });
+  }
+
+  async addNote(project: string, text: string, date?: string): Promise<unknown> {
+    return this.callTool("add_note", date ? { project, text, date } : { project, text });
+  }
+
+  async editNote(project: string, note: string, text: string): Promise<unknown> {
+    return this.callTool("edit_note", { project, note, text });
+  }
+
+  async removeNote(project: string, note: string): Promise<unknown> {
+    return this.callTool("remove_note", { project, note });
+  }
+
+  async promoteNote(project: string, note: string, findingType?: string): Promise<unknown> {
+    return this.callTool("promote_note", findingType ? { project, note, findingType } : { project, note });
+  }
+
   async getTasks(project: string, options: GetTasksOptions = {}): Promise<unknown> {
     return this.callTool("get_tasks", { project, ...options });
   }

--- a/packages/vscode/src/providers/PhrenTreeProvider.ts
+++ b/packages/vscode/src/providers/PhrenTreeProvider.ts
@@ -75,6 +75,14 @@ export class PhrenTreeProvider implements vscode.TreeDataProvider<PhrenNode>, vs
       return { kind: "findingDateGroup", projectName: element.projectName, date: element.date, count: 0 };
     }
 
+    if (element.kind === "noteDateGroup") {
+      return { kind: "category", projectName: element.projectName, category: "notes" };
+    }
+
+    if (element.kind === "note") {
+      return { kind: "noteDateGroup", projectName: element.projectName, date: element.date, count: 0 };
+    }
+
     if (element.kind === "taskSectionGroup") {
       return { kind: "category", projectName: element.projectName, category: "task" };
     }
@@ -136,6 +144,7 @@ export class PhrenTreeProvider implements vscode.TreeDataProvider<PhrenNode>, vs
     if (element.kind === "project") {
       return [
         { kind: "category", projectName: element.projectName, category: "findings" },
+        { kind: "category", projectName: element.projectName, category: "notes" },
         { kind: "category", projectName: element.projectName, category: "truths" },
         { kind: "category", projectName: element.projectName, category: "sessions" },
         { kind: "category", projectName: element.projectName, category: "task" },
@@ -148,6 +157,9 @@ export class PhrenTreeProvider implements vscode.TreeDataProvider<PhrenNode>, vs
     if (element.kind === "category") {
       if (element.category === "findings") {
         return this.data.getFindingDateGroups(element.projectName, this.dateFilter);
+      }
+      if (element.category === "notes") {
+        return this.data.getNoteDateGroups(element.projectName);
       }
       if (element.category === "truths") {
         return this.data.getTruthNodes(element.projectName);
@@ -196,6 +208,10 @@ export class PhrenTreeProvider implements vscode.TreeDataProvider<PhrenNode>, vs
 
     if (element.kind === "findingDateGroup") {
       return this.data.getFindingsForDate(element.projectName, element.date, this.dateFilter);
+    }
+
+    if (element.kind === "noteDateGroup") {
+      return this.data.getNotesForDate(element.projectName, element.date);
     }
 
     if (element.kind === "globalTaskSectionGroup") {

--- a/packages/vscode/src/providers/tree-data.ts
+++ b/packages/vscode/src/providers/tree-data.ts
@@ -5,6 +5,7 @@ import { readDeviceContext } from "../profileConfig";
 import type {
   DateFilter,
   FindingSummary,
+  NoteSummary,
   MessageNode,
   PhrenNode,
   ProjectNode,
@@ -165,6 +166,37 @@ export class TreeDataSource {
         }));
     } catch (error) {
       return [this.errorNode("Failed to load findings", error)];
+    }
+  }
+
+  // --- Tasks ---
+
+  async getNoteDateGroups(projectName: string): Promise<PhrenNode[]> {
+    try {
+      const notes = await this.fetchNotes(projectName);
+      if (notes.length === 0) return [{ kind: "message", label: "No notes yet", iconId: "note" }];
+      const counts = new Map<string, number>();
+      for (const note of notes) counts.set(note.date, (counts.get(note.date) ?? 0) + 1);
+      return [...counts].map(([date, count]) => ({ kind: "noteDateGroup" as const, projectName, date, count }));
+    } catch (error) {
+      return [this.errorNode("Failed to load notes", error)];
+    }
+  }
+
+  async getNotesForDate(projectName: string, date: string): Promise<PhrenNode[]> {
+    try {
+      const notes = await this.fetchNotes(projectName);
+      return notes.filter((note) => note.date === date).map((note) => ({
+        kind: "note" as const,
+        projectName,
+        id: note.id,
+        date: note.date,
+        time: note.time,
+        text: note.text,
+        promoted: note.promoted,
+      }));
+    } catch (error) {
+      return [this.errorNode("Failed to load notes", error)];
     }
   }
 
@@ -1059,6 +1091,30 @@ export class TreeDataSource {
       }
 
       return tasks;
+    });
+  }
+
+  private fetchNotes(projectName: string): Promise<NoteSummary[]> {
+    return this.cachedFetch(`notes:${projectName}`, async () => {
+      const raw = await this.client.getNotes(projectName);
+      const data = responseData(raw);
+      const notes = asArray(data?.notes);
+      const parsed: NoteSummary[] = [];
+      for (const entry of notes) {
+        const record = asRecord(entry);
+        const id = asString(record?.id);
+        const text = asString(record?.text);
+        const date = asString(record?.date);
+        if (!id || !text || !date) continue;
+        parsed.push({
+          id,
+          text,
+          date,
+          time: asString(record?.time) ?? "00:00:00",
+          promoted: asBoolean(record?.promoted) ?? false,
+        });
+      }
+      return parsed;
     });
   }
 

--- a/packages/vscode/src/providers/tree-nodes.ts
+++ b/packages/vscode/src/providers/tree-nodes.ts
@@ -54,7 +54,7 @@ export function buildTreeItem(element: PhrenNode, dateFilter: DateFilter | undef
     }
     case "category": {
       const cat = element.category ?? "unknown";
-      const categoryLabels: Record<string, string> = { findings: "Findings", truths: "Truths", sessions: "Sessions", task: "Tasks", queue: "Review Queue", hooks: "Hooks", reference: "Reference" };
+      const categoryLabels: Record<string, string> = { findings: "Findings", notes: "Notes", truths: "Truths", sessions: "Sessions", task: "Tasks", queue: "Review Queue", hooks: "Hooks", reference: "Reference" };
       let categoryLabel = categoryLabels[cat] ?? cat.charAt(0).toUpperCase() + cat.slice(1);
       if (cat === "findings" && dateFilter) {
         categoryLabel += ` [${dateFilter.label}]`;
@@ -64,6 +64,8 @@ export function buildTreeItem(element: PhrenNode, dateFilter: DateFilter | undef
       item.id = `phren.category.${element.projectName}.${cat}`;
       if (cat === "findings") {
         item.contextValue = "phren.category.findings";
+      } else if (cat === "notes") {
+        item.contextValue = "phren.category.notes";
       }
       return item;
     }
@@ -73,6 +75,13 @@ export function buildTreeItem(element: PhrenNode, dateFilter: DateFilter | undef
       item.description = `${element.count}`;
       item.iconPath = themeIcon("calendar");
       item.id = `phren.findingDateGroup.${element.projectName}.${element.date}`;
+      return item;
+    }
+    case "noteDateGroup": {
+      const item = new vscode.TreeItem(formatDateLabel(element.date), vscode.TreeItemCollapsibleState.Collapsed);
+      item.description = `${element.count}`;
+      item.iconPath = themeIcon("calendar");
+      item.id = `phren.noteDateGroup.${element.projectName}.${element.date}`;
       return item;
     }
     case "sessionDateGroup": {
@@ -121,6 +130,16 @@ export function buildTreeItem(element: PhrenNode, dateFilter: DateFilter | undef
         title: "Open Finding",
         arguments: [element],
       };
+      return item;
+    }
+    case "note": {
+      const item = new vscode.TreeItem(truncate(element.text, 120), vscode.TreeItemCollapsibleState.None);
+      item.description = `${element.time.slice(0, 5)}${element.promoted ? " · promoted" : ""}`;
+      item.tooltip = `${element.date} ${element.time.slice(0, 5)} · ${element.id}\n${element.text}${element.promoted ? "\nPromoted to findings" : ""}`;
+      item.iconPath = themeIcon(element.promoted ? "pass-filled" : "note");
+      item.id = `phren.note.${element.projectName}.${element.id}`;
+      item.contextValue = element.promoted ? "phren.note.promoted" : "phren.note";
+      item.command = { command: "phren.openNote", title: "Open Note", arguments: [element] };
       return item;
     }
     case "globalTaskSectionGroup": {

--- a/packages/vscode/src/providers/tree-types.ts
+++ b/packages/vscode/src/providers/tree-types.ts
@@ -1,5 +1,5 @@
 export type TaskSection = "Active" | "Queue" | "Done";
-export type PhrenCategory = "findings" | "truths" | "sessions" | "task" | "queue" | "reference" | "hooks";
+export type PhrenCategory = "findings" | "notes" | "truths" | "sessions" | "task" | "queue" | "reference" | "hooks";
 export type SessionBucket = "findings" | "tasks";
 export type QueueSection = "Review" | "Stale" | "Conflicts";
 
@@ -69,6 +69,23 @@ export interface FindingNode {
   supersedes?: string;
   contradicts?: string[];
   potentialDuplicates?: string[];
+}
+
+export interface NoteDateGroupNode {
+  kind: "noteDateGroup";
+  projectName: string;
+  date: string;
+  count: number;
+}
+
+export interface NoteNode {
+  kind: "note";
+  projectName: string;
+  id: string;
+  date: string;
+  time: string;
+  text: string;
+  promoted: boolean;
 }
 
 export interface TaskSectionGroupNode {
@@ -229,6 +246,8 @@ export type PhrenNode =
   | CategoryNode
   | FindingDateGroupNode
   | FindingNode
+  | NoteDateGroupNode
+  | NoteNode
   | TaskSectionGroupNode
   | GlobalTaskSectionGroupNode
   | TaskNode
@@ -266,6 +285,14 @@ export interface FindingSummary {
   supersedes?: string;
   contradicts?: string[];
   potentialDuplicates?: string[];
+}
+
+export interface NoteSummary {
+  id: string;
+  date: string;
+  time: string;
+  text: string;
+  promoted: boolean;
 }
 
 export interface TaskSummary {

--- a/packages/vscode/src/providers/tree-utils.ts
+++ b/packages/vscode/src/providers/tree-utils.ts
@@ -5,6 +5,9 @@ export function categoryIconId(category: PhrenCategory): string {
   if (category === "findings") {
     return "list-flat";
   }
+  if (category === "notes") {
+    return "note";
+  }
   if (category === "truths") {
     return "pin";
   }


### PR DESCRIPTION
## What broke

Two root-level config files were missing from `setupSparseCheckout`'s `alwaysInclude` list (`packages/cli/src/link/link.ts`). On any profile-linked store, git tracked them in HEAD but never materialized them to the working tree — and `git status` stays silent about it, so this is invisible unless you look for it specifically.

Both resulting failures are silent:

**`phren.root.yaml` missing → MCP never starts.** The MCP entrypoint gates on `looksLikePhrenRootArg` → `readRootManifest`. With no manifest the store path isn't recognized, so `phren <store-path>` falls through to `Unknown command` and exits. The client then writes `initialize` to a dead stdin, surfacing as:

```
Failed to initialize MCP session: Cannot call write after a stream was destroyed
```

That message is three layers downstream of the real fault.

**`stores.yaml` missing → team stores vanish.** `store-registry.ts` treats a missing registry as "no team stores configured" and returns a single implicit primary entry. No error, no warning — configured team stores just disappear.

## Also fixed

`countStoreProjects` used a CommonJS `require()` inside an ESM package. It always threw `ReferenceError: require is not defined` into a bare `catch` returning `0`, so `phren store list` reported `projects: 0` for every store. Verified against a real 3-store install: now reports 6 / 14 / 5, matching the registry.

## New doctor check

`phren doctor` verifies root config is materialized on disk rather than merely tracked, and distinguishes sparse-checkout exclusion from an outright missing file. `--fix` repairs it by widening the sparse patterns. `stores.yaml` is only flagged when tracked-but-absent, since single-store installs legitimately have none.

## Verification

Reproduced the drift on a real store, confirmed `doctor` flags it and `doctor --fix` repairs it:

```
- fail store-registry-materialized: stores.yaml is tracked in git but excluded by
  sparse-checkout — team stores are hidden; run 'phren doctor --fix'
- ok store-registry-materialized: stores.yaml restored (was excluded by sparse-checkout)
```

Build, lint, validate-docs pass. Full suite: 2688 passed, 6 skipped.