### PR TITLE
feat: streamline graph project workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.39] - 2026-07-20
+
+### Changed
+
+- **The graph project pane is now the single reading and editing surface.** Selecting
+  a finding or task expands its complete text inline; Edit opens controls in that same
+  row instead of spawning a second dossier. Task status and priority are editable
+  inline, while finding topic and health remain visible for context.
+- The project pane is draggable in VS Code, starts taller, persists its position and
+  dimensions, and supports independent width/height resizing plus a diagonal corner
+  handle. Select now shares the filter row, and Select all toggles to Unselect all when
+  every visible item is selected.
+- Filters use an unambiguous cyan selected state, project rows show longer readable
+  previews, and graph scrollbars and HUD spacing are less visually intrusive.
+
+### Fixed
+
+- Removed the yellow radiating selection effect from projects, findings, tasks, and
+  other graph nodes.
+- Fixed project counts that stopped at exactly 50. The VS Code extension now requests
+  up to 200 findings and preserves the API's actual total rather than presenting the
+  first page length as the project total.
+- Fixed pane/card placement races after graph animations, overlapping graph controls,
+  inactive Edit actions, unclear health/filter selection, and saved inline edits not
+  refreshing in the project pane.
+- Released the coordinated VS Code extension patch as `0.6.2`.
+
 ## [0.1.38] - 2026-07-20
 
 ### Added

--- a/packages/cli/browser/graph/api.ts
+++ b/packages/cli/browser/graph/api.ts
@@ -16,6 +16,7 @@ import { applyFilters, disposeScene, setupForceGraph } from "./scene.js";
 import { buildFilterBar, buildHudOverlays } from "./hud.js";
 import { clearSelection, fitCameraToGraph, getNodeAt, hideTooltip, runIntro, selectNode } from "./interactions.js";
 import { disposePulses, mascot, startMascot, stopMascot, walkTo } from "./mascot.js";
+import { refreshProjectPanel } from "./project-panel.js";
 
 function mount(payload: GraphPayload): void {
   state.container = document.getElementById("graph-canvas");
@@ -173,6 +174,7 @@ function updateNode(
     updateEagerLabelText(fgNode);
   }
   refreshLabels();
+  refreshProjectPanel({ data: true });
   return true;
 }
 

--- a/packages/cli/browser/graph/hud.ts
+++ b/packages/cli/browser/graph/hud.ts
@@ -44,6 +44,15 @@ const HUD_CSS = `
   background:rgba(8,10,22,0.94);box-shadow:0 12px 40px rgba(0,0,0,0.6),0 0 24px rgba(103,232,249,0.06);
   color:#dbe4ff;
 }
+.phren-hud-panel,.phren-hud-results,.phren-project-nav{
+  scrollbar-width:thin;scrollbar-color:rgba(139,150,201,0.16) transparent;
+}
+.phren-hud-panel::-webkit-scrollbar,.phren-hud-results::-webkit-scrollbar,.phren-project-nav::-webkit-scrollbar{width:4px;height:4px}
+.phren-hud-panel::-webkit-scrollbar-track,.phren-hud-results::-webkit-scrollbar-track,.phren-project-nav::-webkit-scrollbar-track{background:transparent}
+.phren-hud-panel::-webkit-scrollbar-thumb,.phren-hud-results::-webkit-scrollbar-thumb,.phren-project-nav::-webkit-scrollbar-thumb{
+  background:rgba(139,150,201,0.14);border-radius:999px;
+}
+.phren-hud-panel:hover::-webkit-scrollbar-thumb,.phren-hud-results:hover::-webkit-scrollbar-thumb,.phren-project-nav:hover::-webkit-scrollbar-thumb{background:rgba(139,150,201,0.28)}
 .phren-hud-heading{
   font:700 9.5px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   color:#67e8f9;text-transform:uppercase;letter-spacing:0.14em;margin:10px 0 6px;
@@ -54,7 +63,9 @@ const HUD_CSS = `
   background:rgba(12,15,30,0.9);color:#dbe4ff;font-size:12px;margin-bottom:6px;
 }
 .phren-hud-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px 10px;margin-bottom:6px}
-.phren-hud-checklabel{display:flex;align-items:center;gap:8px;font-size:12px;color:#dbe4ff;cursor:pointer}
+.phren-hud-checklabel{display:flex;align-items:center;gap:8px;font-size:12px;color:#aeb7dd;cursor:pointer;padding:5px 7px;border:1px solid transparent;border-radius:6px}
+.phren-hud-checklabel:has(input:checked){color:#eafcff;background:rgba(103,232,249,0.1);border-color:rgba(103,232,249,0.32)}
+.phren-hud-checklabel input{accent-color:#67e8f9}
 .phren-hud-dot{display:inline-block;width:9px;height:9px;border-radius:999px;flex:0 0 auto}
 .phren-hud-limit{
   width:120px;padding:8px 10px;border-radius:6px;background:rgba(12,15,30,0.9);

--- a/packages/cli/browser/graph/interactions.ts
+++ b/packages/cli/browser/graph/interactions.ts
@@ -6,6 +6,13 @@ import { mascotMoveTo, spawnLookupPulse } from "./mascot.js";
 import { syncProjectNavActive } from "./project-nav.js";
 import { refreshProjectPanel } from "./project-panel.js";
 
+let projectPaneTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cancelProjectPaneReveal(): void {
+  if (projectPaneTimer) clearTimeout(projectPaneTimer);
+  projectPaneTimer = null;
+}
+
 export function containerSize(): { w: number; h: number } {
   const w = state.container?.clientWidth || 800;
   const h = state.container?.clientHeight || 600;
@@ -136,6 +143,7 @@ export function onNodeRightClick(fgNode: FGNode, event: MouseEvent): void {
 
 export function clearSelection(): void {
   if (!state.selectedNodeId && !state.focusedProjectId) return;
+  cancelProjectPaneReveal();
   state.selectedNodeId = null;
   state.focusedProjectId = null;
   state.hoveredNodeId = null;
@@ -161,8 +169,17 @@ export function selectNode(nodeId: string): boolean {
     state.hoveredNodeId = null;
     applyHighlight();
     syncProjectNavActive();
-    refreshProjectPanel();
+    // Keep the graph readable during the camera move, then slide the project's
+    // contents in once the destination has settled. A project click is an
+    // explicit request to see that pane, so it also overrides a stale
+    // persisted collapsed state.
+    cancelProjectPaneReveal();
+    refreshProjectPanel({ transitioning: true });
     flyToNode(fgNode, 900);
+    projectPaneTimer = setTimeout(() => {
+      projectPaneTimer = null;
+      if (state.focusedProjectId === nodeId) refreshProjectPanel({ forceOpen: true });
+    }, 900);
     // Notify hosts right away — the docked dossier doesn't wait on the
     // camera, and delaying was a flake source under load. The short defer
     // just lets the fly-to start before the host re-renders.
@@ -172,6 +189,7 @@ export function selectNode(nodeId: string): boolean {
   }
 
   state.focusedProjectId = null;
+  cancelProjectPaneReveal();
   state.selectedNodeId = nodeId;
   state.hoveredNodeId = nodeId;
   hideTooltip();
@@ -179,7 +197,17 @@ export function selectNode(nodeId: string): boolean {
   syncProjectNavActive();
   refreshProjectPanel();
   flyToNode(fgNode, 800);
-  setTimeout(() => notifySelection(nodeId), 120);
+  // The node's screen position changes throughout the camera flight. Re-anchor
+  // the contextual pane after the camera settles so it cannot end up covering
+  // the newly selected finding/task/fragment.
+  cancelProjectPaneReveal();
+  projectPaneTimer = setTimeout(() => {
+    projectPaneTimer = null;
+    if (state.selectedNodeId === nodeId) {
+      refreshProjectPanel();
+      notifySelection(nodeId);
+    }
+  }, 800);
   mascotMoveTo(nodeId, true);
   return true;
 }

--- a/packages/cli/browser/graph/nodes.ts
+++ b/packages/cli/browser/graph/nodes.ts
@@ -343,5 +343,7 @@ export function tickNodes(dt: number, now: number): void {
   });
 
   positionFocusHalo(hoverHalo, state.hoveredNodeId);
-  positionFocusHalo(selectHalo, state.selectedNodeId || state.focusedProjectId);
+  // Selection is already clear from graph dimming and contextual UI. Avoid a
+  // second amber/yellow glow around projects, findings, tasks, or fragments.
+  positionFocusHalo(selectHalo, null);
 }

--- a/packages/cli/browser/graph/project-panel.ts
+++ b/packages/cli/browser/graph/project-panel.ts
@@ -6,9 +6,8 @@ import { clearSelection, peekNode, selectNode } from "./interactions.js";
 // findings and tasks. It appears whenever a project is "in context" (its orb
 // is focused, or one of its own findings/tasks is selected) so you can scroll
 // the whole list, filter it, and jump straight to any item instead of hunting
-// for its node in 3D. Clicking a row flies to that node and opens the existing
-// dossier (where Edit/Delete already live). Health-tinted rows plus the health
-// filter make aging findings easy to surface and prune.
+// for its node in 3D. Rows expand for reading and editing in place, while
+// health-tinted rows plus the health filter make aging findings easy to prune.
 //
 // Lives in the shared bundle (like the project navigator) so the web-ui and the
 // VS Code webview both pick it up with no host wiring — selection is the only
@@ -23,18 +22,24 @@ const HEALTH_RANK: Record<string, number> = { stale: 2, decaying: 1, healthy: 0 
 
 const PANEL_CSS = `
 .phren-project-panel{
-  position:absolute;right:58px;top:64px;bottom:16px;z-index:9;
-  width:min(340px, calc(100% - 420px));display:flex;flex-direction:column;
+  position:absolute;right:58px;left:auto;top:64px;z-index:9;
+  width:min(300px, calc(100% - 32px));height:min(520px, calc(100% - 92px));display:flex;flex-direction:column;
   border:1px solid rgba(103,232,249,0.22);border-radius:12px;
   background:rgba(8,10,22,0.92);color:#dbe4ff;
   box-shadow:0 16px 60px rgba(0,0,0,0.6),0 0 30px rgba(103,232,249,0.05);
   backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);overflow:hidden;
+  animation:phren-pp-enter 180ms ease-out both;
+  transition:left 180ms ease-out,top 180ms ease-out;
 }
+.phren-vscode-webview .phren-project-panel{left:16px;right:auto}
+@keyframes phren-pp-enter{from{opacity:0;transform:translateX(-14px)}to{opacity:1;transform:translateX(0)}}
 .phren-project-panel[hidden]{display:none}
 .phren-pp-head{
   display:flex;align-items:flex-start;gap:8px;padding:13px 14px 10px;
   border-bottom:1px solid rgba(103,232,249,0.12);
 }
+.phren-vscode-webview .phren-pp-head{cursor:move;touch-action:none}
+.phren-vscode-webview .phren-pp-head button{cursor:pointer}
 .phren-pp-title{flex:1 1 auto;min-width:0}
 .phren-pp-kind{
   font:700 9.5px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
@@ -56,6 +61,7 @@ const PANEL_CSS = `
   font:600 9px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#8b96c9;letter-spacing:0.05em;
 }
 .phren-pp-healthkey button:hover{color:#eaf2ff}
+.phren-pp-healthkey button.active{color:#eafcff;text-decoration:underline;text-decoration-color:#67e8f9;text-underline-offset:3px}
 .phren-pp-healthkey i{width:7px;height:7px;border-radius:999px;font-style:normal}
 .phren-pp-headbtns{flex:0 0 auto;display:flex;gap:6px}
 .phren-pp-iconbtn{
@@ -79,14 +85,32 @@ const PANEL_CSS = `
   writing-mode:vertical-rl;font:700 9.5px/1 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   letter-spacing:0.14em;text-transform:uppercase;max-height:180px;overflow:hidden;text-overflow:ellipsis;
 }
-/* Drag handle on the pane's inner (left) edge to widen/narrow it. */
-.phren-pp-resize{position:absolute;left:-4px;top:0;bottom:0;width:9px;cursor:ew-resize;z-index:3;touch-action:none}
+/* Independent edge handles: width and height never resize each other. */
+.phren-pp-resize{position:absolute;left:-4px;right:auto;top:0;bottom:0;width:9px;cursor:ew-resize;z-index:3;touch-action:none}
+.phren-vscode-webview .phren-pp-resize{left:auto;right:-4px}
 .phren-pp-resize::after{
   content:"";position:absolute;left:3px;top:50%;transform:translateY(-50%);
   width:3px;height:38px;border-radius:999px;background:rgba(103,232,249,0.28);
   opacity:0;transition:opacity 0.15s ease;
 }
+.phren-vscode-webview .phren-pp-resize::after{left:auto;right:3px}
 .phren-pp-resize:hover::after,.phren-pp-resize.dragging::after{opacity:1}
+.phren-pp-resize-y{position:absolute;left:0;right:0;bottom:-4px;height:9px;cursor:ns-resize;z-index:4;touch-action:none}
+.phren-pp-resize-y::after{
+  content:"";position:absolute;left:50%;bottom:3px;transform:translateX(-50%);
+  width:38px;height:3px;border-radius:999px;background:rgba(103,232,249,0.2);
+  opacity:0;transition:opacity 0.15s ease;
+}
+.phren-pp-resize-y:hover::after,.phren-pp-resize-y.dragging::after{opacity:1}
+.phren-pp-resize-xy{
+  position:absolute;left:-3px;right:auto;bottom:-3px;width:15px;height:15px;z-index:5;
+  cursor:nesw-resize;touch-action:none;border-radius:4px 0 0 0;
+}
+.phren-vscode-webview .phren-pp-resize-xy{left:auto;right:-3px;cursor:nwse-resize;border-radius:4px 0 0 0}
+.phren-pp-resize-xy::after{
+  content:"";position:absolute;inset:4px;border-right:2px solid rgba(103,232,249,0.3);border-bottom:2px solid rgba(103,232,249,0.3);
+}
+.phren-pp-resize-xy:hover::after,.phren-pp-resize-xy.dragging::after{border-color:rgba(103,232,249,0.72)}
 .phren-pp-controls{padding:10px 14px;display:flex;flex-direction:column;gap:8px;border-bottom:1px solid rgba(103,232,249,0.1)}
 .phren-pp-search{
   width:100%;padding:8px 11px;border-radius:8px;
@@ -95,42 +119,75 @@ const PANEL_CSS = `
   letter-spacing:0.02em;outline:none;
 }
 .phren-pp-search:focus{border-color:rgba(103,232,249,0.5)}
-.phren-pp-chips{display:flex;flex-wrap:wrap;align-items:center;gap:6px}
+.phren-pp-chips,.phren-pp-tools{display:flex;flex-wrap:wrap;align-items:center;gap:7px}
+.phren-pp-tools{padding-top:1px}
 .phren-pp-sort{
-  margin-left:auto;padding:4px 8px;border-radius:7px;cursor:pointer;
+  margin-left:auto;min-width:112px;padding:6px 9px;border-radius:7px;cursor:pointer;
   background:rgba(12,15,30,0.9);color:#c3ccef;border:1px solid rgba(103,232,249,0.18);
   font:600 9.5px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:0.04em;
 }
 .phren-pp-sort:focus{outline:none;border-color:rgba(103,232,249,0.5)}
 .phren-pp-chip{
-  cursor:pointer;padding:4px 9px;border-radius:999px;user-select:none;
+  cursor:pointer;padding:5px 10px;border-radius:999px;user-select:none;
   border:1px solid rgba(103,232,249,0.16);background:rgba(12,15,30,0.7);
   font:600 9.5px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   color:#aeb7dd;letter-spacing:0.05em;text-transform:uppercase;
   transition:border-color 0.15s ease,color 0.15s ease,background 0.15s ease;
 }
 .phren-pp-chip:hover{border-color:rgba(103,232,249,0.45);color:#eaf2ff}
-.phren-pp-chip.on{border-color:rgba(103,232,249,0.6);color:#eaf6ff;background:rgba(103,232,249,0.12)}
-.phren-pp-chip.on[data-health="aging"]{border-color:rgba(255,182,72,0.6);color:#ffe1a3;background:rgba(255,182,72,0.12)}
-.phren-pp-list{flex:1 1 auto;overflow-y:auto;padding:6px;scrollbar-width:thin}
-.phren-pp-list::-webkit-scrollbar{width:6px}
-.phren-pp-list::-webkit-scrollbar-thumb{background:rgba(103,232,249,0.22);border-radius:999px}
+.phren-pp-chip.on{border-color:#67e8f9;color:#eafcff;background:rgba(103,232,249,0.16);box-shadow:0 0 0 1px rgba(103,232,249,0.12) inset}
+.phren-pp-chip.on::before{content:"✓";margin-right:5px;color:#67e8f9}
+.phren-pp-chip.on[data-health="aging"]{border-color:#ffb648;color:#ffe1a3;background:rgba(255,182,72,0.14)}
+.phren-pp-chip.on[data-health="aging"]::before{color:#ffb648}
+.phren-pp-list{flex:1 1 auto;overflow-y:auto;padding:6px;scrollbar-width:thin;scrollbar-color:rgba(139,150,201,0.16) transparent}
+.phren-pp-list::-webkit-scrollbar{width:4px}
+.phren-pp-list::-webkit-scrollbar-track{background:transparent}
+.phren-pp-list::-webkit-scrollbar-thumb{background:rgba(139,150,201,0.14);border-radius:999px}
+.phren-pp-list:hover::-webkit-scrollbar-thumb{background:rgba(139,150,201,0.28)}
 .phren-pp-group{
+  display:flex;align-items:center;gap:7px;
   font:700 9px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
-  color:#67e8f9;letter-spacing:0.14em;text-transform:uppercase;
-  padding:9px 8px 5px;position:sticky;top:0;background:rgba(8,10,22,0.92);
+  color:#67e8f9;text-transform:uppercase;
+  padding:9px 8px 6px;margin:0 2px 4px;position:sticky;top:0;z-index:1;
+  background:rgba(8,10,22,0.96);border-bottom:1px solid rgba(103,232,249,0.1);
 }
+.phren-pp-group-label{letter-spacing:0.12em}
+.phren-pp-group-count{color:#8b96c9;letter-spacing:0.04em;font-variant-numeric:tabular-nums}
 .phren-pp-row{
-  display:flex;align-items:center;gap:9px;width:100%;text-align:left;cursor:pointer;
+  display:flex;align-items:flex-start;gap:9px;width:100%;text-align:left;cursor:pointer;
   background:transparent;border:1px solid transparent;border-left:2px solid transparent;
   border-radius:7px;padding:7px 9px;margin-bottom:2px;color:#c9d2f2;
   font:500 12px/1.35 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
 }
 .phren-pp-row:hover{background:rgba(103,232,249,0.06);border-color:rgba(103,232,249,0.16)}
-.phren-pp-row.active{background:rgba(255,209,102,0.12);border-color:rgba(255,209,102,0.55);color:#fff}
+.phren-pp-row.active{background:rgba(103,232,249,0.1);border-color:rgba(103,232,249,0.62);color:#fff;box-shadow:inset 3px 0 #67e8f9}
+.phren-pp-row.active{flex-wrap:wrap}
 .phren-pp-row.cursor{border-color:rgba(103,232,249,0.7);box-shadow:0 0 0 1px rgba(103,232,249,0.28) inset}
-.phren-pp-dot{width:8px;height:8px;border-radius:999px;flex:0 0 auto;box-shadow:0 0 7px 1px currentColor}
-.phren-pp-rowlabel{flex:1 1 auto;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.phren-pp-dot{width:8px;height:8px;border-radius:999px;flex:0 0 auto;box-shadow:0 0 7px 1px currentColor;margin-top:4px}
+.phren-pp-rowlabel{flex:1 1 auto;min-width:0;overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;line-height:1.4}
+.phren-pp-row.active .phren-pp-rowlabel{-webkit-line-clamp:2}
+.phren-pp-rowdetail{
+  display:none;flex:1 0 100%;padding:8px 8px 4px 17px;margin-top:2px;
+  border-top:1px solid rgba(103,232,249,0.14);color:#dbe4ff;
+  white-space:pre-wrap;overflow-wrap:anywhere;font:500 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+}
+.phren-pp-row.active .phren-pp-rowdetail{display:block}
+.phren-pp-row.editing{flex-wrap:wrap;background:rgba(103,232,249,0.1);border-color:rgba(103,232,249,0.62);box-shadow:inset 3px 0 #67e8f9}
+.phren-pp-inline-editor{display:flex;flex:1 0 100%;flex-direction:column;gap:9px;padding:9px 7px 5px 17px;margin-top:3px;border-top:1px solid rgba(103,232,249,0.18)}
+.phren-pp-inline-editor textarea{
+  width:100%;min-height:132px;resize:vertical;padding:10px 11px;border-radius:8px;
+  border:1px solid rgba(103,232,249,0.28);background:rgba(5,7,17,0.92);color:#edf4ff;
+  outline:none;font:500 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+}
+.phren-pp-inline-editor textarea:focus{border-color:#67e8f9;box-shadow:0 0 0 1px rgba(103,232,249,0.18)}
+.phren-pp-inline-fields{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px}
+.phren-pp-inline-fields label{display:flex;flex-direction:column;gap:5px;color:#8b96c9;font:700 8.5px/1.3 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-transform:uppercase;letter-spacing:.08em}
+.phren-pp-inline-fields select{min-width:0;padding:7px 8px;border-radius:7px;border:1px solid rgba(103,232,249,.22);background:rgba(12,15,30,.96);color:#dbe4ff;font:600 10px/1.3 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.phren-pp-inline-meta{display:flex;flex-wrap:wrap;gap:7px;color:#8b96c9;font:600 9px/1.3 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.phren-pp-inline-meta span{padding:3px 7px;border-radius:999px;border:1px solid rgba(103,232,249,.14);background:rgba(12,15,30,.75)}
+.phren-pp-inline-actions{display:flex;justify-content:flex-end;gap:7px}
+.phren-pp-inline-actions button{padding:6px 11px;border-radius:7px;cursor:pointer;border:1px solid rgba(103,232,249,.25);background:rgba(12,15,30,.9);color:#bfc9ec;font:700 9px/1.3 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;text-transform:uppercase;letter-spacing:.06em}
+.phren-pp-inline-actions [data-pp-save]{border-color:rgba(103,232,249,.65);background:rgba(103,232,249,.15);color:#eaffff}
 .phren-pp-rowchip{
   flex:0 0 auto;font:600 8.5px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   text-transform:uppercase;letter-spacing:0.05em;color:#8b96c9;
@@ -189,6 +246,7 @@ const PANEL_CSS = `
 .phren-pp-empty{padding:22px 12px;text-align:center;color:#5b6488;
   font:600 10px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;letter-spacing:0.06em}
 @media (max-width: 900px){.phren-project-panel{width:min(300px, calc(100% - 32px))}}
+@media (prefers-reduced-motion: reduce){.phren-project-panel{animation:none}}
 `;
 
 function injectPanelCss(): void {
@@ -207,8 +265,12 @@ let renderedReview = false;
 let cursorId: string | null = null;
 let collapsed = false;
 let selectMode = false;
+let editingId: string | null = null;
 let reviewMode = false; // global "needs review" pane (aging findings, all projects)
 let panelWidth: number | null = null; // user-resized width (px), null = default
+let panelHeight: number | null = null; // user-resized height (px), null = default
+let panelLeft: number | null = null;
+let panelTop: number | null = null;
 const picked = new Set<string>();
 
 /** Count of aging (decaying/stale) findings across every project. */
@@ -238,10 +300,16 @@ function renderCurrentList(): void {
   else renderList();
 }
 
-// Fixed right offset of the pane (matches `.phren-project-panel { right: 58px }`).
+// Host offsets: browser keeps its dossier on the left and contents on the
+// right; VS Code uses the contents pane as its sole persistent left surface.
+const PANE_LEFT = 16;
 const PANE_RIGHT = 58;
 
-// Persisted UI preferences (width, collapsed, sort) — survive reloads in both
+function isVsCodeHost(): boolean {
+  return document.body.classList.contains("phren-vscode-webview");
+}
+
+// Persisted UI preferences (size, collapsed, sort) — survive reloads in both
 // hosts via localStorage. Filters/query stay transient (reset each session).
 const PREFS_KEY = "phren.graph.pane";
 let prefsLoaded = false;
@@ -251,15 +319,18 @@ function loadPrefs(): void {
   try {
     const raw = localStorage.getItem(PREFS_KEY);
     if (!raw) return;
-    const p = JSON.parse(raw) as { width?: unknown; collapsed?: unknown; sort?: unknown };
+    const p = JSON.parse(raw) as { width?: unknown; height?: unknown; left?: unknown; top?: unknown; collapsed?: unknown; sort?: unknown };
     if (typeof p.width === "number" && p.width > 0) panelWidth = p.width;
+    if (typeof p.height === "number" && p.height > 0) panelHeight = p.height;
+    if (typeof p.left === "number" && p.left >= 0) panelLeft = p.left;
+    if (typeof p.top === "number" && p.top >= 0) panelTop = p.top;
     if (typeof p.collapsed === "boolean") collapsed = p.collapsed;
     if (p.sort === "aging" || p.sort === "recent" || p.sort === "az") filters.sort = p.sort;
   } catch { /* storage unavailable — use defaults */ }
 }
 function savePrefs(): void {
   try {
-    localStorage.setItem(PREFS_KEY, JSON.stringify({ width: panelWidth, collapsed, sort: filters.sort }));
+    localStorage.setItem(PREFS_KEY, JSON.stringify({ width: panelWidth, height: panelHeight, left: panelLeft, top: panelTop, collapsed, sort: filters.sort }));
   } catch { /* ignore */ }
 }
 
@@ -274,10 +345,91 @@ function startResize(event: PointerEvent): void {
   const onMove = (ev: PointerEvent) => {
     if (!panelEl || !state.container) return;
     const rect = state.container.getBoundingClientRect();
-    const rightEdge = rect.right - PANE_RIGHT;
-    const width = clamp(rightEdge - ev.clientX, 260, Math.max(260, rect.width - 420));
+    const width = isVsCodeHost()
+      ? clamp(ev.clientX - rect.left - PANE_LEFT, 260, Math.max(260, rect.width - 420))
+      : clamp(rect.right - PANE_RIGHT - ev.clientX, 260, Math.max(260, rect.width - 420));
     panelWidth = width;
     panelEl.style.width = `${width}px`;
+  };
+  const onUp = () => {
+    handle.classList.remove("dragging");
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    savePrefs();
+  };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+}
+
+function startHeightResize(event: PointerEvent): void {
+  if (!panelEl || !state.container) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const handle = event.currentTarget as HTMLElement;
+  handle.classList.add("dragging");
+  try { handle.setPointerCapture(event.pointerId); } catch { /* ignore */ }
+  const onMove = (ev: PointerEvent) => {
+    if (!panelEl || !state.container) return;
+    const pane = panelEl.getBoundingClientRect();
+    const container = state.container.getBoundingClientRect();
+    const height = clamp(ev.clientY - pane.top, 320, Math.max(320, container.bottom - pane.top - 16));
+    panelHeight = height;
+    panelEl.style.height = `${height}px`;
+  };
+  const onUp = () => {
+    handle.classList.remove("dragging");
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    savePrefs();
+  };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+}
+
+function startPanelDrag(event: PointerEvent): void {
+  if (!panelEl || !state.container || !isVsCodeHost()) return;
+  const target = event.target as HTMLElement | null;
+  if (target?.closest("button,input,select,textarea,a")) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const pane = panelEl.getBoundingClientRect();
+  const offsetX = event.clientX - pane.left;
+  const offsetY = event.clientY - pane.top;
+  const onMove = (ev: PointerEvent) => {
+    if (!panelEl || !state.container) return;
+    const bounds = state.container.getBoundingClientRect();
+    const box = panelEl.getBoundingClientRect();
+    panelLeft = clamp(ev.clientX - bounds.left - offsetX, 8, Math.max(8, bounds.width - box.width - 8));
+    panelTop = clamp(ev.clientY - bounds.top - offsetY, 8, Math.max(8, bounds.height - box.height - 8));
+    panelEl.style.left = `${panelLeft}px`;
+    panelEl.style.right = "auto";
+    panelEl.style.top = `${panelTop}px`;
+  };
+  const onUp = () => {
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    savePrefs();
+  };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+}
+
+function startCornerResize(event: PointerEvent): void {
+  if (!panelEl || !state.container) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const handle = event.currentTarget as HTMLElement;
+  handle.classList.add("dragging");
+  const onMove = (ev: PointerEvent) => {
+    if (!panelEl || !state.container) return;
+    const pane = panelEl.getBoundingClientRect();
+    const container = state.container.getBoundingClientRect();
+    panelWidth = isVsCodeHost()
+      ? clamp(ev.clientX - pane.left, 260, Math.max(260, container.right - pane.left - 16))
+      : clamp(pane.right - ev.clientX, 260, Math.max(260, pane.right - container.left - 16));
+    panelHeight = clamp(ev.clientY - pane.top, 320, Math.max(320, container.bottom - pane.top - 16));
+    panelEl.style.width = `${panelWidth}px`;
+    panelEl.style.height = `${panelHeight}px`;
   };
   const onUp = () => {
     handle.classList.remove("dragging");
@@ -412,10 +564,12 @@ function matchesFilters(node: RuntimeNode): boolean {
 
 function rowHtml(node: RuntimeNode): string {
   const hasActions = state.itemActionCallbacks.length > 0;
+  const editing = !selectMode && editingId === node.id;
   const active = !selectMode && state.selectedNodeId === node.id ? " active" : "";
   const isPicked = selectMode && picked.has(node.id) ? " picked" : "";
   const dotColor = node.kind === "task" ? node.baseColor : HEALTH_COLOR[node.health] || "#8b96c9";
   const label = node.fullLabel || node.label || node.id;
+  const preview = node.label || label;
   const chip = node.kind === "task"
     ? (node.section || "task")
     : (node.topicLabel || node.topicSlug || node.health);
@@ -429,16 +583,33 @@ function rowHtml(node: RuntimeNode): string {
   const del = !selectMode && hasActions
     ? `<span class="phren-pp-del" data-pp-del title="Delete this ${esc(node.kind)}">🗑</span>`
     : "";
+  const taskFields = node.kind === "task"
+    ? `<div class="phren-pp-inline-fields">`
+      + `<label>Status<select data-pp-section>`
+      + ["Queue", "Active", "Done"].map((value) => `<option value="${value}"${node.section === value ? " selected" : ""}>${value}</option>`).join("")
+      + `</select></label>`
+      + `<label>Priority<select data-pp-priority>`
+      + [["", "None"], ["high", "High"], ["medium", "Medium"], ["low", "Low"]].map(([value, text]) => `<option value="${value}"${(node.priority || "") === value ? " selected" : ""}>${text}</option>`).join("")
+      + `</select></label></div>`
+    : `<div class="phren-pp-inline-meta"><span>Topic · ${esc(node.topicLabel || node.topicSlug || "General")}</span><span>Health · ${esc(node.health)}</span></div>`;
+  const inlineEditor = editing
+    ? `<div class="phren-pp-inline-editor" data-pp-editor>`
+      + `<textarea data-pp-text aria-label="Edit ${esc(node.kind)} text">${esc(label)}</textarea>`
+      + taskFields
+      + `<div class="phren-pp-inline-actions"><button type="button" data-pp-cancel>Cancel</button><button type="button" data-pp-save>Save</button></div>`
+      + `</div>`
+    : `<span class="phren-pp-rowdetail">${esc(label)}</span>`;
   return (
-    `<button type="button" class="phren-pp-row${active}${isPicked}" data-node-id="${esc(node.id)}" title="${esc(label)}">` +
+    `<div class="phren-pp-row${active}${isPicked}${editing ? " editing" : ""}" data-node-id="${esc(node.id)}" role="button" tabindex="0" aria-expanded="${Boolean(active || editing)}" title="${esc(label)}">` +
     check +
     `<span class="phren-pp-dot" style="background:${esc(dotColor)};color:${esc(dotColor)}"></span>` +
-    `<span class="phren-pp-rowlabel">${esc(label)}</span>` +
+    `<span class="phren-pp-rowlabel">${esc(preview)}</span>` +
     `<span class="phren-pp-rowchip">${esc(chip)}</span>` +
     peek +
     edit +
     del +
-    `</button>`
+    inlineEditor +
+    `</div>`
   );
 }
 
@@ -461,11 +632,11 @@ function renderList(): void {
   }
   let html = "";
   if (findings.length) {
-    html += `<div class="phren-pp-group">Findings · ${findings.length}</div>`;
+    html += `<div class="phren-pp-group"><span class="phren-pp-group-label">Findings</span><span class="phren-pp-group-count">${findings.length}</span></div>`;
     html += findings.map(rowHtml).join("");
   }
   if (tasks.length) {
-    html += `<div class="phren-pp-group">Tasks · ${tasks.length}</div>`;
+    html += `<div class="phren-pp-group"><span class="phren-pp-group-label">Tasks</span><span class="phren-pp-group-count">${tasks.length}</span></div>`;
     html += tasks.map(rowHtml).join("");
   }
   listEl.innerHTML = html;
@@ -499,6 +670,12 @@ function renderBulkBar(): void {
   // Merge is offered only for exactly two same-project findings.
   const merge = bar.querySelector<HTMLButtonElement>("[data-pp-bulk-merge]");
   if (merge) merge.toggleAttribute("hidden", !mergeEligible());
+  const allButton = bar.querySelector<HTMLButtonElement>("[data-pp-bulk-all]");
+  if (allButton) {
+    const visibleIds = rowIdsInOrder();
+    const allVisiblePicked = visibleIds.length > 0 && visibleIds.every((id) => picked.has(id));
+    allButton.textContent = allVisiblePicked ? "Unselect all" : "Select all";
+  }
 }
 
 /** True when the current picks are exactly two findings in the same project. */
@@ -565,7 +742,9 @@ function ensurePanelEl(): void {
         return;
       }
       if (target?.closest("[data-pp-bulk-all]")) {
-        rowIdsInOrder().forEach((rid) => picked.add(rid));
+        const visibleIds = rowIdsInOrder();
+        const allVisiblePicked = visibleIds.length > 0 && visibleIds.every((rid) => picked.has(rid));
+        visibleIds.forEach((rid) => allVisiblePicked ? picked.delete(rid) : picked.add(rid));
         renderCurrentList();
         renderBulkBar();
         return;
@@ -599,6 +778,24 @@ function ensurePanelEl(): void {
       if (!row) return;
       const id = row.getAttribute("data-node-id");
       if (!id) return;
+      if (target?.closest("[data-pp-cancel]")) {
+        editingId = null;
+        renderCurrentList();
+        return;
+      }
+      if (target?.closest("[data-pp-save]")) {
+        const detail = nodeDetail(id);
+        const text = row.querySelector<HTMLTextAreaElement>("[data-pp-text]")?.value.trim() ?? "";
+        if (!detail || !text) return;
+        detail.editedText = text;
+        detail.editedSection = row.querySelector<HTMLSelectElement>("[data-pp-section]")?.value;
+        detail.editedPriority = row.querySelector<HTMLSelectElement>("[data-pp-priority]")?.value;
+        editingId = null;
+        state.itemActionCallbacks.forEach((cb) => cb(detail, "save-inline"));
+        renderCurrentList();
+        return;
+      }
+      if (target?.closest("[data-pp-editor]")) return;
       // Select mode: clicking a row toggles its pick instead of flying to it.
       if (selectMode) {
         if (picked.has(id)) picked.delete(id);
@@ -614,8 +811,10 @@ function ensurePanelEl(): void {
         return;
       }
       if (target?.closest("[data-pp-edit]")) {
-        const detail = nodeDetail(id);
-        if (detail) state.itemActionCallbacks.forEach((cb) => cb(detail, "edit"));
+        editingId = id;
+        cursorId = id;
+        renderCurrentList();
+        panelEl?.querySelector<HTMLTextAreaElement>(`[data-node-id="${CSS.escape(id)}"] [data-pp-text]`)?.focus();
         return;
       }
       if (target?.closest("[data-pp-del]")) {
@@ -624,11 +823,13 @@ function ensurePanelEl(): void {
         return;
       }
       cursorId = id;
+      editingId = null;
       selectNode(id);
     });
     // Keyboard review: ↑/↓ move a cursor row, Enter flies to it, Delete prunes.
     // Works whenever focus is inside the pane (its filter input or a row button).
     panelEl.addEventListener("keydown", (event) => {
+      if ((event.target as HTMLElement | null)?.closest("[data-pp-editor]")) return;
       if (event.key === "ArrowDown") { moveCursor(1); event.preventDefault(); }
       else if (event.key === "ArrowUp") { moveCursor(-1); event.preventDefault(); }
       else if (event.key === "Enter" && cursorId) { selectNode(cursorId); event.preventDefault(); }
@@ -651,23 +852,25 @@ function buildPanel(projectId: string): void {
   const projectName = project ? project.label || project.project || project.id : "";
   const all = project ? projectItems(project.project || project.id) : [];
   const findingItems = all.filter((n) => n.kind === "finding");
-  const findingCount = findingItems.length;
-  const taskCount = all.length - findingCount;
+  const loadedFindingCount = findingItems.length;
+  const findingCount = typeof project?.findingCount === "number" ? project.findingCount : loadedFindingCount;
+  const loadedTaskCount = all.length - loadedFindingCount;
+  const taskCount = typeof project?.taskCount === "number" ? project.taskCount : loadedTaskCount;
 
   // Memory-health tally across the project's findings — a stacked bar plus a
   // clickable key so aging memory is visible (and filterable) at a glance.
   const health = { healthy: 0, decaying: 0, stale: 0 };
   for (const f of findingItems) health[f.health]++;
-  const total = findingCount || 1;
+  const total = loadedFindingCount || 1;
   const seg = (n: number, color: string) => (n ? `<span style="width:${(n / total) * 100}%;background:${color}"></span>` : "");
-  const healthBar = findingCount
+  const healthBar = loadedFindingCount
     ? `<div class="phren-pp-health" title="${health.healthy} healthy · ${health.decaying} decaying · ${health.stale} stale">`
       + seg(health.healthy, HEALTH_COLOR.healthy) + seg(health.decaying, HEALTH_COLOR.decaying) + seg(health.stale, HEALTH_COLOR.stale)
       + "</div>"
       + '<div class="phren-pp-healthkey">'
-      + `<button type="button" data-pp-health-key="healthy"><i style="background:${HEALTH_COLOR.healthy}"></i>${health.healthy} healthy</button>`
-      + `<button type="button" data-pp-health-key="decaying"><i style="background:${HEALTH_COLOR.decaying}"></i>${health.decaying} decaying</button>`
-      + `<button type="button" data-pp-health-key="stale"><i style="background:${HEALTH_COLOR.stale}"></i>${health.stale} stale</button>`
+      + `<button type="button" class="${filters.health === "healthy" ? "active" : ""}" aria-pressed="${filters.health === "healthy"}" data-pp-health-key="healthy"><i style="background:${HEALTH_COLOR.healthy}"></i>${health.healthy} healthy</button>`
+      + `<button type="button" class="${filters.health === "decaying" ? "active" : ""}" aria-pressed="${filters.health === "decaying"}" data-pp-health-key="decaying"><i style="background:${HEALTH_COLOR.decaying}"></i>${health.decaying} decaying</button>`
+      + `<button type="button" class="${filters.health === "stale" ? "active" : ""}" aria-pressed="${filters.health === "stale"}" data-pp-health-key="stale"><i style="background:${HEALTH_COLOR.stale}"></i>${health.stale} stale</button>`
       + "</div>"
     : "";
 
@@ -680,14 +883,16 @@ function buildPanel(projectId: string): void {
     }),
     '<div class="phren-pp-controls">',
     `<input type="text" class="phren-pp-search" data-pp-search placeholder="Filter in project…" value="${esc(filters.query)}" />`,
-    '<div class="phren-pp-chips">',
-    `<span class="phren-pp-chip${filters.kind === "all" ? " on" : ""}" data-pp-chip data-kind="all">All</span>`,
-    `<span class="phren-pp-chip${filters.kind === "finding" ? " on" : ""}" data-pp-chip data-kind="finding">Findings</span>`,
-    `<span class="phren-pp-chip${filters.kind === "task" ? " on" : ""}" data-pp-chip data-kind="task">Tasks</span>`,
-    `<span class="phren-pp-chip${filters.health === "aging" ? " on" : ""}" data-pp-chip data-health="aging" title="Show only decaying or stale">⚠ Aging</span>`,
+    '<div class="phren-pp-chips" aria-label="Content filters">',
+    `<button type="button" class="phren-pp-chip${filters.kind === "all" ? " on" : ""}" aria-pressed="${filters.kind === "all"}" data-pp-chip data-kind="all">All</button>`,
+    `<button type="button" class="phren-pp-chip${filters.kind === "finding" ? " on" : ""}" aria-pressed="${filters.kind === "finding"}" data-pp-chip data-kind="finding">Findings</button>`,
+    `<button type="button" class="phren-pp-chip${filters.kind === "task" ? " on" : ""}" aria-pressed="${filters.kind === "task"}" data-pp-chip data-kind="task">Tasks</button>`,
+    `<button type="button" class="phren-pp-chip${filters.health === "aging" ? " on" : ""}" aria-pressed="${filters.health === "aging"}" data-pp-chip data-health="aging" title="Show only decaying or stale">⚠ Aging</button>`,
     state.itemActionCallbacks.length
-      ? `<span class="phren-pp-chip${selectMode ? " on" : ""}" data-pp-select title="Select multiple to delete">☑ Select</span>`
+      ? `<button type="button" class="phren-pp-chip${selectMode ? " on" : ""}" aria-pressed="${selectMode}" data-pp-select title="Select multiple items">Select</button>`
       : "",
+    "</div>",
+    '<div class="phren-pp-tools">',
     `<select class="phren-pp-sort" data-pp-sort aria-label="Sort items" title="Sort">`,
     `<option value="aging"${filters.sort === "aging" ? " selected" : ""}>Aging first</option>`,
     `<option value="recent"${filters.sort === "recent" ? " selected" : ""}>Recent</option>`,
@@ -722,18 +927,49 @@ function buildPanel(projectId: string): void {
   syncActiveRow();
 }
 
-/** A resize handle + saved width, shared by the project and fragment panels. */
+/** Independent resize handles + saved dimensions, shared by every pane mode. */
 function attachResizeAndWidth(): void {
   if (!panelEl || !state.container) return;
   if (panelWidth) {
     const cw = state.container.getBoundingClientRect().width;
     panelEl.style.width = `${clamp(panelWidth, 260, Math.max(260, cw - 420))}px`;
   }
+  if (panelHeight) {
+    const ch = state.container.getBoundingClientRect().height;
+    panelEl.style.height = `${clamp(panelHeight, 320, Math.max(320, ch - 80))}px`;
+  }
   const resize = document.createElement("div");
   resize.className = "phren-pp-resize";
   resize.setAttribute("aria-hidden", "true");
   resize.addEventListener("pointerdown", startResize);
   panelEl.appendChild(resize);
+  const resizeY = document.createElement("div");
+  resizeY.className = "phren-pp-resize-y";
+  resizeY.setAttribute("role", "separator");
+  resizeY.setAttribute("aria-orientation", "horizontal");
+  resizeY.setAttribute("aria-label", "Resize pane height");
+  resizeY.addEventListener("pointerdown", startHeightResize);
+  panelEl.appendChild(resizeY);
+  const resizeXY = document.createElement("div");
+  resizeXY.className = "phren-pp-resize-xy";
+  resizeXY.setAttribute("role", "separator");
+  resizeXY.setAttribute("aria-label", "Resize pane width and height");
+  resizeXY.addEventListener("pointerdown", startCornerResize);
+  panelEl.appendChild(resizeXY);
+  panelEl.querySelector<HTMLElement>(".phren-pp-head")?.addEventListener("pointerdown", startPanelDrag);
+}
+
+/** Keep the working pane in one predictable place instead of chasing nodes. */
+function positionPaneBesideNode(_nodeId: string): void {
+  if (!panelEl) return;
+  if (isVsCodeHost()) {
+    panelEl.style.left = `${panelLeft ?? 16}px`;
+    panelEl.style.right = "auto";
+  } else {
+    panelEl.style.left = "auto";
+    panelEl.style.right = "58px";
+  }
+  panelEl.style.top = `${isVsCodeHost() ? panelTop ?? 64 : 64}px`;
 }
 
 /** Render the pane for a fragment (entity): its connected projects + references. */
@@ -852,9 +1088,9 @@ function buildReviewPanel(): void {
     }),
     '<div class="phren-pp-controls">',
     `<input type="text" class="phren-pp-search" data-pp-search placeholder="Filter aging findings…" value="${esc(filters.query)}" />`,
-    '<div class="phren-pp-chips">',
+    '<div class="phren-pp-tools">',
     state.itemActionCallbacks.length
-      ? `<span class="phren-pp-chip${selectMode ? " on" : ""}" data-pp-select title="Select multiple to delete">☑ Select</span>`
+      ? `<button type="button" class="phren-pp-chip${selectMode ? " on" : ""}" aria-pressed="${selectMode}" data-pp-select title="Select multiple items">Select</button>`
       : "",
     "</div>",
     "</div>",
@@ -887,6 +1123,7 @@ function applyChip(chip: HTMLElement): void {
     const elHealth = el.getAttribute("data-health");
     const on = elHealth === "aging" ? filters.health === "aging" : el.getAttribute("data-kind") === filters.kind;
     el.classList.toggle("on", on);
+    el.setAttribute("aria-pressed", String(on));
   });
   renderList();
 }
@@ -924,9 +1161,13 @@ function syncActiveRow(): void {
   if (!panelEl) return;
   let active: HTMLElement | null = null;
   panelEl.querySelectorAll<HTMLElement>("[data-node-id]").forEach((row) => {
-    const on = row.getAttribute("data-node-id") === state.selectedNodeId;
+    const id = row.getAttribute("data-node-id");
+    const on = id === state.selectedNodeId;
+    const editing = id === editingId;
     row.classList.toggle("active", on);
-    if (on) active = row;
+    row.classList.toggle("editing", editing);
+    row.setAttribute("aria-expanded", String(on || editing));
+    if (on || editing) active = row;
   });
   (active as HTMLElement | null)?.scrollIntoView({ block: "nearest" });
 }
@@ -936,9 +1177,20 @@ function syncActiveRow(): void {
  * fully (re)build when the context project changes, else just move the active
  * row highlight. Cheap enough to call on every selection / filter change.
  */
-export function refreshProjectPanel(opts?: { data?: boolean }): void {
+export function refreshProjectPanel(opts?: { data?: boolean; transitioning?: boolean; forceOpen?: boolean }): void {
   if (!state.container) return;
   loadPrefs();
+
+  if (opts?.transitioning) {
+    panelEl?.setAttribute("hidden", "");
+    hideReopenTab();
+    setLegendHidden(false);
+    return;
+  }
+  if (opts?.forceOpen) {
+    collapsed = false;
+    savePrefs();
+  }
 
   // Focusing a project exits the global review pane.
   if (reviewMode && state.focusedProjectId) reviewMode = false;
@@ -996,6 +1248,7 @@ export function refreshProjectPanel(opts?: { data?: boolean }): void {
       buildFragmentPanel(ctx.id);
     }
     panelEl?.removeAttribute("hidden");
+    positionPaneBesideNode(state.selectedNodeId || ctx.id);
     syncActiveRow();
     return;
   }
@@ -1006,9 +1259,11 @@ export function refreshProjectPanel(opts?: { data?: boolean }): void {
     if (ctx.id !== renderedProjectId) { selectMode = false; picked.clear(); }
     buildPanel(ctx.id);
     panelEl?.removeAttribute("hidden");
+    positionPaneBesideNode(state.selectedNodeId || ctx.id);
     return;
   }
   panelEl.removeAttribute("hidden");
+  positionPaneBesideNode(state.selectedNodeId || ctx.id);
   // If a selected item of this project is being hidden by the kind/health
   // filters, relax them so the selection is never invisible in its own pane
   // (a query the user typed is left intact — that's explicit intent).

--- a/packages/cli/browser/graph/scene.ts
+++ b/packages/cli/browser/graph/scene.ts
@@ -6,7 +6,6 @@ import { ACCENT_AMBER, BG_COLOR } from "./types.js";
 import {
   buildVisibleData,
   currentTheme,
-  nodeRadius,
   rebuildHostNodes,
   recomputeSearchMatches,
   seeded,
@@ -18,7 +17,6 @@ import {
   disposeFocusHalos,
   ensureFocusHalos,
   glowTexture,
-  nodeWorldPos,
   ringTexture,
   tickNodes,
 } from "./nodes.js";
@@ -47,7 +45,6 @@ import { buildCages, disposeCages, setCageResolution } from "./cages.js";
 let starfield: THREE.Points | null = null;
 let nebula: THREE.Group | null = null;
 let ringSprite: THREE.Sprite | null = null;
-let ringPhase = 0;
 let bloomPass: UnrealBloomPass | null = null;
 let vignetteEl: HTMLElement | null = null;
 let labelRenderer: ReturnType<typeof createLabelRenderer> | null = null;
@@ -385,21 +382,9 @@ export function setupForceGraph(): void {
     labelTick(dt);
     tickIdleResume(timestamp);
 
-    if (ringSprite) {
-      const activeId = state.selectedNodeId || state.focusedProjectId;
-      const pos = activeId ? nodeWorldPos(activeId) : null;
-      const activeNode = activeId ? state.nodeById.get(activeId) : null;
-      if (pos && activeNode) {
-        ringSprite.visible = true;
-        ringSprite.position.copy(pos);
-        ringPhase = (ringPhase + dt * 0.6) % 1;
-        const baseR = nodeRadius(activeNode) || 8;
-        ringSprite.scale.setScalar(baseR * (1.6 + ringPhase * 3));
-        (ringSprite.material as THREE.SpriteMaterial).opacity = (1 - ringPhase) * 0.2;
-      } else {
-        ringSprite.visible = false;
-      }
-    }
+    // Selection is communicated by graph dimming and contextual UI. Do not
+    // draw an expanding ring around any selected node.
+    if (ringSprite) ringSprite.visible = false;
     mascotUpdate(dt);
   };
   state.ambientRafId = requestAnimationFrame(ambientTick);

--- a/packages/cli/browser/graph/types.ts
+++ b/packages/cli/browser/graph/types.ts
@@ -68,6 +68,10 @@ export type NodeDetail = RuntimeNode & {
     references: number;
   };
   score?: ScoreEntry;
+  /** Values supplied by the project pane's inline editor on save. */
+  editedText?: string;
+  editedSection?: string;
+  editedPriority?: string;
 };
 
 /** A node object handed to 3d-force-graph. Force layout mutates x/y/z/vx/vy/vz onto it. */

--- a/packages/cli/e2e/_vscode_assessment.spec.ts
+++ b/packages/cli/e2e/_vscode_assessment.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const html = path.resolve(here, "../../vscode/scratch/vscode-webview.html");
+const shots = process.env.SHOT_DIR || "/tmp/phren-vscode-assessment";
+
+test("graph UI layout and project workflow", async ({ page }) => {
+  fs.mkdirSync(shots, { recursive: true });
+  await page.goto(`file://${html}`, { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => (window as any).phrenGraph?.getData?.().nodes.length > 0);
+  await page.waitForTimeout(1_200);
+  await page.screenshot({ path: path.join(shots, "01-overview.png") });
+
+  const filter = page.locator("#graph-filter");
+  const controls = page.locator(".graph-controls");
+  const filterBox = (await filter.boundingBox())!;
+  const controlsBox = (await controls.boundingBox())!;
+  expect.soft(filterBox.x + filterBox.width).toBeLessThanOrEqual(controlsBox.x - 12);
+
+  await page.evaluate(() => (window as any).phrenGraph.selectNode("project:api-server"));
+  const panel = page.locator(".phren-project-panel");
+  await expect(panel).toBeVisible({ timeout: 5_000 });
+  await expect(panel.locator(".phren-pp-sub")).toContainText("71 findings · 4 tasks");
+  await page.waitForTimeout(1_000);
+  await page.screenshot({ path: path.join(shots, "02-project.png") });
+
+  const initial = (await panel.boundingBox())!;
+  expect(initial.x).toBeLessThanOrEqual(20);
+  expect(initial.height).toBeGreaterThanOrEqual(500);
+  expect(initial.width).toBeLessThanOrEqual(320);
+
+  const heightHandle = (await panel.locator(".phren-pp-resize-y").boundingBox())!;
+  await page.mouse.move(heightHandle.x + heightHandle.width / 2, heightHandle.y + heightHandle.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(heightHandle.x + heightHandle.width / 2, heightHandle.y + 70, { steps: 6 });
+  await page.mouse.up();
+  const taller = (await panel.boundingBox())!;
+  expect(taller.height).toBeGreaterThan(initial.height + 40);
+
+  const widthHandle = (await panel.locator(".phren-pp-resize").boundingBox())!;
+  await page.mouse.move(widthHandle.x + widthHandle.width / 2, widthHandle.y + 30);
+  await page.mouse.down();
+  await page.mouse.move(widthHandle.x + 90, widthHandle.y + 30, { steps: 6 });
+  await page.mouse.up();
+  const wider = (await panel.boundingBox())!;
+  expect(wider.width).toBeGreaterThan(taller.width + 50);
+  expect(Math.abs(wider.height - taller.height)).toBeLessThanOrEqual(2);
+
+  const corner = (await panel.locator(".phren-pp-resize-xy").boundingBox())!;
+  await page.mouse.move(corner.x + corner.width / 2, corner.y + corner.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(corner.x + 45, corner.y + 45, { steps: 5 });
+  await page.mouse.up();
+  const diagonal = (await panel.boundingBox())!;
+  expect(diagonal.width).toBeGreaterThan(wider.width + 25);
+  expect(diagonal.height).toBeGreaterThan(wider.height + 25);
+
+  const head = (await panel.locator(".phren-pp-head").boundingBox())!;
+  await page.mouse.move(head.x + 90, head.y + 20);
+  await page.mouse.down();
+  await page.mouse.move(head.x + 130, head.y + 50, { steps: 6 });
+  await page.mouse.up();
+  await page.waitForTimeout(220);
+  const movedPane = (await panel.boundingBox())!;
+  expect(movedPane.x).toBeGreaterThan(diagonal.x + 25);
+  expect(movedPane.y).toBeGreaterThan(diagonal.y + 15);
+
+  const findingsFilter = panel.locator('[data-pp-chip][data-kind="finding"]');
+  await findingsFilter.click();
+  await expect(findingsFilter).toHaveAttribute("aria-pressed", "true");
+  await expect(findingsFilter).toHaveClass(/on/);
+
+  const firstRow = panel.locator(".phren-pp-row").first();
+  await firstRow.click();
+  await page.waitForTimeout(900);
+  await expect(page.locator("#node-popover")).toBeHidden();
+  await expect(firstRow).toHaveAttribute("aria-expanded", "true");
+  await expect(firstRow.locator(".phren-pp-rowdetail")).toBeVisible();
+  await expect(firstRow.locator(".phren-pp-rowdetail")).toContainText("representative memory");
+  const selectedBox = (await panel.boundingBox())!;
+  expect(Math.abs(selectedBox.x - movedPane.x)).toBeLessThanOrEqual(1);
+  expect(Math.abs(selectedBox.y - movedPane.y)).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: path.join(shots, "03-selected.png") });
+
+  await firstRow.hover();
+  await firstRow.locator("[data-pp-edit]").click();
+  const inlineEditor = firstRow.locator("[data-pp-editor]");
+  await expect(inlineEditor).toBeVisible();
+  await expect(page.locator("#node-popover")).toBeHidden();
+  await expect(inlineEditor.locator(".phren-pp-inline-meta")).toContainText("Topic");
+  await inlineEditor.locator("[data-pp-text]").fill("Updated finding entirely inside the project pane");
+  await inlineEditor.locator("[data-pp-save]").click();
+  await expect(inlineEditor).toBeHidden();
+  await expect.poll(async () => page.evaluate(() => (window as any).__phrenPostedMessages.at(-1)?.command)).toBe("saveFindingEdit");
+
+  const selectButton = panel.locator("[data-pp-select]");
+  await selectButton.click();
+  const selectAll = panel.locator("[data-pp-bulk-all]");
+  await selectAll.click();
+  await expect(selectAll).toHaveText("Unselect all");
+  await selectAll.click();
+  await expect(selectAll).toHaveText("Select all");
+  await panel.locator("[data-pp-bulk-done]").click();
+
+  const taskFilter = panel.locator('[data-pp-chip][data-kind="task"]');
+  await taskFilter.click();
+  const firstTask = panel.locator('.phren-pp-row').first();
+  await firstTask.hover();
+  await firstTask.locator('[data-pp-edit]').click();
+  await firstTask.locator('[data-pp-section]').selectOption('Active');
+  await firstTask.locator('[data-pp-priority]').selectOption('high');
+  await firstTask.locator('[data-pp-save]').click();
+  await expect.poll(async () => page.evaluate(() => (window as any).__phrenPostedMessages.at(-1)?.command)).toBe("saveTaskEdit");
+  await expect(page.locator("#node-popover")).toBeHidden();
+  await page.screenshot({ path: path.join(shots, "04-edit.png") });
+});

--- a/packages/cli/e2e/graph.spec.ts
+++ b/packages/cli/e2e/graph.spec.ts
@@ -1179,7 +1179,7 @@ test.describe.serial("graph visualization e2e", () => {
     expect(after).toBeGreaterThan(before + 60);
   });
 
-  test("row edit action opens the dossier editor for that finding", async ({ page }) => {
+  test("row edit action stays inline in the project pane", async ({ page }) => {
     await openGraphTab(page);
     // Select a project that has findings, so the pane lists editable rows.
     const projectId = await selectNodeOfKind(page, "project");
@@ -1189,8 +1189,8 @@ test.describe.serial("graph visualization e2e", () => {
     const row = panel.locator('.phren-pp-row').filter({ has: page.locator("[data-pp-edit]") }).first();
     await row.hover();
     await row.locator("[data-pp-edit]").click();
-    // The dossier opens in edit mode (its textarea appears).
-    await expect(page.locator("#graph-node-editor")).toBeVisible({ timeout: 8_000 });
+    await expect(row.locator("[data-pp-editor]")).toBeVisible({ timeout: 8_000 });
+    await expect(page.locator("#graph-node-editor")).toBeHidden();
   });
 
   test("row peek flies to a node without changing selection", async ({ page }) => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phren/cli",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Knowledge layer for AI agents — CLI, MCP server, and data layer",
   "type": "module",
   "bin": {

--- a/packages/cli/src/ui/scripts.ts
+++ b/packages/cli/src/ui/scripts.ts
@@ -2694,20 +2694,41 @@ export function renderGraphHostScript(): string {
     deleteNode(currentNode);
   }
 
-  // Open the dossier in edit mode for a finding/task chosen in the contents pane.
-  function editNodeFromPane(node) {
+  // Persist edits made directly inside the project pane. The pane owns the
+  // editor; the host only performs the mutation and updates the rendered node.
+  function saveInlineFromPane(node) {
     if (!node || (node.kind !== 'finding' && node.kind !== 'task')) return;
-    var api = graphApi();
-    if (api && api.selectNode) api.selectNode(node.id);
-    setTimeout(function() {
-      if (currentNode && currentNode.id === node.id) {
-        editMode = currentNode.kind === 'task' ? 'task' : 'finding';
-        var point = currentPopoverPoint();
-        renderPopover(currentNode, point.x, point.y);
-        var editor = document.getElementById('graph-node-editor');
-        if (editor) editor.focus();
-      }
-    }, 220);
+    var nextText = (node.editedText || '').trim();
+    if (!nextText) return;
+    if (node.kind === 'finding') {
+      graphRequest('/api/findings/' + encodeURIComponent(node.projectName), 'PUT', {
+        old_text: node.tooltipLabel || node.fullLabel || '',
+        new_text: nextText,
+        score_key: node.scoreKey || ''
+      }).then(function(result) {
+        if (!result || !result.ok) throw new Error(result && result.error ? result.error : 'Save failed');
+        var api = graphApi();
+        if (api && api.updateNode) api.updateNode(node.id, { text: nextText });
+        graphToast('Finding updated', 'ok');
+      }).catch(function(err) { graphToast('Update failed: ' + err.message, 'err'); });
+      return;
+    }
+    graphRequest('/api/tasks/update', 'POST', {
+      project: node.projectName,
+      item: node.stableId || node.id || node.tooltipLabel || node.fullLabel || node.displayLabel || '',
+      text: nextText,
+      section: node.editedSection || node.section || 'Queue',
+      priority: typeof node.editedPriority === 'string' ? node.editedPriority : (node.priority || '')
+    }).then(function(result) {
+      if (!result || !result.ok) throw new Error(result && result.error ? result.error : 'Save failed');
+      var api = graphApi();
+      if (api && api.updateNode) api.updateNode(node.id, {
+        text: nextText,
+        section: node.editedSection || node.section || 'Queue',
+        priority: typeof node.editedPriority === 'string' ? node.editedPriority : (node.priority || '')
+      });
+      graphToast('Task updated', 'ok');
+    }).catch(function(err) { graphToast('Update failed: ' + err.message, 'err'); });
   }
 
   function completeCurrentTask() {
@@ -2829,7 +2850,7 @@ export function renderGraphHostScript(): string {
       api.onItemAction(function(payload, action) {
         if (action === 'delete') deleteNode(payload);
         else if (action === 'delete-batch') deleteNodes(payload);
-        else if (action === 'edit') editNodeFromPane(payload);
+        else if (action === 'save-inline') saveInlineFromPane(payload);
         else if (action === 'merge') mergeNodes(payload);
       });
     }

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -2,4 +2,5 @@
 .vscode-test/**
 node_modules/**
 src/**
+scratch/**
 tsconfig.json

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "phren-vscode",
   "displayName": "Phren",
   "description": "Browse, search, and manage Phren knowledge directly from VS Code.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "publisher": "alaarab",
   "author": "Ala Arab",
   "license": "MIT",

--- a/packages/vscode/scratch/render-webview.mjs
+++ b/packages/vscode/scratch/render-webview.mjs
@@ -43,7 +43,7 @@ const entries = {};
 const ages = [4, 20, 80, 120, 220, 320];
 let k = 0;
 for (const proj of ["api-server", "web-app"]) {
-  nodes.push({ id: "project:" + proj, kind: "project", projectName: proj, label: proj, text: proj + " summary", subtype: "project", radius: 20, color: "#7B68AE" });
+  nodes.push({ id: "project:" + proj, kind: "project", projectName: proj, label: proj, text: proj + " summary", subtype: "project", radius: 20, color: "#7B68AE", findingCount: proj === "api-server" ? 71 : 12, taskCount: 4 });
   for (let i = 0; i < 12; i++) {
     const [slug, tlabel] = topics[i % topics.length];
     const id = "finding:" + proj + ":" + i;
@@ -73,8 +73,8 @@ let html = renderGraphHtmlForTests(payload);
 // Relax CSP + stub the VS Code API so the inline scripts run in a plain browser.
 html = html.replace(/<meta http-equiv="Content-Security-Policy"[^>]*>/, "");
 html = html.replace(
-  "<body>",
-  "<body>\n<script>window.acquireVsCodeApi=function(){return {postMessage:function(){},getState:function(){return {}},setState:function(){}}};</script>",
+  '<body class="phren-vscode-webview">',
+  '<body class="phren-vscode-webview">\n<script>window.__phrenPostedMessages=[];window.acquireVsCodeApi=function(){return {postMessage:function(message){window.__phrenPostedMessages.push(message)},getState:function(){return {}},setState:function(){}}};</script>',
 );
 fs.writeFileSync(outHtml, html);
 console.log("WROTE " + outHtml + " (" + html.length + " bytes)");

--- a/packages/vscode/src/graphWebview.ts
+++ b/packages/vscode/src/graphWebview.ts
@@ -74,6 +74,11 @@ interface FindingData {
   topicLabel: string;
 }
 
+interface FindingPage {
+  findings: FindingData[];
+  total: number;
+}
+
 interface TaskData {
   id: string;
   line: string;
@@ -116,6 +121,8 @@ interface GraphNode {
   taskItemId?: string;
   checked?: boolean;
   store?: string;
+  findingCount?: number;
+  taskCount?: number;
 }
 
 interface GraphEdge {
@@ -635,11 +642,12 @@ async function loadGraphData(client: PhrenClient): Promise<GraphPayload> {
   const edges: GraphEdge[] = [];
   const summaryMap: Record<string, ProjectSummaryData> = {};
   // Build project nodes (skip empty orphans)
-  for (const { projectName, summary, findings, tasks, topicConfig, store } of perProjectResults) {
-    if (findings.length === 0 && tasks.length === 0) continue;
+  for (const { projectName, summary, findings: findingPage, tasks, topicConfig, store } of perProjectResults) {
+    const findings = findingPage.findings;
+    if (findingPage.total === 0 && tasks.length === 0) continue;
 
     const projectNodeId = `project:${projectName}`;
-    summaryMap[projectName] = { ...summary, findingCount: findings.length, taskCount: tasks.length };
+    summaryMap[projectName] = { ...summary, findingCount: findingPage.total, taskCount: tasks.length };
 
     nodes.push({
       id: projectNodeId,
@@ -648,9 +656,11 @@ async function loadGraphData(client: PhrenClient): Promise<GraphPayload> {
       label: projectName,
       subtype: "project",
       text: summary.summary,
-      radius: Math.min(14 + Math.sqrt(findings.length + tasks.length) * 1.5, 30),
+      radius: Math.min(14 + Math.sqrt(findingPage.total + tasks.length) * 1.5, 30),
       color: "#7B68AE",
       store,
+      findingCount: findingPage.total,
+      taskCount: tasks.length,
     });
 
     // Finding nodes
@@ -840,7 +850,7 @@ async function fetchProjectSummary(client: PhrenClient, project: string): Promis
   };
 }
 
-async function fetchFindings(client: PhrenClient, project: string, projectTopics?: TopicMeta[]): Promise<FindingData[]> {
+async function fetchFindings(client: PhrenClient, project: string, projectTopics?: TopicMeta[]): Promise<FindingPage> {
   const raw = await client.getFindings(project);
   const data = responseData(raw);
   const parsed: FindingData[] = [];
@@ -859,7 +869,8 @@ async function fetchFindings(client: PhrenClient, project: string, projectTopics
       topicLabel: topic.label,
     });
   }
-  return parsed;
+  const total = typeof data?.total === "number" && Number.isFinite(data.total) ? data.total : undefined;
+  return { findings: parsed, total: total === undefined ? parsed.length : total };
 }
 
 async function fetchTopicConfig(client: PhrenClient, project: string): Promise<TopicMeta[]> {
@@ -1131,7 +1142,7 @@ function renderGraphHtml(webview: vscode.Webview, payload: GraphPayload): string
     #graph-filter {
       position: absolute;
       top: 12px;
-      right: 58px;
+      right: 70px;
       left: auto;
       width: min(560px, 60%);
       z-index: 12;
@@ -1211,7 +1222,8 @@ function renderGraphHtml(webview: vscode.Webview, payload: GraphPayload): string
       left: 0;
       top: 0;
       z-index: 20;
-      max-width: min(300px, calc(100% - 24px));
+      width: min(360px, calc(100% - 24px));
+      max-width: none;
       pointer-events: none;
     }
     /* The 3D canvas is immersive-dark in both editor themes; the popover,
@@ -1266,22 +1278,28 @@ function renderGraphHtml(webview: vscode.Webview, payload: GraphPayload): string
       place-items: center;
       z-index: 1;
     }
-    /* Docked reading pane: the card pins to the left edge instead of chasing
-       the cursor (which covered the node you just clicked). Mirrors the web-ui;
-       the contents pane docks to the right, so left = detail, right = list. */
+    /* Contextual reading card: placed after the camera settles, adjacent to
+       the selected node and project pane. The grab handle keeps it movable. */
     #node-popover.docked {
-      left: 12px;
-      top: 58px;
-      bottom: 12px;
+      bottom: auto;
       right: auto;
       width: min(360px, calc(100% - 24px));
       max-width: none;
     }
     #node-popover.docked #node-popover-card {
-      height: 100%;
+      height: auto;
+      max-height: min(520px, calc(100vh - 88px));
       overflow: auto;
     }
-    #node-popover.docked #node-popover-handle { display: none; }
+    #node-popover.docked #node-popover-handle { display: block; }
+    /* Edit transforms the same contextual card instead of spawning a second
+       surface in a remote corner. */
+    #node-popover.docked.editor { width:min(380px, calc(100% - 24px)); }
+    #node-popover.docked.editor #node-popover-card {
+      height: auto;
+      max-height: calc(100vh - 92px);
+      overflow: auto;
+    }
     #node-popover.docked .dossier-resize {
       position: absolute;
       right: -4px;
@@ -1441,7 +1459,7 @@ function renderGraphHtml(webview: vscode.Webview, payload: GraphPayload): string
     .graph-toast button:hover { background: var(--surface); }
   </style>
 </head>
-<body>
+<body class="phren-vscode-webview">
   <div id="graph-filter"></div>
   <div id="graph-project-filter"></div>
   <div id="graph-limit-row"></div>
@@ -1555,12 +1573,14 @@ ${graphScript}
       topicSlug: n.topicSlug || '',
       topicLabel: n.topicLabel || '',
       tagged: n.kind === 'finding',
-      store: n.store || ''
+      store: n.store || '',
+      findingCount: typeof n.findingCount === 'number' ? n.findingCount : undefined,
+      taskCount: typeof n.taskCount === 'number' ? n.taskCount : undefined
     });
   }
 
-  // Project totals for tooltips/labels — counted from the payload itself
-  // (the extension's node shape has no findingCount/taskCount fields).
+  // Project totals for tooltips/labels. Prefer API totals carried by project
+  // nodes; fall back to counting rendered nodes for older payloads.
   var projectTotals = {};
   for (var totalsIdx = 0; totalsIdx < graphNodes.length; totalsIdx++) {
     var totalsNode = graphNodes[totalsIdx];
@@ -1573,8 +1593,8 @@ ${graphScript}
     var projNode = graphNodes[projIdx];
     if (projNode.group !== 'project') continue;
     var projTotals = projectTotals[projNode.project || projNode.id] || { findings: 0, tasks: 0 };
-    projNode.findingCount = projTotals.findings;
-    projNode.taskCount = projTotals.tasks;
+    if (typeof projNode.findingCount !== 'number') projNode.findingCount = projTotals.findings;
+    if (typeof projNode.taskCount !== 'number') projNode.taskCount = projTotals.tasks;
   }
 
   var topics = [];
@@ -1644,6 +1664,8 @@ ${graphScript}
   var ctxMenu = document.getElementById('node-ctx-menu');
   var currentNode = null;
   var editMode = null;
+  var lastAnchorPoint = { x: 0, y: 0 };
+  var cardWasDragged = false;
 
   // --- Draggable popover ---
   var isDraggingPopover = false;
@@ -1653,6 +1675,7 @@ ${graphScript}
     popoverHandle.addEventListener('mousedown', function(e) {
       if (!popover) return;
       isDraggingPopover = true;
+      cardWasDragged = true;
       var container = document.querySelector('.graph-container');
       var containerRect = container ? container.getBoundingClientRect() : { left: 0, top: 0 };
       var popRect = popover.getBoundingClientRect();
@@ -1761,12 +1784,37 @@ ${graphScript}
   function positionPopover(x, y) {
     if (!popover || !popoverCard) return;
     popover.classList.add('docked');
-    popover.style.left = '';
-    popover.style.top = '';
+    popover.classList.toggle('editor', Boolean(editMode));
     popover.setAttribute('aria-hidden', 'false');
-    popover.style.visibility = 'visible';
+    popover.style.visibility = 'hidden';
     popover.style.display = 'block';
     ensureDossierResize();
+    if (cardWasDragged && popover.style.left && popover.style.top) {
+      popover.style.visibility = 'visible';
+      return;
+    }
+    var container = document.querySelector('.graph-container');
+    var bounds = container ? container.getBoundingClientRect() : { left: 0, top: 0, width: window.innerWidth, height: window.innerHeight };
+    var panel = document.querySelector('.phren-project-panel:not([hidden])');
+    var panelRect = panel ? panel.getBoundingClientRect() : null;
+    var cardRect = popover.getBoundingClientRect();
+    var width = cardRect.width || 360;
+    var height = cardRect.height || 260;
+    var paneRight = panelRect ? panelRect.right - bounds.left : 16;
+    var anchorX = x > 0 ? x : paneRight + width + 44;
+    var anchorY = y > 0 ? y : (panelRect ? panelRect.top - bounds.top + 180 : 240);
+    var gap = 26;
+    var leftOfNode = anchorX - width - gap;
+    var rightOfNode = anchorX + gap;
+    var left;
+    if (leftOfNode >= paneRight + 14) left = leftOfNode;
+    else if (rightOfNode + width <= bounds.width - 16) left = rightOfNode;
+    else left = Math.max(16, Math.min(bounds.width - width - 16, paneRight + 14));
+    var top = Math.max(64, Math.min(bounds.height - height - 16, anchorY - height / 2));
+    popover.style.left = left + 'px';
+    popover.style.top = top + 'px';
+    popover.style.right = 'auto';
+    popover.style.visibility = 'visible';
   }
 
   function renderDocs(node) {
@@ -1777,12 +1825,11 @@ ${graphScript}
 
   function renderView(node) {
     var title = node.label || node.text || node.id;
-    var chips = [chip(nodeKindLabel(node))];
+    var chips = [];
     if (node.projectName) chips.push(chip(node.projectName));
     if (node.store) chips.push(chip(node.store));
     if (node.kind === 'task' && node.section) chips.push(chip(node.section));
     if (node.kind === 'task' && node.priority) chips.push(chip('Priority ' + node.priority));
-    if (node.kind === 'finding' && node.topicLabel) chips.push(chip(node.topicLabel));
 
     var body = '';
     var actions = [];
@@ -1827,17 +1874,19 @@ ${graphScript}
 
     return '<div style="font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted)">' + esc(nodeKindLabel(node)) + '</div>'
       + '<div style="font-size:15px;font-weight:600;line-height:1.2">' + esc(title) + '</div>'
-      + '<div class="node-chips">' + chips.join('') + '</div>'
+      + (chips.length ? '<div class="node-chips">' + chips.join('') + '</div>' : '')
       + body
       + (actions.length ? '<div class="node-actions">' + actions.join('') + '</div>' : '');
   }
 
   function renderEdit(node) {
     var title = node.kind === 'task' ? 'Edit task' : 'Edit finding';
+    var itemTitle = node.label || node.text || node.id;
     var section = node.section || 'Queue';
     var priority = node.priority || '';
     return '<div style="font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted)">' + esc(title) + '</div>'
-      + '<div style="font-size:14px;font-weight:600;line-height:1.2">' + esc(node.projectName || nodeKindLabel(node)) + '</div>'
+      + '<div style="font-size:14px;font-weight:600;line-height:1.25;white-space:nowrap;overflow:hidden;text-overflow:ellipsis" title="' + esc(itemTitle) + '">' + esc(itemTitle) + '</div>'
+      + (node.projectName ? '<div class="node-date">' + esc(node.projectName) + '</div>' : '')
       + '<textarea id="node-editor" class="node-editor">' + esc(node.text || node.label || '') + '</textarea>'
       + (node.kind === 'task'
         ? '<div class="node-select-grid">'
@@ -1859,14 +1908,12 @@ ${graphScript}
         var action = button.getAttribute('data-node-action');
         if (action === 'edit') {
           editMode = currentNode.kind === 'task' ? 'task' : 'finding';
-          var point = currentPoint();
-          renderPopover(currentNode, point.x, point.y);
+          renderPopover(currentNode, lastAnchorPoint.x, lastAnchorPoint.y);
           return;
         }
         if (action === 'cancel') {
           editMode = null;
-          var point = currentPoint();
-          renderPopover(currentNode, point.x, point.y);
+          renderPopover(currentNode, lastAnchorPoint.x, lastAnchorPoint.y);
           return;
         }
         if (action === 'save') {
@@ -1928,6 +1975,7 @@ ${graphScript}
       return;
     }
     currentNode = node;
+    if (!editMode && x > 0 && y > 0) lastAnchorPoint = { x: x, y: y };
     popoverContent.innerHTML = editMode ? renderEdit(node) : renderView(node);
     bindActions();
     positionPopover(x, y);
@@ -2004,7 +2052,11 @@ ${graphScript}
       }
       currentNode = Object.assign({}, nodeLookup[node.id] || {}, node);
       editMode = null;
-      renderPopover(currentNode, x, y);
+      cardWasDragged = false;
+      // Ordinary selection expands the matching row inside the project pane;
+      // never stack a second reading card over the graph. Explicit Edit still
+      // uses the movable editor surface.
+      hidePopover(true);
     });
   }
 
@@ -2059,8 +2111,7 @@ ${graphScript}
         if (refreshedNode) {
           Object.assign(currentNode, refreshedNode);
           if (!editMode) {
-            var refreshedPoint = currentPoint();
-            renderPopover(currentNode, refreshedPoint.x, refreshedPoint.y);
+            renderPopover(currentNode, lastAnchorPoint.x, lastAnchorPoint.y);
           }
         } else {
           hidePopover(true);
@@ -2086,8 +2137,7 @@ ${graphScript}
       if (currentNode && currentNode.id === data.id) {
         Object.assign(currentNode, cached || {});
         if (!editMode) {
-          var point = currentPoint();
-          renderPopover(currentNode, point.x, point.y);
+          renderPopover(currentNode, lastAnchorPoint.x, lastAnchorPoint.y);
         }
       }
       return;
@@ -2145,25 +2195,32 @@ ${graphScript}
       vscode.postMessage({ command: 'deleteTask', projectName: node.projectName, item: (node.taskItemId || node.text || node.fullLabel || ''), nodeId: node.id });
     }
   }
-  function editNodeFromPane(node) {
-    if (!node || (node.kind !== 'finding' && node.kind !== 'task')) return;
-    if (window.phrenGraph && window.phrenGraph.selectNode) window.phrenGraph.selectNode(node.id);
-    setTimeout(function() {
-      if (currentNode && currentNode.id === node.id) {
-        editMode = currentNode.kind === 'task' ? 'task' : 'finding';
-        var point = currentPoint();
-        renderPopover(currentNode, point.x, point.y);
-        var editor = document.getElementById('node-editor');
-        if (editor) editor.focus();
-      }
-    }, 220);
-  }
   if (window.phrenGraph && window.phrenGraph.onItemAction) {
     window.phrenGraph.onItemAction(function(payload, action) {
       if (action === 'delete') {
         deleteNodeMsg(payload);
-      } else if (action === 'edit') {
-        editNodeFromPane(payload);
+      } else if (action === 'save-inline' && payload && !Array.isArray(payload)) {
+        var nextText = (payload.editedText || '').trim();
+        if (!nextText) return;
+        if (payload.kind === 'task') {
+          vscode.postMessage({
+            command: 'saveTaskEdit',
+            projectName: payload.projectName,
+            item: payload.taskItemId || payload.text || payload.fullLabel || '',
+            nodeId: payload.id,
+            text: nextText,
+            section: payload.editedSection || payload.section || 'Queue',
+            priority: typeof payload.editedPriority === 'string' ? payload.editedPriority : (payload.priority || '')
+          });
+        } else if (payload.kind === 'finding') {
+          vscode.postMessage({
+            command: 'saveFindingEdit',
+            projectName: payload.projectName,
+            nodeId: payload.id,
+            oldText: payload.text || payload.fullLabel || '',
+            newText: nextText
+          });
+        }
       } else if (action === 'merge' && Array.isArray(payload) && payload.length === 2) {
         vscode.postMessage({
           command: 'mergeFindings',

--- a/packages/vscode/src/phrenClient.ts
+++ b/packages/vscode/src/phrenClient.ts
@@ -166,7 +166,9 @@ export class PhrenClient {
   }
 
   async getFindings(project: string): Promise<unknown> {
-    return this.callTool("get_findings", { project });
+    // The MCP tool defaults to 50. The extension renders findings directly and
+    // must not mistake that first page for the project's complete contents.
+    return this.callTool("get_findings", { project, limit: 200 });
   }
 
   async getNotes(project: string, date?: string): Promise<unknown> {


### PR DESCRIPTION
## What

- replace the graph's secondary finding/task card with readable inline expansion and editing in the main project pane
- add inline finding topic/health and task status/priority controls
- make the project pane draggable and independently resizable, with improved filters, selection controls, spacing, and scrollbars
- remove yellow radiating selection effects throughout the graph
- preserve the API finding total instead of presenting the first 50 results as the project total
- release `@phren/cli` 0.1.39 and the coordinated VS Code extension 0.6.2

## Why

The previous interaction split attention between overlapping panes, sometimes positioned a detail card unpredictably after graph animation, and hid too much finding text. The project list is now the single place to browse, read, select, and edit items.

## Impact

Project findings and tasks expand in place, edits save and refresh in place, filter/selection state is explicit, and the pane can be positioned and sized around the graph. Existing API compatibility remains intact; the VS Code client simply requests a larger page and respects the server-reported total.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm run validate-docs`
- `pnpm test` — 142 files passed, 2,697 tests passed
- CLI package dry run for 0.1.39
- VS Code package build for 0.6.2
- focused Playwright VS Code UI assessment and graph interaction regressions
